### PR TITLE
fix: disable demo seed in packaged app (seed is dev-only)

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -549,8 +549,8 @@ app.whenReady().then(async () => {
     loadingWin.close();
     createWindow();
 
-    // Seed demo data on first boot (non-blocking)
-    maybeRunSeed(dbConfig.url);
+    // Seed demo data on first boot (dev only — packaged app users set up their own account)
+    if (IS_DEV) maybeRunSeed(dbConfig.url);
 
     if (!IS_DEV) {
       setupAutoUpdater();

--- a/scripts/seed_demo.py
+++ b/scripts/seed_demo.py
@@ -95,6 +95,7 @@ _CONTACTS = [
 ]
 
 
+
 async def login(client: httpx.AsyncClient) -> str:
     r = await client.post("/auth/login", json={"email": EMAIL, "password": PASSWORD})
     if r.is_error:


### PR DESCRIPTION
## Problem

`maybeRunSeed()` runs on first boot in the packaged app. It calls `seed_demo.py` which tries to `POST /auth/login` with hardcoded credentials (`admin@demo.test` / `demo-password`). In a packaged app, the user creates their own account via the setup screen — those credentials never exist → 401 on every first launch.

Reported by @gaporf.

## Fix

- `electron/main.js`: guard `maybeRunSeed()` with `IS_DEV` — completely skipped in packaged builds
- `scripts/seed_demo.py`: remove dead code left over from an aborted bootstrap-polling attempt

The seed script still works in dev where credentials are known.