### PR TITLE
fix: skip postgres initdb on second boot when data dir already exists

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -167,7 +167,13 @@ async function startPostgres(dbPort) {
     persistent: true,  // data survives across app restarts
   });
 
-  await pgInstance.initialise();
+  // Only run initdb on first boot — PG_VERSION is written by initdb and
+  // signals that the cluster is already initialised. Calling initialise()
+  // on an existing data directory causes initdb to exit non-zero and crash.
+  const pgVersionFile = path.join(PG_DATA_DIR, "PG_VERSION");
+  if (!fs.existsSync(pgVersionFile)) {
+    await pgInstance.initialise();
+  }
   await pgInstance.start();
 
   // Create database if it doesn't exist yet

--- a/tests/test_modules/test_electron_integration.py
+++ b/tests/test_modules/test_electron_integration.py
@@ -196,3 +196,55 @@ class TestModuleSetupElectron:
         assert r.returncode == 0
         combined = r.stdout + r.stderr
         assert "testmod" in combined or "dry-run" in combined.lower()
+
+
+# ── Second-boot / re-init guards ──────────────────────────────────────────────
+
+class TestSecondBootGuards:
+    """Verify Electron main.js contains idempotency guards for operations that
+    must only run once (first boot), not on every app launch."""
+
+    @pytest.fixture(autouse=True)
+    def source(self):
+        self._src = ELECTRON_MAIN.read_text()
+
+    def test_postgres_initialise_guarded_by_pg_version_file(self):
+        """initialise() must only be called when PG_VERSION does not exist.
+
+        embedded-postgres.initialise() runs initdb, which fails with non-zero
+        exit if the data directory already contains a Postgres cluster.
+        On second boot this would crash the entire app.
+        """
+        # Guard must check for PG_VERSION sentinel before calling initialise()
+        assert "PG_VERSION" in self._src, (
+            "startPostgres must check for PG_VERSION to skip initdb on second boot"
+        )
+        assert "initialise" in self._src, "initialise() call must still exist for first boot"
+
+        # The guard must come before the initialise() call
+        pg_version_pos = self._src.find("PG_VERSION")
+        initialise_pos = self._src.find("pgInstance.initialise()")
+        assert pg_version_pos < initialise_pos, (
+            "PG_VERSION check must appear before pgInstance.initialise() call"
+        )
+
+    def test_postgres_initialise_inside_conditional(self):
+        """initialise() must be inside an if-block, not called unconditionally."""
+        # Find the block around initialise() — it should be inside an if (!existsSync(...))
+        init_pos = self._src.find("pgInstance.initialise()")
+        # Look backwards from initialise() for the conditional
+        before = self._src[:init_pos]
+        last_if = before.rfind("if (")
+        last_if_content = before[last_if:init_pos]
+        assert "existsSync" in last_if_content, (
+            "pgInstance.initialise() must be inside an if (!fs.existsSync(...)) guard"
+        )
+
+    def test_seed_default_modules_skips_existing(self):
+        """seedDefaultModules must skip already-installed module dirs (idempotent)."""
+        assert "fs.existsSync(dst)" in self._src
+        assert "continue" in self._src
+
+    def test_migrations_are_idempotent_upgrade_head(self):
+        """runMigrations uses alembic upgrade head which is a no-op if already current."""
+        assert "upgrade" in self._src and "head" in self._src


### PR DESCRIPTION
## Problem

On second app launch, Celerp crashed before the Python servers could start.

`startPostgres()` called `pgInstance.initialise()` unconditionally on every boot. `initialise()` runs `initdb`, which fails with a non-zero exit code when the data directory already contains a Postgres cluster — it rejects re-initialisation. This threw an unhandled error that crashed the Electron startup sequence before FastAPI or the UI server had a chance to launch.

The app *worked* on first boot (cluster didn't exist yet), but crashed on every subsequent launch. Closing and reopening showed the correct initialized company because the crash was happening before the window loaded.

## Root cause

`embedded-postgres.initialise()` is documented as first-boot-only:
> If your Postgres cluster is already initialised, you don't need to call this function again.

But the code called it unconditionally.

## Fix

Check for `PG_VERSION` before calling `initialise()`:

```js
const pgVersionFile = path.join(PG_DATA_DIR, 'PG_VERSION');
if (!fs.existsSync(pgVersionFile)) {
  await pgInstance.initialise();
}
await pgInstance.start();
```

`PG_VERSION` is written by `initdb` and is present in every valid Postgres data directory. Its presence is the standard way to detect an already-initialised cluster.

The `CREATE DATABASE celerp` call that follows was already guarded (`already exists` error is swallowed), so the full boot sequence is now idempotent and safe to run on every launch.

## This mirrors the PyPI path

`celerp start` skips initialisation entirely — it trusts `celerp init` was run once. The Electron path now has the same property.

## Tests

Added `TestSecondBootGuards` to `tests/test_modules/test_electron_integration.py`:
- `PG_VERSION` guard exists in `main.js` source
- Guard appears **before** `initialise()` call
- `initialise()` is inside a conditional (not called unconditionally)
- `seedDefaultModules` skips existing dirs (already tested, now explicitly named)
- `runMigrations` uses `alembic upgrade head` (idempotent)

All 81 Python tests + 13 Jest tests passing.