### PR TITLE
fix: remove broken maybeRunSeed auto-seed on first boot

### DIFF
--- a/electron/README.md
+++ b/electron/README.md
@@ -17,7 +17,7 @@ Data lives in the OS user data directory (`app.getPath("userData")/celerp-data/`
 
 A `.jwt_secret` file is generated on first launch and reused on subsequent starts — the session stays valid across restarts.
 
-Demo data is seeded automatically on first boot via `scripts/seed_demo.py`. A `.seed_done` flag prevents re-seeding.
+Demo data is seeded automatically when the first admin registers via the UI, using `celerp/services/demo.py`.
 
 ## Development
 

--- a/electron/main.js
+++ b/electron/main.js
@@ -390,36 +390,6 @@ function resolveStorageEnv() {
   return { STORAGE_BACKEND: "local" };
 }
 
-/** Run demo seed on first boot (if DB is fresh). Runs in background after UI opens. */
-async function maybeRunSeed(dbUrl) {
-  const seedFlagPath = path.join(DATA_DIR, ".seed_done");
-  if (fs.existsSync(seedFlagPath)) return;
-
-  // Wait a moment for API to be fully ready
-  await new Promise(r => setTimeout(r, 2000));
-
-  try {
-    execFileSync(
-      pythonBin(),
-      ["scripts/seed_demo.py"],
-      {
-        cwd: APP_DIR,
-        env: {
-          ...process.env,
-          DATABASE_URL: dbUrl,
-          JWT_SECRET: getOrCreateJwtSecret(),
-          PYTHONPATH: APP_DIR,
-          API_BASE: `http://127.0.0.1:${apiPort}`,
-        },
-        stdio: "pipe",
-      }
-    );
-    fs.writeFileSync(seedFlagPath, new Date().toISOString());
-  } catch (e) {
-    // Seed failure is non-fatal — user can always import their own data
-    console.error("Demo seed failed (non-fatal):", e.message);
-  }
-}
 
 
 
@@ -555,9 +525,6 @@ app.whenReady().then(async () => {
 
     loadingWin.close();
     createWindow();
-
-    // Seed demo data on first boot (non-blocking)
-    maybeRunSeed(dbConfig.url);
 
     if (!IS_DEV) {
       setupAutoUpdater();

--- a/electron/package.json
+++ b/electron/package.json
@@ -1,7 +1,7 @@
 {
   "name": "celerp",
   "version": "1.0.0",
-  "description": "Free business software \u2014 inventory, invoicing, and operations in one place.",
+  "description": "Free business software — inventory, invoicing, and operations in one place.",
   "main": "main.js",
   "author": "Data Universal Limited",
   "license": "BSL-1.1",
@@ -26,7 +26,7 @@
   "build": {
     "appId": "com.celerp.app",
     "productName": "Celerp",
-    "copyright": "Copyright \u00a9 2026 Data Universal Limited",
+    "copyright": "Copyright © 2026 Data Universal Limited",
     "directories": {
       "output": "dist"
     },
@@ -58,7 +58,6 @@
           "!celerp.db",
           "!electron/**",
           "scripts/module_setup.py",
-          "scripts/seed_demo.py",
           "!build/**",
           "!dist/**",
           "!*.egg-info/**",


### PR DESCRIPTION
## Root cause

`maybeRunSeed()` in `electron/main.js` called `scripts/seed_demo.py` on every first boot.

That script logs in via HTTP API with hardcoded credentials:
```
EMAIL = "admin@demo.test"
PASSWORD = "demo-password"
```

These credentials are **never created by the app**. They exist only in `tests/integration/conftest.py` as fixture credentials for a pre-populated `dev.db`. On any real install, the call always fails with `401 Invalid credentials`.

## Correct behavior

Demo data is already seeded correctly via `celerp/services/demo.py → seed_demo_items()`, called from `/auth/register` when the first admin registers through the UI. No additional boot-time seeding is needed.

## Changes

- Remove `maybeRunSeed()` function and its call site from `electron/main.js`
- Remove `scripts/seed_demo.py` from `extraResources` (binary no longer needs it)
- Update `electron/README.md` to reflect the correct seeding flow