### PR TITLE
fix: guard err.message in showErrorBox calls against non-Error throws

### DIFF
--- a/electron/README.md
+++ b/electron/README.md
@@ -17,7 +17,6 @@ Data lives in the OS user data directory (`app.getPath("userData")/celerp-data/`
 
 A `.jwt_secret` file is generated on first launch and reused on subsequent starts — the session stays valid across restarts.
 
-Demo data is seeded automatically when the first admin registers via the UI, using `celerp/services/demo.py`.
 
 ## Development
 

--- a/electron/main.js
+++ b/electron/main.js
@@ -428,7 +428,7 @@ function setupAutoUpdater() {
 
   autoUpdater.on("error", (err) => {
     // Log only — update failures must never interrupt the user's work
-    console.error("[updater] error:", err.message);
+    console.error("[updater] error:", err?.message ?? String(err));
   });
 
   autoUpdater.checkForUpdates();
@@ -518,7 +518,7 @@ app.whenReady().then(async () => {
       startUi,
       sentinelPath: restartSentinelPath(),
       onCrash: (err) => {
-        dialog.showErrorBox("Celerp crashed", err.message);
+        dialog.showErrorBox("Celerp crashed", err?.message ?? String(err));
         app.quit();
       },
     });
@@ -530,7 +530,7 @@ app.whenReady().then(async () => {
       setupAutoUpdater();
     }
   } catch (err) {
-    dialog.showErrorBox("Celerp failed to start", err.message);
+    dialog.showErrorBox("Celerp failed to start", err?.message ?? String(err));
     app.quit();
   }
 });


### PR DESCRIPTION
## Problem

`dialog.showErrorBox()` requires a string for its second argument. When the caught error is not a standard `Error` object (e.g. a raw Node.js system error event or a rejected non-Error value), `err.message` is `undefined`, causing:

```
TypeError: Error processing argument at index 1, conversion failure from undefined
  at Object.showErrorBox (node:electron/js2c/browser_init:2:24327)
  at main.js:533
```

This means the app crashes inside the crash handler — the actual startup error is swallowed and the user sees an unhandled promise rejection instead of a meaningful dialog.

## Fix

Replace `err.message` with `err?.message ?? String(err)` in all three error/catch sites:
- Auto-updater error handler
- `onCrash` callback in `watchForRestart`
- Top-level startup catch block

## Also

Remove stale seeding note from `electron/README.md` (already removed in PR #26 but changed wording; this removes the line entirely per request).