### PR TITLE
fix: include restart.js in asar bundle files list

### DIFF
--- a/electron/package.json
+++ b/electron/package.json
@@ -35,6 +35,7 @@
     ],
     "files": [
       "main.js",
+      "restart.js",
       "preload.js",
       "assets/**"
     ],


### PR DESCRIPTION
## Problem

PR #22 extracted restart logic into `restart.js` but the `electron-builder` `files` array in `electron/package.json` only listed:

```json
["main.js", "preload.js", "assets/**"]
```

`restart.js` was never packed into the asar, causing:

```
Uncaught Exception: Error: Cannot find module './restart'
```

on every packaged app launch.

## Fix

Add `restart.js` to the `files` array.

## Testing

Build a new .dmg and verify the app launches without the module-not-found error.