### PR TITLE
fix: startup 404 log + add PyPI auto-publish on tag

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,37 @@
+name: Publish to PyPI
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  id-token: write  # Required for PyPI trusted publishing
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment: pypi
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # setuptools-scm needs full history
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Build
+        run: |
+          pip install build setuptools-scm
+          python -m build
+
+      - name: Verify version matches tag
+        run: |
+          TAG=${GITHUB_REF#refs/tags/v}
+          PKG=$(python -c "from setuptools_scm import get_version; print(get_version())")
+          echo "Tag: $TAG, Package: $PKG"
+          [ "$TAG" = "$PKG" ] || { echo "Version mismatch!"; exit 1; }
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/celerp/main.py
+++ b/celerp/main.py
@@ -46,8 +46,14 @@ async def _try_auto_activate() -> None:
             _s.gateway_http_url.rstrip("/") if _s.gateway_http_url
             else _s.gateway_url.replace("wss://", "https://").replace("ws://", "http://").replace("/ws/connect", "")
         )
-        async with httpx.AsyncClient(timeout=10.0) as c:
-            r = await c.post(f"{relay_base}/auth/activate", json={"instance_id": iid})
+        _httpx_log = logging.getLogger("httpx")
+        _prev_level = _httpx_log.level
+        _httpx_log.setLevel(logging.WARNING)
+        try:
+            async with httpx.AsyncClient(timeout=10.0) as c:
+                r = await c.post(f"{relay_base}/auth/activate", json={"instance_id": iid})
+        finally:
+            _httpx_log.setLevel(_prev_level)
         if r.status_code != 200:
             return
         data = r.json()


### PR DESCRIPTION
## What

1. **httpx 404 log** Expected to 404 for self-hosted users, but the log line looks like an error.

2. **Auto-publish workflow** (`.github/workflows/publish.yml`): pushing a `v*` tag triggers build + publish to PyPI via trusted publishing (no API token needed).