### PR TITLE
fix: add DELETE /api/inventory/{entity_id} UI route for row-menu delete

### DIFF
--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -3776,6 +3776,43 @@ class TestItemActionRouteCompleteness:
         assert r.status_code == 200
         assert b"already disposed" in r.content
 
+    # ── DELETE /api/inventory/{entity_id} (row-menu delete) ──────────────────
+
+    @pytest.mark.asyncio
+    async def test_row_menu_delete_returns_200_removes_row(self, ui_client):
+        """DELETE /api/inventory/{id} returns 200 empty body so htmx removes the row."""
+        with patch("ui.api_client.dispose_item", new=AsyncMock(return_value={"deleted": "gc:abc"})):
+            r = await ui_client.delete("/api/inventory/gc:abc", cookies=_authed())
+        assert r.status_code == 200
+        assert r.content == b""
+
+    @pytest.mark.asyncio
+    async def test_row_menu_delete_unauthenticated_redirects(self, ui_client):
+        """DELETE without auth cookie is intercepted by _auth_guard → 302 to /login."""
+        r = await ui_client.delete("/api/inventory/gc:abc")
+        assert r.status_code == 302
+        assert "/login" in r.headers.get("location", "")
+
+    @pytest.mark.asyncio
+    async def test_row_menu_delete_api_error_returns_inline_error_row(self, ui_client):
+        """On API error, DELETE returns a Tr with an error cell so the row shows the error."""
+        from ui.api_client import APIError
+        with patch("ui.api_client.dispose_item", new=AsyncMock(side_effect=APIError(403, "permission denied"))):
+            r = await ui_client.delete("/api/inventory/gc:abc", cookies=_authed())
+        assert r.status_code == 200
+        assert b"permission denied" in r.content
+
+    @pytest.mark.asyncio
+    async def test_row_menu_delete_calls_dispose_with_correct_id(self, ui_client):
+        """DELETE proxies to api.dispose_item with the correct entity_id."""
+        captured = {}
+        async def _mock(token, entity_id):
+            captured["entity_id"] = entity_id
+            return {"deleted": entity_id}
+        with patch("ui.api_client.dispose_item", new=_mock):
+            await ui_client.delete("/api/inventory/gc:TEST-001", cookies=_authed())
+        assert captured["entity_id"] == "gc:TEST-001"
+
     # ── split (additional coverage) ───────────────────────────────────────────
 
     @pytest.mark.asyncio

--- a/ui/routes/inventory.py
+++ b/ui/routes/inventory.py
@@ -1684,6 +1684,31 @@ function celerpPrintLabel(entityId, templateId) {
             return P(str(e.detail), cls="cell-error")
         return _attachments_panel(entity_id, item)
 
+    @app.delete("/api/inventory/{entity_id}")
+    async def item_delete(request: Request, entity_id: str):
+        """Delete a single item from the row-action menu.
+
+        The data_table component renders the row menu with:
+            hx_delete="/api/inventory/{entity_id}"
+            hx_target="#row-{safe_id}"
+            hx_swap="outerHTML"
+
+        Returning an empty 200 causes htmx to replace the row element with
+        nothing, removing it from the DOM immediately without a page reload.
+        """
+        from starlette.responses import Response as _R
+        token = _token(request)
+        if not token:
+            return _R("", status_code=401, headers={"HX-Redirect": "/login"})
+        try:
+            await api.dispose_item(token, entity_id)
+        except APIError as e:
+            return Tr(
+                Td(Span(str(e.detail), cls="flash flash--error"), colspan="100"),
+                id=f"row-{entity_id.replace(':', '-')}",
+            )
+        return _R("", status_code=200)
+
     @app.delete("/inventory/{entity_id}/attachments/{att_id}")
     async def item_delete_attachment(request: Request, entity_id: str, att_id: str):
         from starlette.responses import Response as _R


### PR DESCRIPTION
## Problem

Clicking Delete in the inventory row-action menu (three dots → Delete → OK) did nothing. The item stayed in the table with no error shown in the terminal or logs.

## Root cause

The inventory table's row menu is rendered by `data_table(entity_type='inventory')` which builds:
```
hx_delete="/api/inventory/{entity_id}"
hx_target="#row-{safe_id}"
hx_swap="outerHTML"
```

No route existed for `DELETE /api/inventory/{entity_id}` in the UI server. The request returned 404 — htmx's default `responseHandling` for `4xx` is `swap:false`, so nothing happened. No error in the terminal because the 404 was handled silently by htmx.

This is the same on both PyPI and Electron — the route was simply never implemented.

## Fix

Added `DELETE /api/inventory/{entity_id}` to `ui/routes/inventory.py`:
- Auth-guarded (middleware 302s to /login if no cookie)
- Proxies to `api.dispose_item(token, entity_id)` (hard delete: removes projection rows + ledger events)
- Returns **200 empty body** on success — htmx replaces `#row-{id}` with nothing, removing the row from the DOM instantly without page reload
- Returns inline `<tr>` error on API failure so the user sees the problem in-place

## Tests (4 new)

- `test_row_menu_delete_returns_200_removes_row` — success path returns 200 + empty body
- `test_row_menu_delete_unauthenticated_redirects` — no cookie → 302 to /login
- `test_row_menu_delete_api_error_returns_inline_error_row` — API error → 200 with error message in row
- `test_row_menu_delete_calls_dispose_with_correct_id` — correct entity_id forwarded