### PR TITLE
build: versioning via setuptools-scm + psycopg2-binary in core deps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,10 +60,8 @@ dev = [
     "pytest>=8.0",
     "pytest-asyncio>=0.23",
     "pytest-cov>=5.0",
-    "httpx>=0.27",
     "faker>=24.0",
     "aiosqlite>=0.20",
-    "psycopg2-binary>=2.9",
     "respx>=0.21",
     "playwright>=1.43",
     "pytest-playwright>=0.5",
@@ -72,7 +70,6 @@ dev = [
 ]
 prod = [
     "gunicorn>=22.0",
-    "psycopg2-binary>=2.9",
 ]
 
 [tool.pytest.ini_options]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "celerp"
-version = "1.0.0"
+dynamic = ["version"]
 description = "Free, self-hosted ERP for small businesses"
 readme = "README.md"
 license = {file = "LICENSE"}
@@ -44,6 +44,7 @@ dependencies = [
     "qrcode>=7.0",
     "Pillow>=10.0",
     "pypdf>=4.0",
+    "psycopg2-binary>=2.9",
 ]
 
 [project.urls]
@@ -124,5 +125,10 @@ include = ["celerp", "celerp.*", "ui", "ui.*", "default_modules"]
 "*" = ["__pycache__/**", "*.pyc", "*.pyo"]
 
 [build-system]
-requires = ["setuptools>=68", "wheel"]
+requires = ["setuptools>=68", "setuptools-scm>=8", "wheel"]
 build-backend = "setuptools.build_meta"
+
+[tool.setuptools_scm]
+version_scheme = "guess-next-dev"
+local_scheme = "no-local-version"
+tag_regex = "^v(?P<version>\\d+\\.\\d+\\.\\d+)$"


### PR DESCRIPTION
## What

- **versioning**: Replace hardcoded `version = "1.0.0"` with `dynamic = ["version"]` powered by `setuptools-scm`. Version is now derived from git tags (`v1.0.3` tag → `1.0.3` package).
- **Fix missing dep**: Move `psycopg2-binary` from optional `[prod]` group to core `dependencies`. Without this, `pip install celerp && celerp init` fails on migrations.