### PR TITLE
fix: ui/app.py falls back to config.toml for ENABLED_MODULES (binary parity)

### DIFF
--- a/ui/app.py
+++ b/ui/app.py
@@ -214,10 +214,18 @@ async def proxy_attachment(request: Request, path: str) -> Response:
 
 app.mount("/static", StaticFiles(directory=_static_dir), name="static")
 
-# Determine enabled modules from env (set by cli.py _config_to_env)
+# Determine enabled modules from env (set by cli.py _config_to_env).
+# Fall back to config.toml when env is absent (e.g. Electron binary restart).
 _ENABLED_MODULES: set[str] = set(
     m.strip() for m in os.environ.get("ENABLED_MODULES", "").split(",") if m.strip()
 )
+if not _ENABLED_MODULES and os.environ.get("MODULE_DIR"):
+    try:
+        from celerp.config import read_config as _read_config
+        _cfg = _read_config()
+        _ENABLED_MODULES = set(_cfg.get("modules", {}).get("enabled") or [])
+    except Exception:
+        pass
 
 # Kernel UI routes — always registered
 for mod in (auth, setup, search, settings, settings_import,


### PR DESCRIPTION
## Problem

In the PyPI deployment, `cli.py` sets `ENABLED_MODULES` from `config.toml` before spawning uvicorn. In the Electron binary, `ENABLED_MODULES` is not set in the environment.

This means after a `/system/restart` (triggered by the setup wizard's vertical selection), `ui/app.py` reads an empty set — and **never registers the conditional UI routes** for the enabled modules (inventory, documents, contacts, etc).

`celerp/main.py` already has this fallback, but `ui/app.py` didn't.

## Fix

Mirror `celerp/main.py`'s existing pattern: when `ENABLED_MODULES` env is absent and `MODULE_DIR` is set, read from `config.toml` instead.

The fallback is gated on `MODULE_DIR` being set, so it only activates in Electron (or explicit module-dir setups). PyPI deployments always have `ENABLED_MODULES` in env and are unaffected.

Part of ongoing binary parity work (PRs #14-#22).