### PR TITLE
fix: dynamic import embedded-postgres (ESM-only module)

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -17,7 +17,7 @@ const { autoUpdater } = require("electron-updater");
 const path = require("path");
 const { spawn, execFileSync } = require("child_process");
 const net = require("net");
-const EmbeddedPostgres = require("embedded-postgres");
+let EmbeddedPostgres; // loaded via dynamic import() - embedded-postgres is ESM-only
 
 // ── Constants ────────────────────────────────────────────────────────────────
 
@@ -107,6 +107,10 @@ async function startPostgres(dbPort) {
   const fs = require("fs");
   fs.mkdirSync(PG_DATA_DIR, { recursive: true });
   fs.mkdirSync(LOG_DIR, { recursive: true });
+
+  if (!EmbeddedPostgres) {
+    EmbeddedPostgres = (await import("embedded-postgres")).default;
+  }
 
   pgInstance = new EmbeddedPostgres({
     databaseDir: PG_DATA_DIR,


### PR DESCRIPTION
## Problems fixed

### 1. App crashes on launch: `ERR_REQUIRE_ESM`
`embedded-postgres` is an ESM-only module and cannot be loaded via `require()`.

**Fix:** replaced top-level `require("embedded-postgres")` with a lazy dynamic `import()` inside `startPostgres()` (already `async`).

### 2. App crashes with `ENOTDIR` on startup
`embedded-postgres` needs to `chmod` its bundled `postgres` and `initdb` binaries to make them executable. These binaries were packed inside the `.asar` archive (a virtual filesystem), where `chmod` is not possible.

**Fix:** added `asarUnpack` for `node_modules/@embedded-postgres/**` in `package.json` so the binaries are extracted to `app.asar.unpacked/` and can be chmod'd at runtime.

## Reported by
@gaporf