### PR TITLE
fix: patch spawn() to rewrite asar paths to asar.unpacked for embedded-postgres binaries

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -15,9 +15,23 @@
 const { app, BrowserWindow, shell, dialog } = require("electron");
 const { autoUpdater } = require("electron-updater");
 const path = require("path");
-const { spawn, execFileSync } = require("child_process");
+const childProcess = require("child_process");
+const { execFileSync } = childProcess;
 const net = require("net");
 let EmbeddedPostgres; // loaded via dynamic import() - embedded-postgres is ESM-only
+
+// ── Asar unpack path fix ─────────────────────────────────────────────────────
+// Electron does NOT patch child_process.spawn for asar paths (only execFile is
+// patched). embedded-postgres calls spawn() with binary paths that resolve inside
+// app.asar - the OS sees app.asar as a file, not a directory, causing ENOTDIR.
+// Fix: wrap spawn to rewrite any .asar/ path to .asar.unpacked/ before the OS sees it.
+const _spawn = childProcess.spawn.bind(childProcess);
+function spawn(cmd, args, opts) {
+  if (typeof cmd === "string" && cmd.includes("app.asar") && !cmd.includes("app.asar.unpacked")) {
+    cmd = cmd.replace(/app\.asar([/\\])/g, "app.asar.unpacked$1");
+  }
+  return _spawn(cmd, args, opts);
+}
 
 // ── Constants ────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Root cause

Electron does NOT patch `child_process.spawn()` for asar paths (documented limitation). `embedded-postgres` uses `spawn()` to run `initdb` and `postgres` - paths resolve inside `.asar` → OS hits `ENOTDIR`.

## Fix

Wraps `child_process.spawn` in `main.js` to rewrite `.asar/` → `.asar.unpacked/` in the command path before the OS sees it. Non-asar paths (bundled Python etc.) are unaffected.

## Verification

5/5 unit tests pass: darwin arm64 paths, already-unpacked paths (no double-rewrite), non-asar paths, Windows backslash paths.

## Reported by
@gaporf