### PR TITLE
fix: resolve GatewayClient proxy ports dynamically for Electron

### DIFF
--- a/celerp/gateway/client.py
+++ b/celerp/gateway/client.py
@@ -49,11 +49,52 @@ class GatewayClient:
         self._stop_event = asyncio.Event()
         self._relay_status: str = "inactive"  # inactive | connecting | active | tos_required | error
         self._required_tos_version: str = ""
-        # Cache local server ports for proxy routing
+
+    # ── Port resolution ────────────────────────────────────────────────
+
+    @staticmethod
+    def _port_from_url(env_var: str, fallback: int) -> int:
+        """Extract port from a ``host:port`` URL env var, or return *fallback*.
+
+        Reads env vars at call time (not cached) so the correct port is used
+        even when the env var is set after this class is imported -- e.g. when
+        Electron pre-allocates ports and passes them to child processes.
+        """
+        from urllib.parse import urlparse
+        raw = os.environ.get(env_var, "")
+        if raw:
+            try:
+                parsed = urlparse(raw)
+                if parsed.port:
+                    return parsed.port
+            except Exception:
+                pass
+        return fallback
+
+    def _resolve_ports(self) -> tuple[int, int]:
+        """Return ``(api_port, ui_port)`` using the most reliable source available.
+
+        Priority (highest first):
+        1. ``CELERP_API_URL`` / ``API_URL`` env var (set by Electron for the API process)
+        2. ``CELERP_UI_URL`` env var (set by Electron so the API process knows the UI port)
+        3. ``[server]`` section of ``config.toml``
+        4. Compile-time defaults (8000 / 8080)
+
+        Reading at call time (not cached) ensures correctness even if Electron
+        writes the config after this object is constructed.
+        """
         from celerp.config import read_config
         cfg = read_config() or {}
-        self._ui_port: int = cfg.get("server", {}).get("ui_port", 8080)
-        self._api_port: int = cfg.get("server", {}).get("api_port", 8000)
+        srv = cfg.get("server", {})
+        api_port = self._port_from_url(
+            "CELERP_API_URL",
+            self._port_from_url("API_URL", srv.get("api_port", 8000)),
+        )
+        ui_port = self._port_from_url(
+            "CELERP_UI_URL",
+            srv.get("ui_port", 8080),
+        )
+        return api_port, ui_port
 
     # ── Public API ─────────────────────────────────────────────────────
 
@@ -263,10 +304,11 @@ class GatewayClient:
             return
 
         # API-only paths go to the API server; everything else to the UI
+        api_port, ui_port = self._resolve_ports()
         if path.startswith("/api/") or path.startswith("/openapi"):
-            port = self._api_port
+            port = api_port
         else:
-            port = self._ui_port
+            port = ui_port
 
         url = f"http://127.0.0.1:{port}{path}"
         if query:

--- a/electron/main.js
+++ b/electron/main.js
@@ -271,6 +271,9 @@ function _moduleAlembicLocations() {
 function startApi(dbUrl, cfg) {
   return new Promise(async (resolve, reject) => {
     apiPort = await getFreePort();
+    // Pre-allocate uiPort here so we can pass CELERP_UI_URL to the API process.
+    // The UI process will bind to this exact port in startUi().
+    uiPort = await getFreePort();
     const env = {
       ...process.env,
       DATABASE_URL: dbUrl,
@@ -279,6 +282,10 @@ function startApi(dbUrl, cfg) {
       MODULE_DIR: MODULE_DIR,
       CELERP_DATA_DIR: DATA_DIR,
       CELERP_CONFIG: PYTHON_CONFIG_PATH,
+      // Expose both ports so GatewayClient can proxy relay traffic to the
+      // correct dynamic ports even inside Electron (no static 8000/8080).
+      CELERP_API_URL: `http://127.0.0.1:${apiPort}`,
+      CELERP_UI_URL: `http://127.0.0.1:${uiPort}`,
       ...resolveStorageEnv(cfg),
     };
     apiProcess = spawn(
@@ -293,7 +300,8 @@ function startApi(dbUrl, cfg) {
 
 function startUi(dbUrl, cfg) {
   return new Promise(async (resolve, reject) => {
-    uiPort = await getFreePort();
+    // uiPort is pre-allocated in startApi() so both processes see consistent ports.
+    // Do NOT call getFreePort() here again.
     const env = {
       ...process.env,
       API_URL: `http://127.0.0.1:${apiPort}`,

--- a/tests/test_gateway/test_electron_ports.py
+++ b/tests/test_gateway/test_electron_ports.py
@@ -1,0 +1,130 @@
+# Copyright (c) 2026 Noah Severs
+# SPDX-License-Identifier: LicenseRef-Proprietary
+
+"""Regression tests: GatewayClient port resolution must use env vars in Electron.
+
+These tests prevent reintroduction of the bug where GatewayClient proxied
+relay traffic to static defaults (8000/8080) instead of the dynamic ports
+chosen by Electron at runtime.
+
+Root cause: Electron picks apiPort/uiPort dynamically via getFreePort() and
+passes them as CELERP_API_URL / CELERP_UI_URL env vars. The old code read
+ports from config.toml only (defaulting to 8000/8080), so relay proxy
+requests were forwarded to the wrong ports in Electron.
+
+Fix: _resolve_ports() reads CELERP_API_URL and CELERP_UI_URL (highest
+priority), then config.toml [server] section, then static defaults.
+"""
+
+from __future__ import annotations
+
+import os
+
+os.environ.setdefault("ALLOW_INSECURE_JWT", "true")
+os.environ.setdefault("DATABASE_URL", "sqlite+aiosqlite:///:memory:")
+
+import pytest
+from unittest.mock import patch
+
+from celerp.gateway.client import GatewayClient
+
+
+@pytest.fixture
+def client():
+    return GatewayClient(
+        gateway_token="tok",
+        instance_id="iid",
+        gateway_url="wss://relay.celerp.com/ws/connect",
+    )
+
+
+# ── _port_from_url ────────────────────────────────────────────────────────────
+
+class TestPortFromUrl:
+    def test_extracts_port_from_http_url(self, client):
+        with patch.dict(os.environ, {"CELERP_TEST_URL": "http://127.0.0.1:54321"}):
+            assert client._port_from_url("CELERP_TEST_URL", 9999) == 54321
+
+    def test_returns_fallback_when_env_var_missing(self, client):
+        env = {k: v for k, v in os.environ.items() if k != "CELERP_TEST_URL"}
+        with patch.dict(os.environ, env, clear=True):
+            assert client._port_from_url("CELERP_TEST_URL", 1234) == 1234
+
+    def test_returns_fallback_when_env_var_empty(self, client):
+        with patch.dict(os.environ, {"CELERP_TEST_URL": ""}):
+            assert client._port_from_url("CELERP_TEST_URL", 4321) == 4321
+
+    def test_returns_fallback_when_no_port_in_url(self, client):
+        with patch.dict(os.environ, {"CELERP_TEST_URL": "https://relay.celerp.com"}):
+            # No explicit port in URL - falls back
+            assert client._port_from_url("CELERP_TEST_URL", 7777) == 7777
+
+
+# ── _resolve_ports ────────────────────────────────────────────────────────────
+
+class TestResolvePorts:
+    def _clean_env(self):
+        """Return env dict without any port-related env vars."""
+        strip = {"CELERP_API_URL", "CELERP_UI_URL", "API_URL"}
+        return {k: v for k, v in os.environ.items() if k not in strip}
+
+    def test_electron_env_vars_take_priority(self, client):
+        """CELERP_API_URL and CELERP_UI_URL override everything else."""
+        env = {
+            **self._clean_env(),
+            "CELERP_API_URL": "http://127.0.0.1:41000",
+            "CELERP_UI_URL": "http://127.0.0.1:42000",
+        }
+        with patch.dict(os.environ, env, clear=True):
+            with patch("celerp.gateway.client.GatewayClient._resolve_ports",
+                       wraps=client._resolve_ports):
+                api_port, ui_port = client._resolve_ports()
+        assert api_port == 41000
+        assert ui_port == 42000
+
+    def test_api_url_fallback_for_api_port(self, client):
+        """Legacy API_URL (set by Electron for UI process) used as fallback."""
+        env = {
+            **self._clean_env(),
+            "API_URL": "http://127.0.0.1:43000",
+        }
+        with patch.dict(os.environ, env, clear=True):
+            with patch("celerp.config.read_config", return_value={}):
+                api_port, ui_port = client._resolve_ports()
+        assert api_port == 43000
+        # UI port falls back to config/default since CELERP_UI_URL absent
+        assert ui_port == 8080
+
+    def test_config_toml_used_when_no_env_vars(self, client):
+        """config.toml [server] section is authoritative when env vars absent."""
+        env = self._clean_env()
+        cfg = {"server": {"api_port": 9001, "ui_port": 9002}}
+        with patch.dict(os.environ, env, clear=True):
+            with patch("celerp.config.read_config", return_value=cfg):
+                api_port, ui_port = client._resolve_ports()
+        assert api_port == 9001
+        assert ui_port == 9002
+
+    def test_static_defaults_as_last_resort(self, client):
+        """Falls back to 8000/8080 only when nothing else provides a port."""
+        env = self._clean_env()
+        with patch.dict(os.environ, env, clear=True):
+            with patch("celerp.config.read_config", return_value={}):
+                api_port, ui_port = client._resolve_ports()
+        assert api_port == 8000
+        assert ui_port == 8080
+
+    def test_no_static_port_hardcode_at_init(self):
+        """GatewayClient.__init__ must NOT cache ports as instance attributes.
+
+        Ensures we can never regress to the old pattern of reading ports at
+        construction time (which would silently use wrong defaults in Electron).
+        """
+        c = GatewayClient(
+            gateway_token="t", instance_id="i",
+            gateway_url="wss://relay.celerp.com/ws/connect",
+        )
+        assert not hasattr(c, "_ui_port"), \
+            "_ui_port must not be set at init; use _resolve_ports() at call time"
+        assert not hasattr(c, "_api_port"), \
+            "_api_port must not be set at init; use _resolve_ports() at call time"


### PR DESCRIPTION
## Problem

When running under Electron, API and UI ports are chosen dynamically via getFreePort(). The GatewayClient that proxies cloud relay traffic was reading ports from config.toml [server] at construction time, defaulting to 8000/8080 — values that were never written there in Electron builds.

This meant any request proxied from slug.celerp.com through the relay would be forwarded to port 8000 or 8080, which are almost certainly closed (wrong ports) in Electron. The cloud relay subscription workflow therefore cannot function in the Electron app.

## Root cause

Two separate issues:
1. GatewayClient.__init__ cached self._api_port / self._ui_port from config.toml at construction time
2. Electron only passed API_URL to the UI process — the API process (which runs GatewayClient) had no way to know uiPort

## Fix

electron/main.js: Pre-allocate both ports before starting either process. Pass CELERP_API_URL and CELERP_UI_URL as env vars to the API process.

celerp/gateway/client.py: Remove cached _api_port/_ui_port from __init__. Add _resolve_ports() that reads env vars (CELERP_API_URL > API_URL > config.toml > defaults) at call time (lazy). Called per proxy request, never stale.

## Tests

9 regression tests in tests/test_gateway/test_electron_ports.py verifying priority order and that construction-time port caching cannot be reintroduced. All 36 gateway tests pass.