### PR TITLE
fix: intercept htmx:confirm with native Electron dialog

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -13,7 +13,7 @@
 
 "use strict";
 
-const { app, BrowserWindow, shell, dialog } = require("electron");
+const { app, BrowserWindow, shell, dialog, ipcMain } = require("electron");
 const { autoUpdater } = require("electron-updater");
 const path = require("path");
 const fs = require("fs");
@@ -463,6 +463,24 @@ function createWindow() {
 
   mainWindow.once("ready-to-show", () => mainWindow.show());
 
+  // Intercept htmx hx-confirm on every navigation. window.confirm() is silently
+  // stubbed to false in Electron's renderer, so we override it here via the
+  // contextBridge (window.celerp.showConfirm → IPC → dialog.showMessageBoxSync).
+  mainWindow.webContents.on("did-finish-load", () => {
+    mainWindow.webContents.executeJavaScript(`
+      (function () {
+        if (window.__ceConfirmPatched) return;
+        window.__ceConfirmPatched = true;
+        document.addEventListener("htmx:confirm", function (e) {
+          if (!e.detail.question) return;
+          e.preventDefault();
+          var ok = window.celerp && window.celerp.showConfirm(e.detail.question);
+          if (ok) e.detail.issueRequest(true);
+        });
+      })();
+    `).catch(() => {}); // ignore if page is being navigated away
+  });
+
   // Open external links in the default browser, not in the app
   mainWindow.webContents.setWindowOpenHandler(({ url }) => {
     if (!url.startsWith(`http://127.0.0.1:${uiPort}`)) {
@@ -474,6 +492,22 @@ function createWindow() {
 
   mainWindow.on("closed", () => { mainWindow = null; });
 }
+
+// ── IPC handlers ─────────────────────────────────────────────────────────────
+
+// show-confirm: renderer calls window.celerp.showConfirm(message) for hx-confirm
+// dialogs. window.confirm() is silently stubbed to false in Electron's renderer,
+// so htmx hx-confirm never fires without this native dialog bridge.
+ipcMain.on("show-confirm", (event, message) => {
+  const result = dialog.showMessageBoxSync(mainWindow, {
+    type: "question",
+    buttons: ["Cancel", "OK"],
+    defaultId: 1,
+    cancelId: 0,
+    message: String(message),
+  });
+  event.returnValue = result === 1; // true = OK, false = Cancel
+});
 
 // ── App lifecycle ────────────────────────────────────────────────────────────
 

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -11,4 +11,9 @@ const { contextBridge, ipcRenderer } = require("electron");
 contextBridge.exposeInMainWorld("celerp", {
   // Renderer can call this to open a URL in the system browser
   openExternal: (url) => ipcRenderer.invoke("open-external", url),
+
+  // Renderer calls this for hx-confirm dialogs; returns true if user clicked OK.
+  // Synchronous round-trip via ipcRenderer.sendSync so the htmx confirm handler
+  // can return a plain boolean without needing async/await.
+  showConfirm: (message) => ipcRenderer.sendSync("show-confirm", message),
 });

--- a/tests/test_modules/test_electron_integration.py
+++ b/tests/test_modules/test_electron_integration.py
@@ -248,3 +248,56 @@ class TestSecondBootGuards:
     def test_migrations_are_idempotent_upgrade_head(self):
         """runMigrations uses alembic upgrade head which is a no-op if already current."""
         assert "upgrade" in self._src and "head" in self._src
+
+
+class TestElectronConfirmDialog:
+    """Verify the hx-confirm → native dialog bridge is correctly wired in main.js and preload.js."""
+
+    @pytest.fixture(autouse=True)
+    def _src(self):
+        import os
+        p = os.path.join(os.path.dirname(__file__), "../../electron/main.js")
+        with open(p) as f:
+            self.main_src = f.read()
+        p2 = os.path.join(os.path.dirname(__file__), "../../electron/preload.js")
+        with open(p2) as f:
+            self.preload_src = f.read()
+
+    def test_ipcmain_imported(self):
+        """ipcMain must be destructured from 'electron' require."""
+        assert "ipcMain" in self.main_src
+
+    def test_show_confirm_handler_registered(self):
+        """main.js must register an ipcMain.on('show-confirm', ...) handler."""
+        assert 'ipcMain.on("show-confirm"' in self.main_src
+
+    def test_show_confirm_uses_showmessageboxsync(self):
+        """show-confirm handler must use showMessageBoxSync (synchronous) not showMessageBox."""
+        assert "showMessageBoxSync" in self.main_src
+
+    def test_show_confirm_sets_event_returnvalue(self):
+        """show-confirm handler must set event.returnValue for ipcRenderer.sendSync."""
+        assert "event.returnValue" in self.main_src
+
+    def test_preload_exposes_showconfirm(self):
+        """preload.js must expose showConfirm on the contextBridge."""
+        assert "showConfirm" in self.preload_src
+
+    def test_preload_uses_sendsync(self):
+        """showConfirm must use ipcRenderer.sendSync (not invoke) to return synchronously."""
+        assert "sendSync" in self.preload_src
+        assert '"show-confirm"' in self.preload_src
+
+    def test_htmx_confirm_interceptor_in_main(self):
+        """main.js must inject htmx:confirm event listener that calls window.celerp.showConfirm."""
+        assert "htmx:confirm" in self.main_src
+        assert "showConfirm" in self.main_src
+        assert "issueRequest" in self.main_src
+
+    def test_interceptor_attached_on_did_finish_load(self):
+        """Confirm interceptor must be re-injected on did-finish-load (survives htmx navigation)."""
+        assert "did-finish-load" in self.main_src
+
+    def test_interceptor_is_idempotent(self):
+        """Interceptor must guard against double-registration (__ceConfirmPatched sentinel)."""
+        assert "__ceConfirmPatched" in self.main_src


### PR DESCRIPTION
## Root cause

`window.confirm()` is silently stubbed to `false` in Electron's renderer process when `contextIsolation: true`. htmx uses `window.confirm()` to evaluate `hx-confirm` attributes. Result: clicking OK in the confirmation popup always returned `false` → htmx cancelled the request before it fired.

This is why bulk delete worked (no `hx-confirm`) but three-dot row-menu delete didn't (has `hx-confirm="Delete this item?"`).

## Fix

Three-part wiring:

1. **`preload.js`**: expose `window.celerp.showConfirm(message)` via `ipcRenderer.sendSync` — synchronous so it can return a plain boolean
2. **`main.js`**: `ipcMain.on('show-confirm')` calls `dialog.showMessageBoxSync` and sets `event.returnValue = (user clicked OK)`
3. **`main.js`**: on every `did-finish-load`, inject an `htmx:confirm` event listener that:
   - calls `e.preventDefault()` to suppress the native `window.confirm()`
   - calls `window.celerp.showConfirm(e.detail.question)` to show a native OS dialog
   - calls `e.detail.issueRequest(true)` only if the user confirmed
   - guards with `__ceConfirmPatched` sentinel to avoid double-registration on htmx partial-page swaps

## Tests

`TestElectronConfirmDialog` (9 tests): verify `ipcMain` import, handler registration, `showMessageBoxSync` use, `event.returnValue`, preload exposure, `sendSync` use, `htmx:confirm` injection, `did-finish-load` attachment, and idempotent sentinel.