### PR TITLE
fix: make embedded-postgres work inside Electron asar bundle (Mac)

### DIFF
--- a/electron/package.json
+++ b/electron/package.json
@@ -28,6 +28,9 @@
     "directories": {
       "output": "dist"
     },
+    "asarUnpack": [
+      "node_modules/@embedded-postgres/**"
+    ],
     "files": [
       "main.js",
       "preload.js",


### PR DESCRIPTION
## Root cause

`embedded-postgres` ships native Postgres binaries (`postgres`, `initdb`, `pg_ctl`) which need to:
1. Be `chmod`d to executable at runtime
2. Be `spawn()`d as child processes

Both operations fail when the files are packed inside `app.asar`:
- `fs.chmod` on a path inside `.asar` → `ENOTDIR` (asar is a file, not a dir)
- `child_process.spawn` with an `.asar` path → `ENOTDIR` (OS can't traverse into the archive)

Electron patches `fs` and `execFile` for asar paths, but **does NOT patch `spawn()`** (documented Electron limitation). `embedded-postgres` uses `spawn()` for both `initdb` and `postgres`.

## Fixes (2 commits)

### 1. `asarUnpack` for `@embedded-postgres/**` (package.json)
Tells Electron Builder to extract the `@embedded-postgres` packages to `app.asar.unpacked/` at build time. This makes the binary files physically present on disk, so `fs.chmod` (which Electron does patch) works correctly.

### 2. `spawn()` path rewrite wrapper (main.js)
Wraps `child_process.spawn` to rewrite any path containing `app.asar/` → `app.asar.unpacked/` before the OS sees it. This is the standard workaround for Electron's documented `spawn` limitation.

```js
const _spawn = childProcess.spawn.bind(childProcess);
function spawn(cmd, args, opts) {
  if (typeof cmd === "string" && cmd.includes("app.asar") && !cmd.includes("app.asar.unpacked")) {
    cmd = cmd.replace(/app\.asar([/\\])/g, "app.asar.unpacked$1");
  }
  return _spawn(cmd, args, opts);
}
```

## Verification

5/5 unit tests pass covering: darwin arm64 paths, already-unpacked paths (no double-rewrite), non-asar paths (bundled Python unaffected), Windows backslash paths.

## Reported by
@gaporf