### PR TITLE
fix: reload main window to new uiPort after server restart

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -526,6 +526,13 @@ app.whenReady().then(async () => {
         dialog.showErrorBox("Celerp crashed", err?.message ?? String(err));
         app.quit();
       },
+      onRestart: () => {
+        // After respawn, API and UI are on new ports. Reload the window to the
+        // new uiPort so the browser is no longer pointed at the dead old port.
+        if (mainWindow) {
+          mainWindow.loadURL(`http://127.0.0.1:${uiPort}`);
+        }
+      },
     });
 
     loadingWin.close();

--- a/electron/restart.js
+++ b/electron/restart.js
@@ -44,6 +44,7 @@ function restartSentinelPath(proc) {
  *   startUi: (dbUrl: string) => Promise<void>,
  *   sentinelPath: string,
  *   onCrash: (err: Error) => void,
+ *   onRestart?: () => void,
  *   fs?: typeof import("fs"),
  * }} deps
  */
@@ -55,6 +56,7 @@ function watchForRestart(dbUrl, {
   startUi,
   sentinelPath,
   onCrash,
+  onRestart,
   fs: fsOverride,
 }) {
   const proc = getApiProcess();
@@ -70,8 +72,9 @@ function watchForRestart(dbUrl, {
         if (ui) { ui.kill(); setUiProcess(null); }
         await startApi(dbUrl);
         await startUi(dbUrl);
-        watchForRestart(dbUrl, { getApiProcess, getUiProcess, setUiProcess, startApi, startUi, sentinelPath, onCrash, fs });
+        watchForRestart(dbUrl, { getApiProcess, getUiProcess, setUiProcess, startApi, startUi, sentinelPath, onCrash, onRestart, fs });
         console.log("[restart] Servers respawned.");
+        if (onRestart) onRestart();
       } catch (err) {
         onCrash(err);
       }

--- a/electron/tests/restart.test.js
+++ b/electron/tests/restart.test.js
@@ -92,6 +92,46 @@ describe("watchForRestart", () => {
     expect(onCrash).not.toHaveBeenCalled();
   });
 
+  test("onRestart callback is invoked after successful respawn", async () => {
+    const { deps } = makeTestDeps({ sentinelExists: true });
+    const onRestart = jest.fn();
+    deps.onRestart = onRestart;
+    const api = deps.getApiProcess();
+
+    watchForRestart("postgres://x", deps);
+    api.emit("exit", 0);
+    await new Promise(r => setTimeout(r, 10));
+
+    expect(onRestart).toHaveBeenCalledTimes(1);
+  });
+
+  test("onRestart is NOT called when sentinel is absent", async () => {
+    const { deps } = makeTestDeps({ sentinelExists: false });
+    const onRestart = jest.fn();
+    deps.onRestart = onRestart;
+    const api = deps.getApiProcess();
+
+    watchForRestart("postgres://x", deps);
+    api.emit("exit", 0);
+    await new Promise(r => setTimeout(r, 10));
+
+    expect(onRestart).not.toHaveBeenCalled();
+  });
+
+  test("onRestart is NOT called when respawn fails", async () => {
+    const { deps } = makeTestDeps({ sentinelExists: true });
+    deps.startApi = jest.fn(async () => { throw new Error("boom"); });
+    const onRestart = jest.fn();
+    deps.onRestart = onRestart;
+    const api = deps.getApiProcess();
+
+    watchForRestart("postgres://x", deps);
+    api.emit("exit", 0);
+    await new Promise(r => setTimeout(r, 10));
+
+    expect(onRestart).not.toHaveBeenCalled();
+  });
+
   test("sentinel absent, exit code 0: no crash, no respawn", async () => {
     const { deps, startApi, startUi, onCrash } = makeTestDeps({ sentinelExists: false });
     const api = deps.getApiProcess();


### PR DESCRIPTION
## Root cause

After `watchForRestart` respawns the API and UI, both processes call `getFreePort()` again — so they bind to **new random ports**. The Electron `mainWindow` still points at the **old dead `uiPort`**, so every `fetch('/setup/activating-status')` fails with a network error. The browser showed "Applying Configuration" / "Restarting server" indefinitely, never recovering.

## What the fix does

Adds an `onRestart` callback to `watchForRestart`. `main.js` passes a handler that calls `mainWindow.loadURL()` with the updated `uiPort` immediately after respawn completes.

The window navigates to the live new port and the `/setup/activating-status` polling resumes normally, progressing through `down → loading → ready → /dashboard`.

## Sequence after fix

1. Setup wizard POSTs → Python writes sentinel, SIGTERMs itself
2. `watchForRestart` fires: kills UI, respawns API on new port, respawns UI on new port
3. `onRestart` called → `mainWindow.loadURL(new uiPort)`
4. Browser navigates to the live UI, `/setup/activating-status` becomes reachable
5. Poll sees `phase=down` briefly, then `phase=loading`, then `phase=ready`
6. JS redirects to `/dashboard`

## Tests

New Jest tests (13 total, all passing):
- `onRestart` is called after successful respawn
- `onRestart` is NOT called when sentinel is absent
- `onRestart` is NOT called when respawn throws

81 Python tests passing.
