### PR TITLE
fix: row-menu delete - correct route URL, API call, and add contract tests

### DIFF
--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -3902,6 +3902,454 @@ class TestItemActionRouteCompleteness:
         assert b"Invalid" in r.content
 
 
+class TestItemActionHtmlContracts:
+    """HTML-rendering contract tests: assert the item detail page generates
+    the correct hx-post/hx-delete URLs for every action card. These tests
+    catch URL mismatches between component rendering and route definitions
+    before they reach production (lesson from row-menu delete bug)."""
+
+    _PATCHES = {
+        "ui.api_client.get_item_schema": AsyncMock(return_value=_SCHEMA),
+        "ui.api_client.get_item": AsyncMock(return_value=_ITEM),
+        "ui.api_client.get_company": AsyncMock(return_value=_COMPANY),
+        "ui.api_client.get_all_category_schemas": AsyncMock(return_value={}),
+        "ui.api_client.list_ledger": AsyncMock(return_value={"items": [], "total": 0}),
+        "ui.api_client.get_locations": AsyncMock(return_value={"items": [], "total": 0}),
+        "ui.api_client.list_import_batches": AsyncMock(return_value={"batches": []}),
+    }
+
+    @pytest.mark.asyncio
+    async def test_action_card_split_url(self, ui_client):
+        """Item detail page renders split form targeting /api/items/{id}/split."""
+        with (
+            patch("ui.api_client.get_item_schema", new=AsyncMock(return_value=_SCHEMA)),
+            patch("ui.api_client.get_item", new=AsyncMock(return_value=_ITEM)),
+            patch("ui.api_client.get_company", new=AsyncMock(return_value=_COMPANY)),
+            patch("ui.api_client.get_all_category_schemas", new=AsyncMock(return_value={})),
+            patch("ui.api_client.list_ledger", new=AsyncMock(return_value={"items": [], "total": 0})),
+            patch("ui.api_client.get_locations", new=AsyncMock(return_value={"items": [], "total": 0})),
+            patch("ui.api_client.list_import_batches", new=AsyncMock(return_value={"batches": []})),
+        ):
+            r = await ui_client.get("/inventory/gc:123", cookies=_authed())
+        assert r.status_code == 200
+        assert b'hx-post="/api/items/gc:123/split"' in r.content
+
+    @pytest.mark.asyncio
+    async def test_action_card_duplicate_url(self, ui_client):
+        """Item detail page renders duplicate form targeting /api/items/{id}/duplicate."""
+        with (
+            patch("ui.api_client.get_item_schema", new=AsyncMock(return_value=_SCHEMA)),
+            patch("ui.api_client.get_item", new=AsyncMock(return_value=_ITEM)),
+            patch("ui.api_client.get_company", new=AsyncMock(return_value=_COMPANY)),
+            patch("ui.api_client.get_all_category_schemas", new=AsyncMock(return_value={})),
+            patch("ui.api_client.list_ledger", new=AsyncMock(return_value={"items": [], "total": 0})),
+            patch("ui.api_client.get_locations", new=AsyncMock(return_value={"items": [], "total": 0})),
+            patch("ui.api_client.list_import_batches", new=AsyncMock(return_value={"batches": []})),
+        ):
+            r = await ui_client.get("/inventory/gc:123", cookies=_authed())
+        assert r.status_code == 200
+        assert b'hx-post="/api/items/gc:123/duplicate"' in r.content
+
+    @pytest.mark.asyncio
+    async def test_action_card_expire_url(self, ui_client):
+        """Item detail page renders expire form targeting /api/items/{id}/expire."""
+        with (
+            patch("ui.api_client.get_item_schema", new=AsyncMock(return_value=_SCHEMA)),
+            patch("ui.api_client.get_item", new=AsyncMock(return_value=_ITEM)),
+            patch("ui.api_client.get_company", new=AsyncMock(return_value=_COMPANY)),
+            patch("ui.api_client.get_all_category_schemas", new=AsyncMock(return_value={})),
+            patch("ui.api_client.list_ledger", new=AsyncMock(return_value={"items": [], "total": 0})),
+            patch("ui.api_client.get_locations", new=AsyncMock(return_value={"items": [], "total": 0})),
+            patch("ui.api_client.list_import_batches", new=AsyncMock(return_value={"batches": []})),
+        ):
+            r = await ui_client.get("/inventory/gc:123", cookies=_authed())
+        assert r.status_code == 200
+        assert b'hx-post="/api/items/gc:123/expire"' in r.content
+
+    @pytest.mark.asyncio
+    async def test_action_card_dispose_url(self, ui_client):
+        """Item detail page renders dispose form targeting /api/items/{id}/dispose."""
+        with (
+            patch("ui.api_client.get_item_schema", new=AsyncMock(return_value=_SCHEMA)),
+            patch("ui.api_client.get_item", new=AsyncMock(return_value=_ITEM)),
+            patch("ui.api_client.get_company", new=AsyncMock(return_value=_COMPANY)),
+            patch("ui.api_client.get_all_category_schemas", new=AsyncMock(return_value={})),
+            patch("ui.api_client.list_ledger", new=AsyncMock(return_value={"items": [], "total": 0})),
+            patch("ui.api_client.get_locations", new=AsyncMock(return_value={"items": [], "total": 0})),
+            patch("ui.api_client.list_import_batches", new=AsyncMock(return_value={"batches": []})),
+        ):
+            r = await ui_client.get("/inventory/gc:123", cookies=_authed())
+        assert r.status_code == 200
+        assert b'hx-post="/api/items/gc:123/dispose"' in r.content
+
+    @pytest.mark.asyncio
+    async def test_action_card_rtv_url(self, ui_client):
+        """Item detail page renders return-to-vendor form targeting /api/items/{id}/return-to-vendor
+        when the item has consignment_flag='in'."""
+        consigned_item = {**_ITEM, "consignment_flag": "in", "quantity": 5}
+        with (
+            patch("ui.api_client.get_item_schema", new=AsyncMock(return_value=_SCHEMA)),
+            patch("ui.api_client.get_item", new=AsyncMock(return_value=consigned_item)),
+            patch("ui.api_client.get_company", new=AsyncMock(return_value=_COMPANY)),
+            patch("ui.api_client.get_all_category_schemas", new=AsyncMock(return_value={})),
+            patch("ui.api_client.get_price_lists", new=AsyncMock(return_value=[])),
+            patch("ui.api_client.list_ledger", new=AsyncMock(return_value={"items": [], "total": 0})),
+            patch("ui.api_client.get_locations", new=AsyncMock(return_value={"items": [], "total": 0})),
+            patch("ui.api_client.list_import_batches", new=AsyncMock(return_value={"batches": []})),
+        ):
+            r = await ui_client.get("/inventory/gc:123", cookies=_authed())
+        assert r.status_code == 200
+        assert b'hx-post="/api/items/gc:123/return-to-vendor"' in r.content
+
+    @pytest.mark.asyncio
+    async def test_action_card_bbi_url(self, ui_client):
+        """Item detail page renders bring-back-in form targeting /api/items/{id}/bring-back-in
+        when the item has consignment_flag='out'."""
+        consigned_out = {**_ITEM, "consignment_flag": "out", "quantity": 5}
+        with (
+            patch("ui.api_client.get_item_schema", new=AsyncMock(return_value=_SCHEMA)),
+            patch("ui.api_client.get_item", new=AsyncMock(return_value=consigned_out)),
+            patch("ui.api_client.get_company", new=AsyncMock(return_value=_COMPANY)),
+            patch("ui.api_client.get_all_category_schemas", new=AsyncMock(return_value={})),
+            patch("ui.api_client.get_price_lists", new=AsyncMock(return_value=[])),
+            patch("ui.api_client.list_ledger", new=AsyncMock(return_value={"items": [], "total": 0})),
+            patch("ui.api_client.get_locations", new=AsyncMock(return_value={"items": [], "total": 0})),
+            patch("ui.api_client.list_import_batches", new=AsyncMock(return_value={"batches": []})),
+        ):
+            r = await ui_client.get("/inventory/gc:123", cookies=_authed())
+        assert r.status_code == 200
+        assert b'hx-post="/api/items/gc:123/bring-back-in"' in r.content
+
+
+class TestItemReturnToVendor:
+    """Route tests for POST /api/items/{entity_id}/return-to-vendor."""
+
+    @pytest.mark.asyncio
+    async def test_rtv_success_redirects(self, ui_client):
+        with (
+            patch("ui.api_client.get_item", new=AsyncMock(return_value={"quantity": 10.0})),
+            patch("ui.api_client.adjust_item", new=AsyncMock(return_value={"event_id": "e1"})),
+        ):
+            r = await ui_client.post(
+                "/api/items/gc:123/return-to-vendor",
+                data={"quantity": "3"},
+                cookies=_authed(),
+            )
+        assert r.status_code == 204
+        assert r.headers.get("HX-Redirect") == "/inventory/gc:123"
+
+    @pytest.mark.asyncio
+    async def test_rtv_reduces_quantity_correctly(self, ui_client):
+        """return-to-vendor adjusts item to current_qty - returned_qty."""
+        captured = {}
+        async def _mock_adjust(token, entity_id, new_qty):
+            captured["new_qty"] = new_qty
+            return {"event_id": "e1"}
+        with (
+            patch("ui.api_client.get_item", new=AsyncMock(return_value={"quantity": 10.0})),
+            patch("ui.api_client.adjust_item", new=_mock_adjust),
+        ):
+            await ui_client.post(
+                "/api/items/gc:123/return-to-vendor",
+                data={"quantity": "3"},
+                cookies=_authed(),
+            )
+        assert captured["new_qty"] == 7.0
+
+    @pytest.mark.asyncio
+    async def test_rtv_zero_quantity_returns_error(self, ui_client):
+        r = await ui_client.post(
+            "/api/items/gc:123/return-to-vendor",
+            data={"quantity": "0"},
+            cookies=_authed(),
+        )
+        assert r.status_code == 200
+        assert b"greater than 0" in r.content.lower() or b"quantity" in r.content.lower()
+
+    @pytest.mark.asyncio
+    async def test_rtv_invalid_quantity_returns_error(self, ui_client):
+        r = await ui_client.post(
+            "/api/items/gc:123/return-to-vendor",
+            data={"quantity": "notanumber"},
+            cookies=_authed(),
+        )
+        assert r.status_code == 200
+        assert b"greater than 0" in r.content.lower() or b"quantity" in r.content.lower()
+
+    @pytest.mark.asyncio
+    async def test_rtv_api_error_shown(self, ui_client):
+        from ui.api_client import APIError
+        with (
+            patch("ui.api_client.get_item", new=AsyncMock(return_value={"quantity": 10.0})),
+            patch("ui.api_client.adjust_item", new=AsyncMock(side_effect=APIError(400, "cannot return"))),
+        ):
+            r = await ui_client.post(
+                "/api/items/gc:123/return-to-vendor",
+                data={"quantity": "5"},
+                cookies=_authed(),
+            )
+        assert r.status_code == 200
+        assert b"cannot return" in r.content
+
+
+class TestItemBringBackIn:
+    """Route tests for POST /api/items/{entity_id}/bring-back-in."""
+
+    @pytest.mark.asyncio
+    async def test_bbi_success_redirects(self, ui_client):
+        with (
+            patch("ui.api_client.get_item", new=AsyncMock(return_value={"quantity": 5.0})),
+            patch("ui.api_client.adjust_item", new=AsyncMock(return_value={"event_id": "e1"})),
+            patch("ui.api_client.set_item_status", new=AsyncMock(return_value={"event_id": "e2"})),
+        ):
+            r = await ui_client.post(
+                "/api/items/gc:123/bring-back-in",
+                data={"quantity": "5"},
+                cookies=_authed(),
+            )
+        assert r.status_code == 204
+        assert r.headers.get("HX-Redirect") == "/inventory/gc:123"
+
+    @pytest.mark.asyncio
+    async def test_bbi_increases_quantity_correctly(self, ui_client):
+        """bring-back-in adjusts item to current_qty + returned_qty."""
+        captured = {}
+        async def _mock_adjust(token, entity_id, new_qty):
+            captured["new_qty"] = new_qty
+            return {"event_id": "e1"}
+        with (
+            patch("ui.api_client.get_item", new=AsyncMock(return_value={"quantity": 3.0})),
+            patch("ui.api_client.adjust_item", new=_mock_adjust),
+            patch("ui.api_client.set_item_status", new=AsyncMock(return_value={})),
+        ):
+            await ui_client.post(
+                "/api/items/gc:123/bring-back-in",
+                data={"quantity": "4"},
+                cookies=_authed(),
+            )
+        assert captured["new_qty"] == 7.0
+
+    @pytest.mark.asyncio
+    async def test_bbi_sets_status_to_available(self, ui_client):
+        captured = {}
+        async def _mock_status(token, entity_id, status):
+            captured["status"] = status
+            return {}
+        with (
+            patch("ui.api_client.get_item", new=AsyncMock(return_value={"quantity": 3.0})),
+            patch("ui.api_client.adjust_item", new=AsyncMock(return_value={})),
+            patch("ui.api_client.set_item_status", new=_mock_status),
+        ):
+            await ui_client.post(
+                "/api/items/gc:123/bring-back-in",
+                data={"quantity": "2"},
+                cookies=_authed(),
+            )
+        assert captured["status"] == "available"
+
+    @pytest.mark.asyncio
+    async def test_bbi_zero_quantity_returns_error(self, ui_client):
+        r = await ui_client.post(
+            "/api/items/gc:123/bring-back-in",
+            data={"quantity": "0"},
+            cookies=_authed(),
+        )
+        assert r.status_code == 200
+        assert b"greater than 0" in r.content.lower() or b"quantity" in r.content.lower()
+
+    @pytest.mark.asyncio
+    async def test_bbi_api_error_shown(self, ui_client):
+        from ui.api_client import APIError
+        with (
+            patch("ui.api_client.get_item", new=AsyncMock(return_value={"quantity": 3.0})),
+            patch("ui.api_client.adjust_item", new=AsyncMock(side_effect=APIError(400, "item locked"))),
+        ):
+            r = await ui_client.post(
+                "/api/items/gc:123/bring-back-in",
+                data={"quantity": "2"},
+                cookies=_authed(),
+            )
+        assert r.status_code == 200
+        assert b"item locked" in r.content
+
+
+class TestBulkTransferRoute:
+    """Route tests for POST /api/items/bulk/transfer."""
+
+    @pytest.mark.asyncio
+    async def test_bulk_transfer_success(self, ui_client):
+        with patch("ui.api_client.bulk_transfer", new=AsyncMock(return_value={"updated": 2})):
+            r = await ui_client.post(
+                "/api/items/bulk/transfer",
+                data={"selected": ["item:a", "item:b"], "bulk_location_id": "loc:1"},
+                cookies=_authed(),
+            )
+        assert r.status_code == 200
+        assert b"transferred" in r.content
+
+    @pytest.mark.asyncio
+    async def test_bulk_transfer_no_items_selected(self, ui_client):
+        r = await ui_client.post(
+            "/api/items/bulk/transfer",
+            data={"selected": [], "bulk_location_id": "loc:1"},
+            cookies=_authed(),
+        )
+        assert r.status_code == 200
+        assert b"selected" in r.content.lower()
+
+    @pytest.mark.asyncio
+    async def test_bulk_transfer_no_location(self, ui_client):
+        r = await ui_client.post(
+            "/api/items/bulk/transfer",
+            data={"selected": ["item:a"], "bulk_location_id": ""},
+            cookies=_authed(),
+        )
+        assert r.status_code == 200
+        assert b"location" in r.content.lower()
+
+    @pytest.mark.asyncio
+    async def test_bulk_transfer_passes_correct_args(self, ui_client):
+        captured = {}
+        async def _mock(token, entity_ids, location_id):
+            captured.update({"ids": entity_ids, "loc": location_id})
+            return {"updated": len(entity_ids)}
+        with patch("ui.api_client.bulk_transfer", new=_mock):
+            await ui_client.post(
+                "/api/items/bulk/transfer",
+                data={"selected": ["item:a", "item:b"], "bulk_location_id": "loc:warehouse"},
+                cookies=_authed(),
+            )
+        assert captured["ids"] == ["item:a", "item:b"]
+        assert captured["loc"] == "loc:warehouse"
+
+    @pytest.mark.asyncio
+    async def test_bulk_transfer_api_error_shown(self, ui_client):
+        from ui.api_client import APIError
+        with patch("ui.api_client.bulk_transfer", new=AsyncMock(side_effect=APIError(403, "not allowed"))):
+            r = await ui_client.post(
+                "/api/items/bulk/transfer",
+                data={"selected": ["item:a"], "bulk_location_id": "loc:1"},
+                cookies=_authed(),
+            )
+        assert r.status_code == 200
+        assert b"not allowed" in r.content
+
+
+class TestAttachmentRoutes:
+    """Route tests for attachment upload and delete."""
+
+    @pytest.mark.asyncio
+    async def test_upload_attachment_success_returns_panel(self, ui_client):
+        """POST /inventory/{id}/attachments returns updated attachments panel on success."""
+        import io
+        from starlette.datastructures import UploadFile as SF
+        file_content = b"fake image data"
+        with (
+            patch("ui.api_client.upload_attachment", new=AsyncMock(return_value={"id": "att:1"})),
+            patch("ui.api_client.get_item", new=AsyncMock(return_value={**_ITEM, "attachments": [{"id": "att:1", "filename": "photo.jpg", "url": "/static/attachments/c/photo.jpg"}]})),
+        ):
+            r = await ui_client.post(
+                "/inventory/gc:123/attachments",
+                files={"file": ("photo.jpg", io.BytesIO(file_content), "image/jpeg")},
+                cookies=_authed(),
+            )
+        assert r.status_code == 200
+        # Returns the attachments panel HTML (not a redirect)
+        assert b"photo.jpg" in r.content or b"attachment" in r.content.lower()
+
+    @pytest.mark.asyncio
+    async def test_upload_attachment_no_file_returns_error(self, ui_client):
+        """POST /inventory/{id}/attachments with no file field returns an error message."""
+        r = await ui_client.post(
+            "/inventory/gc:123/attachments",
+            data={},
+            cookies=_authed(),
+        )
+        assert r.status_code == 200
+        assert b"no file" in r.content.lower() or b"file" in r.content.lower()
+
+    @pytest.mark.asyncio
+    async def test_upload_attachment_unauthenticated(self, ui_client):
+        """POST without auth redirects to /login."""
+        import io
+        r = await ui_client.post(
+            "/inventory/gc:123/attachments",
+            files={"file": ("photo.jpg", io.BytesIO(b"data"), "image/jpeg")},
+        )
+        assert r.status_code == 302
+        assert "/login" in r.headers.get("location", "")
+
+    @pytest.mark.asyncio
+    async def test_upload_attachment_api_error_shown(self, ui_client):
+        from ui.api_client import APIError
+        import io
+        with patch("ui.api_client.upload_attachment", new=AsyncMock(side_effect=APIError(413, "file too large"))):
+            r = await ui_client.post(
+                "/inventory/gc:123/attachments",
+                files={"file": ("big.jpg", io.BytesIO(b"data"), "image/jpeg")},
+                cookies=_authed(),
+            )
+        assert r.status_code == 200
+        assert b"file too large" in r.content
+
+    @pytest.mark.asyncio
+    async def test_delete_attachment_success(self, ui_client):
+        """DELETE /inventory/{id}/attachments/{att_id} returns 204 with HX-Refresh."""
+        with patch("ui.api_client.delete_attachment", new=AsyncMock(return_value={})):
+            r = await ui_client.delete(
+                "/inventory/gc:123/attachments/att:1",
+                cookies=_authed(),
+            )
+        assert r.status_code == 204
+        assert r.headers.get("HX-Refresh") == "true"
+
+    @pytest.mark.asyncio
+    async def test_delete_attachment_unauthenticated(self, ui_client):
+        """DELETE without auth is redirected to /login by the global auth guard."""
+        r = await ui_client.delete("/inventory/gc:123/attachments/att:1")
+        assert r.status_code == 302
+        assert "/login" in r.headers.get("location", "")
+
+    @pytest.mark.asyncio
+    async def test_delete_attachment_passes_correct_ids(self, ui_client):
+        captured = {}
+        async def _mock(token, entity_id, att_id):
+            captured.update({"entity_id": entity_id, "att_id": att_id})
+            return {}
+        with patch("ui.api_client.delete_attachment", new=_mock):
+            await ui_client.delete(
+                "/inventory/gc:XYZ-999/attachments/att:abc",
+                cookies=_authed(),
+            )
+        assert captured["entity_id"] == "gc:XYZ-999"
+        assert captured["att_id"] == "att:abc"
+
+    @pytest.mark.asyncio
+    async def test_delete_attachment_api_error_still_returns_204(self, ui_client):
+        """API error on delete is logged but the response is still 204 (graceful)."""
+        from ui.api_client import APIError
+        with patch("ui.api_client.delete_attachment", new=AsyncMock(side_effect=APIError(404, "not found"))):
+            r = await ui_client.delete(
+                "/inventory/gc:123/attachments/att:missing",
+                cookies=_authed(),
+            )
+        assert r.status_code == 204
+
+    def test_attachment_upload_url_in_item_detail_html(self):
+        """_attachments_panel renders fetch POST targeting /inventory/{id}/attachments
+        and hx-delete targeting /inventory/{id}/attachments/{att_id}."""
+        from ui.routes.inventory import _attachments_panel
+        from fasthtml.common import to_xml
+        item_with_attachments = {**_ITEM, "attachments": [
+            {"id": "att:1", "filename": "photo.jpg", "url": "/static/attachments/c/photo.jpg", "type": "image"},
+        ]}
+        html = to_xml(_attachments_panel("gc:ROW-001", item_with_attachments))
+        assert "/inventory/gc:ROW-001/attachments" in html, \
+            "attachment upload fetch must POST to /inventory/{id}/attachments"
+        assert 'hx-delete="/inventory/gc:ROW-001/attachments/att:1"' in html, \
+            "attachment delete button must target DELETE /inventory/{id}/attachments/{att_id}"
+
+
 class TestInventoryBulkActions:
     """List-level bulk action routes: status, transfer, delete."""
 

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -3776,20 +3776,20 @@ class TestItemActionRouteCompleteness:
         assert r.status_code == 200
         assert b"already disposed" in r.content
 
-    # ── DELETE /api/inventory/{entity_id} (row-menu delete) ──────────────────
+    # ── DELETE /api/items/{entity_id} (row-menu delete) ──────────────────
 
     @pytest.mark.asyncio
     async def test_row_menu_delete_returns_200_removes_row(self, ui_client):
-        """DELETE /api/inventory/{id} returns 200 empty body so htmx removes the row."""
-        with patch("ui.api_client.dispose_item", new=AsyncMock(return_value={"deleted": "gc:abc"})):
-            r = await ui_client.delete("/api/inventory/gc:abc", cookies=_authed())
+        """DELETE /api/items/{id} returns 200 empty body so htmx removes the row."""
+        with patch("ui.api_client.bulk_delete", new=AsyncMock(return_value={"deleted": 1})):
+            r = await ui_client.delete("/api/items/gc:abc", cookies=_authed())
         assert r.status_code == 200
         assert r.content == b""
 
     @pytest.mark.asyncio
     async def test_row_menu_delete_unauthenticated_redirects(self, ui_client):
         """DELETE without auth cookie is intercepted by _auth_guard → 302 to /login."""
-        r = await ui_client.delete("/api/inventory/gc:abc")
+        r = await ui_client.delete("/api/items/gc:abc")
         assert r.status_code == 302
         assert "/login" in r.headers.get("location", "")
 
@@ -3797,21 +3797,33 @@ class TestItemActionRouteCompleteness:
     async def test_row_menu_delete_api_error_returns_inline_error_row(self, ui_client):
         """On API error, DELETE returns a Tr with an error cell so the row shows the error."""
         from ui.api_client import APIError
-        with patch("ui.api_client.dispose_item", new=AsyncMock(side_effect=APIError(403, "permission denied"))):
-            r = await ui_client.delete("/api/inventory/gc:abc", cookies=_authed())
+        with patch("ui.api_client.bulk_delete", new=AsyncMock(side_effect=APIError(403, "permission denied"))):
+            r = await ui_client.delete("/api/items/gc:abc", cookies=_authed())
         assert r.status_code == 200
         assert b"permission denied" in r.content
 
     @pytest.mark.asyncio
-    async def test_row_menu_delete_calls_dispose_with_correct_id(self, ui_client):
-        """DELETE proxies to api.dispose_item with the correct entity_id."""
+    async def test_row_menu_delete_calls_bulk_delete_with_correct_id(self, ui_client):
+        """DELETE proxies to api.bulk_delete with the entity_id wrapped in a list."""
         captured = {}
-        async def _mock(token, entity_id):
-            captured["entity_id"] = entity_id
-            return {"deleted": entity_id}
-        with patch("ui.api_client.dispose_item", new=_mock):
-            await ui_client.delete("/api/inventory/gc:TEST-001", cookies=_authed())
-        assert captured["entity_id"] == "gc:TEST-001"
+        async def _mock(token, entity_ids):
+            captured["entity_ids"] = entity_ids
+            return {"deleted": len(entity_ids)}
+        with patch("ui.api_client.bulk_delete", new=_mock):
+            await ui_client.delete("/api/items/gc:TEST-001", cookies=_authed())
+        assert captured["entity_ids"] == ["gc:TEST-001"]
+
+    def test_row_menu_delete_html_targets_correct_endpoint(self):
+        """data_table renders hx-delete pointing at /api/items/{id}, not /api/inventory/."""
+        from ui.components.table import data_table
+        from fasthtml.common import to_xml
+        schema = [{"key": "sku", "label": "SKU"}, {"key": "name", "label": "Name"}]
+        rows = [{"entity_id": "gc:ROW-001", "sku": "TEST", "name": "Widget"}]
+        html = to_xml(data_table(schema=schema, rows=rows, entity_type="item", show_row_menu=True))
+        assert 'hx-delete="/api/items/gc:ROW-001"' in html, \
+            "row-menu delete button must target /api/items/{id}, not /api/inventory/{id}"
+        assert "/api/inventory/" not in html, \
+            "route must not reference deprecated /api/inventory/ path"
 
     # ── split (additional coverage) ───────────────────────────────────────────
 

--- a/ui/routes/inventory.py
+++ b/ui/routes/inventory.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 
 from fasthtml.common import *
 from starlette.requests import Request
-from starlette.responses import RedirectResponse
+from starlette.responses import RedirectResponse, Response
 
 import ui.api_client as api
 from ui.api_client import APIError
@@ -288,7 +288,6 @@ def setup_routes(app):
             if e.status == 401:
                 return RedirectResponse("/login", status_code=302)
             data = b"error\n" + e.detail.encode()
-        from starlette.responses import Response
         return Response(
             content=data,
             media_type="text/csv",
@@ -333,7 +332,6 @@ def setup_routes(app):
         writer.writeheader()
         # Write one empty example row
         writer.writerow({c: "" for c in spec.cols})
-        from starlette.responses import Response
         return Response(
             content=output.getvalue(),
             media_type="text/csv",
@@ -740,10 +738,9 @@ def setup_routes(app):
     @app.post("/inventory/create-blank")
     async def inventory_create_blank(request: Request):
         """Create a minimal item and redirect to its detail page."""
-        from starlette.responses import Response as _R
         token = _token(request)
         if not token:
-            return _R("", status_code=401, headers={"HX-Redirect": "/login"})
+            return Response("", status_code=401, headers={"HX-Redirect": "/login"})
         import uuid as _uuid
         sku = f"ITEM-{_uuid.uuid4().hex[:8].upper()}"
         try:
@@ -751,10 +748,10 @@ def setup_routes(app):
             item_id = result.get("id", result.get("entity_id", ""))
         except APIError as e:
             if e.status == 401:
-                return _R("", status_code=401, headers={"HX-Redirect": "/login"})
+                return Response("", status_code=401, headers={"HX-Redirect": "/login"})
             logger.warning("Blank-create item failed: %s", e.detail)
-            return _R("", status_code=500)
-        return _R("", status_code=204, headers={"HX-Redirect": f"/inventory/{item_id}"})
+            return Response("", status_code=500)
+        return Response("", status_code=204, headers={"HX-Redirect": f"/inventory/{item_id}"})
 
     # /inventory/new: redirect for any bookmarked links
     @app.get("/inventory/new")
@@ -1060,10 +1057,9 @@ function celerpPrintLabel(entityId, templateId) {
 
     @app.post("/api/items/bulk/merge")
     async def bulk_item_merge(request: Request):
-        from starlette.responses import Response as _R
         token = _token(request)
         if not token:
-            return _R("", status_code=401, headers={"HX-Redirect": "/login"})
+            return Response("", status_code=401, headers={"HX-Redirect": "/login"})
         form = await request.form()
         entity_ids = [v.strip() for v in form.getlist("selected") if v.strip()]
         target_sku_from = str(form.get("target_sku_from", "")).strip()
@@ -1147,10 +1143,9 @@ function celerpPrintLabel(entityId, templateId) {
 
     @app.post("/api/items/bulk/split")
     async def bulk_item_split(request: Request):
-        from starlette.responses import Response as _R
         token = _token(request)
         if not token:
-            return _R("", status_code=401, headers={"HX-Redirect": "/login"})
+            return Response("", status_code=401, headers={"HX-Redirect": "/login"})
         form = await request.form()
         entity_ids = [v.strip() for v in form.getlist("selected") if v.strip()]
         if len(entity_ids) != 1:
@@ -1253,11 +1248,10 @@ function celerpPrintLabel(entityId, templateId) {
 
     @app.post("/api/items/send-to")
     async def send_to_action(request: Request):
-        from starlette.responses import Response as _R
         from ui.routes.documents import _line_items_from_inventory
         token = _token(request)
         if not token:
-            return _R("", status_code=401, headers={"HX-Redirect": "/login"})
+            return Response("", status_code=401, headers={"HX-Redirect": "/login"})
         form = await request.form()
         entity_ids = [v.strip() for v in form.getlist("selected") if v.strip()]
         doc_type = str(form.get("send_to_doc_type", "")).strip()
@@ -1275,18 +1269,18 @@ function celerpPrintLabel(entityId, templateId) {
                     combined = (doc.get("line_items") or []) + new_lines
                     subtotal = sum(l.get("quantity", 0) * l.get("unit_price", 0) for l in combined)
                     await api.patch_doc(token, target_id, {"line_items": combined, "subtotal": subtotal, "total": subtotal})
-                    return _R("", status_code=204, headers={"HX-Redirect": f"/docs/{target_id}"})
+                    return Response("", status_code=204, headers={"HX-Redirect": f"/docs/{target_id}"})
                 elif doc_type == "list":
                     new_lines = await _line_items_from_inventory(token, entity_ids)
                     lst = await api.get_list(token, target_id)
                     combined = (lst.get("line_items") or []) + new_lines
                     subtotal = sum(l.get("quantity", 0) * l.get("unit_price", 0) for l in combined)
                     await api.patch_list(token, target_id, {"line_items": combined, "subtotal": subtotal, "total": subtotal})
-                    return _R("", status_code=204, headers={"HX-Redirect": f"/lists/{target_id}"})
+                    return Response("", status_code=204, headers={"HX-Redirect": f"/lists/{target_id}"})
                 elif doc_type == "memo":
                     for eid in entity_ids:
                         await api.add_memo_item(token, target_id, {"item_id": eid})
-                    return _R("", status_code=204, headers={"HX-Redirect": f"/crm/memos/{target_id}"})
+                    return Response("", status_code=204, headers={"HX-Redirect": f"/crm/memos/{target_id}"})
             else:
                 # Create new document
                 if doc_type == "invoice":
@@ -1295,18 +1289,18 @@ function celerpPrintLabel(entityId, templateId) {
                     doc_taxes = await _company_doc_taxes(token)
                     result = await api.create_doc(token, {"doc_type": "invoice", "status": "draft", "line_items": line_items, "doc_taxes": doc_taxes})
                     doc_id = result.get("entity_id") or result.get("id", "")
-                    return _R("", status_code=204, headers={"HX-Redirect": f"/docs/{doc_id}"})
+                    return Response("", status_code=204, headers={"HX-Redirect": f"/docs/{doc_id}"})
                 elif doc_type == "list":
                     line_items = await _line_items_from_inventory(token, entity_ids)
                     result = await api.create_list(token, {"list_type": "quotation", "status": "draft", "line_items": line_items})
                     list_id = result.get("entity_id") or result.get("id", "")
-                    return _R("", status_code=204, headers={"HX-Redirect": f"/lists/{list_id}"})
+                    return Response("", status_code=204, headers={"HX-Redirect": f"/lists/{list_id}"})
                 elif doc_type == "memo":
                     result = await api.create_memo(token)
                     memo_id = result.get("id", "")
                     for eid in entity_ids:
                         await api.add_memo_item(token, memo_id, {"item_id": eid})
-                    return _R("", status_code=204, headers={"HX-Redirect": f"/crm/memos/{memo_id}"})
+                    return Response("", status_code=204, headers={"HX-Redirect": f"/crm/memos/{memo_id}"})
         except APIError as e:
             return Div(P(str(e.detail), cls="flash flash--error"), id="bulk-action-result")
         return Div(P(t("inv.unknown_document_type"), cls="flash flash--warning"), id="bulk-action-result")
@@ -1315,10 +1309,9 @@ function celerpPrintLabel(entityId, templateId) {
 
     @app.post("/api/items/{entity_id}/adjust")
     async def item_adjust(request: Request, entity_id: str):
-        from starlette.responses import Response as _R
         token = _token(request)
         if not token:
-            return _R("", status_code=401, headers={"HX-Redirect": "/login"})
+            return Response("", status_code=401, headers={"HX-Redirect": "/login"})
         form = await request.form()
         try:
             new_qty = float(str(form.get("new_qty", "0")))
@@ -1328,28 +1321,26 @@ function celerpPrintLabel(entityId, templateId) {
             await api.adjust_item(token, entity_id, new_qty)
         except APIError as e:
             return Div(Span(str(e.detail), cls="flash flash--error"), id="item-action-error")
-        return _R("", status_code=204, headers={"HX-Redirect": f"/inventory/{entity_id}"})
+        return Response("", status_code=204, headers={"HX-Redirect": f"/inventory/{entity_id}"})
 
     @app.post("/api/items/{entity_id}/transfer")
     async def item_transfer(request: Request, entity_id: str):
-        from starlette.responses import Response as _R
         token = _token(request)
         if not token:
-            return _R("", status_code=401, headers={"HX-Redirect": "/login"})
+            return Response("", status_code=401, headers={"HX-Redirect": "/login"})
         form = await request.form()
         location_id = str(form.get("location_id", "")).strip()
         try:
             await api.transfer_item(token, entity_id, location_id)
         except APIError as e:
             return Div(Span(str(e.detail), cls="flash flash--error"), id="item-action-error")
-        return _R("", status_code=204, headers={"HX-Redirect": f"/inventory/{entity_id}"})
+        return Response("", status_code=204, headers={"HX-Redirect": f"/inventory/{entity_id}"})
 
     @app.post("/api/items/{entity_id}/reserve")
     async def item_reserve(request: Request, entity_id: str):
-        from starlette.responses import Response as _R
         token = _token(request)
         if not token:
-            return _R("", status_code=401, headers={"HX-Redirect": "/login"})
+            return Response("", status_code=401, headers={"HX-Redirect": "/login"})
         form = await request.form()
         try:
             qty = float(str(form.get("quantity", "0")))
@@ -1360,14 +1351,13 @@ function celerpPrintLabel(entityId, templateId) {
             await api.reserve_item(token, entity_id, qty, reference)
         except APIError as e:
             return Div(Span(str(e.detail), cls="flash flash--error"), id="item-action-error")
-        return _R("", status_code=204, headers={"HX-Redirect": f"/inventory/{entity_id}"})
+        return Response("", status_code=204, headers={"HX-Redirect": f"/inventory/{entity_id}"})
 
     @app.post("/api/items/{entity_id}/unreserve")
     async def item_unreserve(request: Request, entity_id: str):
-        from starlette.responses import Response as _R
         token = _token(request)
         if not token:
-            return _R("", status_code=401, headers={"HX-Redirect": "/login"})
+            return Response("", status_code=401, headers={"HX-Redirect": "/login"})
         form = await request.form()
         try:
             qty = float(str(form.get("quantity", "0")))
@@ -1377,14 +1367,13 @@ function celerpPrintLabel(entityId, templateId) {
             await api.unreserve_item(token, entity_id, qty)
         except APIError as e:
             return Div(Span(str(e.detail), cls="flash flash--error"), id="item-action-error")
-        return _R("", status_code=204, headers={"HX-Redirect": f"/inventory/{entity_id}"})
+        return Response("", status_code=204, headers={"HX-Redirect": f"/inventory/{entity_id}"})
 
     @app.post("/api/items/{entity_id}/price")
     async def item_price(request: Request, entity_id: str):
-        from starlette.responses import Response as _R
         token = _token(request)
         if not token:
-            return _R("", status_code=401, headers={"HX-Redirect": "/login"})
+            return Response("", status_code=401, headers={"HX-Redirect": "/login"})
         form = await request.form()
         # Read all price list names dynamically from company settings
         try:
@@ -1404,42 +1393,39 @@ function celerpPrintLabel(entityId, templateId) {
                     await api.set_item_price(token, entity_id, pl_name, price)
         except APIError as e:
             return Div(Span(str(e.detail), cls="flash flash--error"), id="item-action-error")
-        return _R("", status_code=204, headers={"HX-Redirect": f"/inventory/{entity_id}"})
+        return Response("", status_code=204, headers={"HX-Redirect": f"/inventory/{entity_id}"})
 
     @app.post("/api/items/{entity_id}/status")
     async def item_status(request: Request, entity_id: str):
-        from starlette.responses import Response as _R
         token = _token(request)
         if not token:
-            return _R("", status_code=401, headers={"HX-Redirect": "/login"})
+            return Response("", status_code=401, headers={"HX-Redirect": "/login"})
         form = await request.form()
         status = str(form.get("status", "")).strip()
         try:
             await api.set_item_status(token, entity_id, status)
         except APIError as e:
             return Div(Span(str(e.detail), cls="flash flash--error"), id="item-action-error")
-        return _R("", status_code=204, headers={"HX-Redirect": f"/inventory/{entity_id}"})
+        return Response("", status_code=204, headers={"HX-Redirect": f"/inventory/{entity_id}"})
 
     @app.post("/api/items/{entity_id}/expire")
     async def item_expire(request: Request, entity_id: str):
-        from starlette.responses import Response as _R
         token = _token(request)
         if not token:
-            return _R("", status_code=401, headers={"HX-Redirect": "/login"})
+            return Response("", status_code=401, headers={"HX-Redirect": "/login"})
         form = await request.form()
         reason = str(form.get("reason", "")).strip() or None
         try:
             await api.expire_item(token, entity_id, reason)
         except APIError as e:
             return Div(Span(str(e.detail), cls="flash flash--error"), id="item-action-error")
-        return _R("", status_code=204, headers={"HX-Redirect": f"/inventory/{entity_id}"})
+        return Response("", status_code=204, headers={"HX-Redirect": f"/inventory/{entity_id}"})
 
     @app.post("/api/items/{entity_id}/dispose")
     async def item_dispose(request: Request, entity_id: str):
-        from starlette.responses import Response as _R
         token = _token(request)
         if not token:
-            return _R("", status_code=401, headers={"HX-Redirect": "/login"})
+            return Response("", status_code=401, headers={"HX-Redirect": "/login"})
         form = await request.form()
         reason = str(form.get("reason", "")).strip() or None
         notes = str(form.get("notes", "")).strip() or None
@@ -1447,15 +1433,14 @@ function celerpPrintLabel(entityId, templateId) {
             await api.dispose_item(token, entity_id, reason, notes)
         except APIError as e:
             return Div(Span(str(e.detail), cls="flash flash--error"), id="item-action-error")
-        return _R("", status_code=204, headers={"HX-Redirect": f"/inventory/{entity_id}"})
+        return Response("", status_code=204, headers={"HX-Redirect": f"/inventory/{entity_id}"})
 
     @app.post("/api/items/{entity_id}/return-to-vendor")
     async def item_return_to_vendor(request: Request, entity_id: str):
         """Return an item received from a bill/PO back to the vendor."""
-        from starlette.responses import Response as _R
         token = _token(request)
         if not token:
-            return _R("", status_code=401, headers={"HX-Redirect": "/login"})
+            return Response("", status_code=401, headers={"HX-Redirect": "/login"})
         form = await request.form()
         try:
             qty = float(str(form.get("quantity", "0")))
@@ -1474,15 +1459,14 @@ function celerpPrintLabel(entityId, templateId) {
             # Note: the source doc tracking for returns will be enhanced in future
         except APIError as e:
             return Div(Span(str(e.detail), cls="flash flash--error"), id="item-action-error")
-        return _R("", status_code=204, headers={"HX-Redirect": f"/inventory/{entity_id}"})
+        return Response("", status_code=204, headers={"HX-Redirect": f"/inventory/{entity_id}"})
 
     @app.post("/api/items/{entity_id}/bring-back-in")
     async def item_bring_back_in(request: Request, entity_id: str):
         """Return a consigned-out item back into inventory."""
-        from starlette.responses import Response as _R
         token = _token(request)
         if not token:
-            return _R("", status_code=401, headers={"HX-Redirect": "/login"})
+            return Response("", status_code=401, headers={"HX-Redirect": "/login"})
         form = await request.form()
         try:
             qty = float(str(form.get("quantity", "0")))
@@ -1499,16 +1483,15 @@ function celerpPrintLabel(entityId, templateId) {
             await api.set_item_status(token, entity_id, "available")
         except APIError as e:
             return Div(Span(str(e.detail), cls="flash flash--error"), id="item-action-error")
-        return _R("", status_code=204, headers={"HX-Redirect": f"/inventory/{entity_id}"})
+        return Response("", status_code=204, headers={"HX-Redirect": f"/inventory/{entity_id}"})
 
     @app.post("/api/items/{entity_id}/split")
     async def item_split(request: Request, entity_id: str):
         import json as _json
-        from starlette.responses import Response as _R
         from urllib.parse import quote
         token = _token(request)
         if not token:
-            return _R("", status_code=401, headers={"HX-Redirect": "/login"})
+            return Response("", status_code=401, headers={"HX-Redirect": "/login"})
 
         # Get parent item for SKU
         try:
@@ -1578,14 +1561,13 @@ function celerpPrintLabel(entityId, templateId) {
         except APIError as e:
             return Div(Span(str(e.detail), cls="flash flash--error"), id="item-action-error")
         redirect = f"/inventory?q={quote(orig_sku)}" if orig_sku else f"/inventory/{entity_id}"
-        return _R("", status_code=204, headers={"HX-Redirect": redirect})
+        return Response("", status_code=204, headers={"HX-Redirect": redirect})
 
     @app.post("/api/items/merge")
     async def item_merge(request: Request):
-        from starlette.responses import Response as _R
         token = _token(request)
         if not token:
-            return _R("", status_code=401, headers={"HX-Redirect": "/login"})
+            return Response("", status_code=401, headers={"HX-Redirect": "/login"})
         form = await request.form()
         source_entity_ids = [v.strip() for v in form.getlist("source_entity_ids") if v.strip()]
         target_sku_from = str(form.get("target_sku_from", "")).strip()
@@ -1627,14 +1609,13 @@ function celerpPrintLabel(entityId, templateId) {
         except APIError as e:
             return Span(str(e.detail), cls="flash flash--error")
         new_id = result.get("id", "")
-        return _R("", status_code=204, headers={"HX-Redirect": f"/inventory/{new_id}"})
+        return Response("", status_code=204, headers={"HX-Redirect": f"/inventory/{new_id}"})
 
     @app.post("/api/items/{entity_id}/duplicate")
     async def item_duplicate(request: Request, entity_id: str):
-        from starlette.responses import Response as _R
         token = _token(request)
         if not token:
-            return _R("", status_code=401, headers={"HX-Redirect": "/login"})
+            return Response("", status_code=401, headers={"HX-Redirect": "/login"})
         form = await request.form()
         new_sku = str(form.get("new_sku", "")).strip()
         if not new_sku:
@@ -1664,7 +1645,7 @@ function celerpPrintLabel(entityId, templateId) {
         except APIError as e:
             return Div(Span(str(e.detail), cls="flash flash--error"), id="item-action-error")
         new_id = result.get("id", "")
-        return _R("", status_code=204, headers={"HX-Redirect": f"/inventory/{new_id}"})
+        return Response("", status_code=204, headers={"HX-Redirect": f"/inventory/{new_id}"})
 
     # ── Attachment upload (single file) ──────────────────────────────────────
 
@@ -1684,42 +1665,40 @@ function celerpPrintLabel(entityId, templateId) {
             return P(str(e.detail), cls="cell-error")
         return _attachments_panel(entity_id, item)
 
-    @app.delete("/api/inventory/{entity_id}")
+    @app.delete("/api/items/{entity_id}")
     async def item_delete(request: Request, entity_id: str):
         """Delete a single item from the row-action menu.
 
         The data_table component renders the row menu with:
-            hx_delete="/api/inventory/{entity_id}"
+            hx_delete="/api/items/{entity_id}"
             hx_target="#row-{safe_id}"
             hx_swap="outerHTML"
 
         Returning an empty 200 causes htmx to replace the row element with
         nothing, removing it from the DOM immediately without a page reload.
         """
-        from starlette.responses import Response as _R
         token = _token(request)
         if not token:
-            return _R("", status_code=401, headers={"HX-Redirect": "/login"})
+            return Response("", status_code=401, headers={"HX-Redirect": "/login"})
         try:
-            await api.dispose_item(token, entity_id)
+            await api.bulk_delete(token, [entity_id])
         except APIError as e:
             return Tr(
                 Td(Span(str(e.detail), cls="flash flash--error"), colspan="100"),
                 id=f"row-{entity_id.replace(':', '-')}",
             )
-        return _R("", status_code=200)
+        return Response("", status_code=200)
 
     @app.delete("/inventory/{entity_id}/attachments/{att_id}")
     async def item_delete_attachment(request: Request, entity_id: str, att_id: str):
-        from starlette.responses import Response as _R
         token = _token(request)
         if not token:
-            return _R("", status_code=401)
+            return Response("", status_code=401)
         try:
             await api.delete_attachment(token, entity_id, att_id)
         except APIError as e:
             logger.warning("API error on delete attachment %s/%s: %s", entity_id, att_id, e.detail)
-        return _R("", status_code=204, headers={"HX-Refresh": "true"})
+        return Response("", status_code=204, headers={"HX-Refresh": "true"})
 
 
 def _bulk_toolbar(locations: list[dict]) -> FT:


### PR DESCRIPTION
## Problem
Row-menu delete button didn't work:
- Route was `/api/inventory/{entity_id}` but `data_table` renders `/api/items/{entity_id}` → 404 on every delete
- Route called `api.dispose_item()` (disposal workflow requiring reason/notes) instead of `api.bulk_delete([entity_id])`
- `Response` was imported locally inside 20+ functions instead of at module scope
- Tests were written against the wrong URL and wrong mock, so they passed against broken code

## Fixes
- Route path: `/api/inventory/` → `/api/items/`
- API call: `dispose_item` → `bulk_delete([entity_id])`
- Hoist `Response` import to module scope; remove 20 local inline imports across `inventory.py`

## Test improvements (lesson applied)
New rule: every action route now has an **HTML contract test** that renders the component and asserts the exact `hx-post`/`hx-delete` URL - not just that the label text appears. This would have caught the original bug.

New test coverage added:
- Row-menu delete: corrected URL + mock + HTML contract (`data_table` renders `hx-delete=/api/items/{id}`)
- `return-to-vendor`: 5 tests (was zero)
- `bring-back-in`: 5 tests (was zero)
- `bulk/transfer`: 5 tests (was zero)
- Attachment upload/delete: 9 tests (was zero)
- Item detail action card HTML contracts: 6 tests (split, duplicate, expire, dispose, RTV, BBI)