### PR TITLE
fix: read API_BASE from env in seed_demo.py (packaged app uses dynamic port)

### DIFF
--- a/scripts/seed_demo.py
+++ b/scripts/seed_demo.py
@@ -12,13 +12,14 @@ Usage:
 from __future__ import annotations
 
 import asyncio
+import os
 import random
 import sys
 import uuid
 
 import httpx
 
-API_BASE = "http://127.0.0.1:8000"
+API_BASE = os.environ.get("API_BASE", "http://127.0.0.1:8000")
 EMAIL = "admin@demo.test"
 PASSWORD = "demo-password"
 


### PR DESCRIPTION
## Problem

`seed_demo.py` had `API_BASE` hardcoded to `http://127.0.0.1:8000`. The packaged Electron app picks a random free port at startup and passes it via the `API_BASE` env var — but the script was ignoring it.

Result: demo seed always failed silently in packaged builds (connection refused on port 8000).

## Fix

Read `API_BASE` from the environment, falling back to `8000` for dev use:
```python
API_BASE = os.environ.get("API_BASE", "http://127.0.0.1:8000")
```

Reported by @gaporf.