### PR TITLE
fix: disable electron-builder auto-publish

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,8 +71,6 @@ jobs:
 
       - name: Build
         working-directory: electron
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: ${{ matrix.build_cmd }}
 
       - name: Upload artifacts

--- a/electron/package.json
+++ b/electron/package.json
@@ -9,9 +9,9 @@
   "scripts": {
     "start": "electron .",
     "dev": "CELERP_DEV_MODE=1 electron .",
-    "build:win": "electron-builder --win",
-    "build:linux": "electron-builder --linux",
-    "build:mac": "electron-builder --mac"
+    "build:win": "electron-builder --win --publish never",
+    "build:linux": "electron-builder --linux --publish never",
+    "build:mac": "electron-builder --mac --publish never"
   },
   "dependencies": {
     "embedded-postgres": "^17.9.0-beta.16",


### PR DESCRIPTION
Add `--publish never` to all electron-builder commands so builds create artifacts without requiring a GitHub token. The `upload-artifact` action handles CI artifact storage.

Also removes the now-unnecessary `GH_TOKEN` env from `build.yml`.

After merge, re-tag `v1.0.0` to trigger a clean build.