### PR TITLE
fix: resolve Electron Mac label creation error and version mismatch

### DIFF
--- a/celerp/__init__.py
+++ b/celerp/__init__.py
@@ -3,4 +3,9 @@
 
 from __future__ import annotations
 
-__version__ = "1.0.0"
+from importlib.metadata import version, PackageNotFoundError
+
+try:
+    __version__ = version("celerp")
+except PackageNotFoundError:
+    __version__ = "0.0.0+dev"

--- a/default_modules/celerp-labels/celerp_labels/ui_routes.py
+++ b/default_modules/celerp-labels/celerp_labels/ui_routes.py
@@ -1050,9 +1050,9 @@ def setup_ui_routes(app) -> None:
         from ui.config import COOKIE_NAME
         return request.cookies.get(COOKIE_NAME)
 
-    def _api_base(request: Request) -> str:
-        host = request.url.hostname or "localhost"
-        return f"http://{host}:8000"
+    def _api_base(request: Request) -> str:  # noqa: ARG001
+        from ui.config import API_BASE
+        return API_BASE
 
     async def _fetch_templates(request: Request) -> list[dict]:
         token = _token(request)

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -321,3 +321,103 @@ class TestStaleTokenRedirectLoop:
         assert r.headers.get("location", "") == "/", (
             f"Valid token should redirect to /, got {r.headers.get('location')!r}"
         )
+
+
+# ---------------------------------------------------------------------------
+# REG-005  celerp.__version__ must be read from installed package metadata,
+#          not hardcoded. Hardcoding causes Electron/Mac to show "1.0.0"
+#          regardless of the published git tag.
+# ---------------------------------------------------------------------------
+
+class TestREG005VersionSourceOfTruth:
+    """Ensure __version__ is not a hardcoded string literal.
+
+    Rationale: if the string is hardcoded, it will always read "1.0.0" even
+    after a release tag is pushed, causing the Electron UI to display the
+    wrong version. The canonical source is importlib.metadata which reads
+    from the installed package's METADATA file (populated by the git tag via
+    setuptools-scm).
+    """
+
+    def test_version_not_hardcoded_string(self):
+        """__version__ must be sourced from importlib.metadata, not a literal.
+
+        Specifically: the first (primary) assignment to __version__ at module
+        scope must be a function call (importlib.metadata.version(...)), not a
+        string constant.  A fallback constant inside an except block is fine.
+        """
+        import ast, pathlib
+
+        src = pathlib.Path(__file__).parent.parent / "celerp" / "__init__.py"
+        tree = ast.parse(src.read_text())
+
+        for node in ast.walk(tree):
+            # Only check top-level Assign nodes (not inside try/except handlers)
+            if not isinstance(node, ast.Assign):
+                continue
+            # Skip nodes that are inside an ExceptHandler
+            # We walk the top-level body only
+            if node not in tree.body:
+                continue
+            for target in node.targets:
+                if isinstance(target, ast.Name) and target.id == "__version__":
+                    assert not isinstance(node.value, ast.Constant), (
+                        "__version__ at module scope must not be a hardcoded string literal. "
+                        "Use importlib.metadata.version('celerp') instead so "
+                        "the version shown in Electron matches the git tag."
+                    )
+
+    def test_version_is_importable_string(self):
+        """__version__ must be a non-empty string at runtime."""
+        from celerp import __version__
+        assert isinstance(__version__, str) and len(__version__) > 0
+
+
+# ---------------------------------------------------------------------------
+# REG-006  celerp-labels: _api_base must use ui.config.API_BASE, not a
+#          hardcoded hostname:8000. Hardcoding broke label creation in the
+#          Electron app where the API runs on a dynamic port.
+# ---------------------------------------------------------------------------
+
+class TestREG006LabelsApiBaseUsesEnvVar:
+    """Ensure the labels module reads the API base from ui.config.API_BASE.
+
+    In Electron the API port is dynamic (assigned by the OS). The UI process
+    receives it via the API_URL env var, surfaced as ui.config.API_BASE.
+    Any hardcoded ':8000' in the labels UI routes causes
+    'All connection attempts failed' on Electron/Mac.
+    """
+
+    def test_labels_ui_routes_no_hardcoded_port(self):
+        """No hardcoded ':8000' in celerp_labels/ui_routes.py."""
+        import pathlib
+
+        src = pathlib.Path(__file__).parent.parent / "default_modules" / "celerp-labels" / "celerp_labels" / "ui_routes.py"
+        text = src.read_text()
+        assert ":8000" not in text, (
+            "celerp_labels/ui_routes.py contains a hardcoded ':8000' port. "
+            "Use ui.config.API_BASE instead so Electron's dynamic API port is respected."
+        )
+
+    def test_labels_ui_routes_uses_config_api_base(self):
+        """_api_base in ui_routes.py must reference ui.config.API_BASE."""
+        import pathlib
+
+        src = pathlib.Path(__file__).parent.parent / "default_modules" / "celerp-labels" / "celerp_labels" / "ui_routes.py"
+        text = src.read_text()
+        assert "API_BASE" in text, (
+            "celerp_labels/ui_routes.py must import and use ui.config.API_BASE "
+            "as the API base URL. Hardcoding the port breaks Electron builds."
+        )
+
+    def test_inventory_no_hardcoded_label_template_port(self):
+        """No hardcoded port in inventory.py's label-templates fetch."""
+        import pathlib
+
+        src = pathlib.Path(__file__).parent.parent / "ui" / "routes" / "inventory.py"
+        text = src.read_text()
+        # The old pattern: http://127.0.0.1:{request.url.port or 8080}
+        assert "request.url.port" not in text or "api/labels/templates" not in text.split("request.url.port")[0].rsplit("\n", 5)[-1], (
+            "inventory.py constructs label template URL from request.url.port (hardcoded pattern). "
+            "Use ui.config.API_BASE instead."
+        )

--- a/ui/routes/inventory.py
+++ b/ui/routes/inventory.py
@@ -19,7 +19,7 @@ import ui.api_client as api
 from ui.api_client import APIError
 from ui.components.shell import base_shell, page_header
 from ui.components.table import data_table, search_bar, pagination, EMPTY, breadcrumbs, status_cards, empty_state_cta, add_new_option
-from ui.config import get_token as _token
+from ui.config import get_token as _token, API_BASE as _api_base
 from ui.i18n import t, get_lang
 
 _DEFAULT_PER_PAGE = 50
@@ -833,7 +833,7 @@ def setup_routes(app):
             import httpx
             async with httpx.AsyncClient(timeout=5) as c:
                 r = await c.get(
-                    f"http://127.0.0.1:{request.url.port or 8080}/api/labels/templates",
+                    f"{_api_base}/api/labels/templates",
                     headers={"Authorization": f"Bearer {token}"},
                 )
                 templates = r.json() if r.status_code == 200 else []


### PR DESCRIPTION
## Summary

Fixes two bugs reported on Electron Mac builds.

### Bug 1 - Label creation fails on Electron/Mac

**Error:** `Could not create: All connections attempts failed`

**Root cause:** Two hardcoded API URLs ignored the dynamic port Electron assigns at runtime:

1. `default_modules/celerp-labels/celerp_labels/ui_routes.py` - `_api_base()` constructed `http://{hostname}:8000`, hardcoding port 8000.
2. `ui/routes/inventory.py` - label-templates fetch used `http://127.0.0.1:{request.url.port or 8080}`, also hardcoded.

In Electron, FastAPI starts on a free OS-assigned port passed to the UI process as `API_URL`. Both calls hit port 8000 (or the UI port) instead, causing all connections to fail.

**Fix:** Both now use `ui.config.API_BASE` which reads the `API_URL` env var (set by `electron/main.js`).

### Bug 2 - App shows version `1.0.0` on Mac (should be `1.0.6`)

**Root cause:** `celerp/__init__.py` had `__version__ = "1.0.0"` hardcoded. `pyproject.toml` uses setuptools-scm to derive version from git tags, but the hardcoded literal overrides it.

**Fix:** Read version from `importlib.metadata` at import time. This reads the installed package METADATA written from the git tag during `pip install`. Fallback `"0.0.0+dev"` used only when not installed.

### Tests added

`tests/test_regression.py` REG-005 and REG-006:
- **REG-005:** AST check that `__version__` at module scope is not a string literal; runtime check it resolves to a non-empty string.
- **REG-006:** Source checks that `celerp_labels/ui_routes.py` has no hardcoded `:8000` and references `API_BASE`; `inventory.py` no longer uses `request.url.port` for label template URLs.

36 tests pass (`test_regression.py` + `test_labels.py`).

### Commandments check
- DRY: API base URL and version each have one canonical source
- SOLID: minimal, targeted changes
- No backward compat: removed the hardcoded port fallback
- Determinism: no implicit environment-dependent fallbacks
- KISS/Concision: each fix is 2-3 lines
- Cruft removed: dead `request.url.port` pattern eliminated