### PR TITLE
fix: align restart sentinel path with PYTHON_CONFIG_PATH

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -102,7 +102,7 @@ let uiProcess = null;
 let apiPort = null;
 let uiPort = null;
 
-const { restartSentinelPath, watchForRestart } = require("./restart");
+const { watchForRestart } = require("./restart");
 
 // ── Utilities ────────────────────────────────────────────────────────────────
 
@@ -519,7 +519,9 @@ app.whenReady().then(async () => {
       setUiProcess: (p) => { uiProcess = p; },
       startApi,
       startUi,
-      sentinelPath: restartSentinelPath(),
+      // Sentinel must live next to PYTHON_CONFIG_PATH so Python's config_path().parent
+      // resolves to the same directory that Electron watches.
+      sentinelPath: path.join(path.dirname(PYTHON_CONFIG_PATH), ".restart_requested"),
       onCrash: (err) => {
         dialog.showErrorBox("Celerp crashed", err?.message ?? String(err));
         app.quit();


### PR DESCRIPTION
## Root cause

The restart loop ("Restarting server...") was caused by a sentinel path mismatch between Python and Electron.

**Python side** (`celerp/routers/system.py`):
```python
config_path().parent / ".restart_requested"
```
`config_path()` honours `CELERP_CONFIG` env var, which Electron sets to `DATA_DIR/config.toml`.
So the sentinel lands at **`DATA_DIR/.restart_requested`**.

**Electron side** (`restart.js restartSentinelPath()`):
```js
path.join($HOME, ".config", "celerp", ".restart_requested")
```
Computed the XDG path independently, completely ignoring `CELERP_CONFIG`.

**Result**: Python writes the sentinel to `DATA_DIR/.restart_requested`. Electron watches `~/.config/celerp/.restart_requested`. Sentinel never found → `watchForRestart` never fires → API stays dead → UI polls forever showing "Restarting server...".

## Fix

Derive `sentinelPath` directly from `PYTHON_CONFIG_PATH`'s parent in `main.js`:
```js
sentinelPath: path.join(path.dirname(PYTHON_CONFIG_PATH), ".restart_requested")
```

Both sides now agree on the file location unconditionally.

## Tests

- 81 Python tests passing
- 10 Jest tests passing (restart.test.js unaffected — `restartSentinelPath()` still exported/correct for non-Electron usage)