### PR TITLE
fix: set CELERP_CONFIG env var so API/UI use a known config.toml path

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -85,6 +85,7 @@ const PG_DATA_DIR = path.join(DATA_DIR, "postgres");
 const LOG_DIR = path.join(DATA_DIR, "logs");
 const MODULE_DIR = path.join(DATA_DIR, "modules");
 const CONFIG_PATH = path.join(DATA_DIR, "celerp-config.json");
+const PYTHON_CONFIG_PATH = path.join(DATA_DIR, "config.toml");
 
 // Default modules shipped with the binary (in app resources/default_modules/).
 // Copied to MODULE_DIR on first boot if not already present.
@@ -271,6 +272,7 @@ function startApi(dbUrl) {
       PYTHONPATH: `${APP_DIR}:${MODULE_DIR}`,
       MODULE_DIR: MODULE_DIR,
       CELERP_DATA_DIR: DATA_DIR,
+      CELERP_CONFIG: PYTHON_CONFIG_PATH,
       ...resolveStorageEnv(),
     };
     apiProcess = spawn(
@@ -293,6 +295,7 @@ function startUi(dbUrl) {
       JWT_SECRET: getOrCreateJwtSecret(),
       PYTHONPATH: `${APP_DIR}:${MODULE_DIR}`,
       MODULE_DIR: MODULE_DIR,
+      CELERP_CONFIG: PYTHON_CONFIG_PATH,
       ...resolveStorageEnv(),
     };
     uiProcess = spawn(


### PR DESCRIPTION
## Problem

`celerp/config.py` resolves `config.toml` via `XDG_CONFIG_HOME` or `~/.config`, which varies by platform and shell environment.

In the packaged Electron app this caused a path mismatch:

1. Setup wizard (UI process) calls `set_enabled_modules()` — writes `config.toml` to `~/.config/celerp/config.toml`
2. API respawns after `/system/restart` — calls `read_config()` on startup
3. If the respawned process sees a different `XDG_CONFIG_HOME` (e.g. unset vs set), it resolves a different path and reads `{}` — no modules in `_enabled` — `load_all()` never called — all modules stay `running=False` forever
4. UI polling times out: "Taking longer than expected"

## Fix

Define `PYTHON_CONFIG_PATH = path.join(DATA_DIR, "config.toml")` and pass it as `CELERP_CONFIG` to both `startApi` and `startUi` env blocks. `config_path()` already honours this env var as an override (first thing it checks), so all Python processes use the same deterministic path inside `userData/celerp-data/`.

This also makes `config.toml` co-located with all other Celerp data (`postgres/`, `modules/`, `.jwt_secret`) — easier to find and backup.
