### PR TITLE
fix: correct sidebar highlighting for sold inventory and reconcile

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -166,9 +166,12 @@ _SLOT_CONTRIBUTIONS = [
     {"slot": "nav", "contrib": {"group": "Sales Documents", "key": "lists", "href": "/lists", "label": "Lists", "order": 21, "_module": "celerp-docs"}},
     {"slot": "nav", "contrib": {"group": "Sales", "key": "subscriptions", "href": "/subscriptions", "label": "Subscriptions", "order": 25, "_module": "celerp-subscriptions"}},
     {"slot": "nav", "contrib": {"group": "Inventory", "key": "inventory", "href": "/inventory", "label": "Inventory", "order": 30, "settings_href": "/settings/inventory", "_module": "celerp-inventory"}},
-    {"slot": "nav", "contrib": {"group": "Inventory", "key": "scanning", "href": "/scanning", "label": "Scanning", "order": 31, "_module": "celerp-inventory"}},
+    {"slot": "nav", "contrib": {"group": "Inventory", "key": "inventory_sold", "href": "/inventory?status=sold", "label": "Sold Inventory", "order": 31, "_module": "celerp-inventory"}},
+    {"slot": "nav", "contrib": {"group": "Inventory", "key": "inventory_archived", "href": "/inventory?status=archived", "label": "Archived Inventory", "order": 32, "_module": "celerp-inventory"}},
+    {"slot": "nav", "contrib": {"group": "Inventory", "key": "scanning", "href": "/scanning", "label": "Scanning", "order": 33, "_module": "celerp-inventory"}},
     {"slot": "nav", "contrib": {"group": "Finance", "key": "accounting", "href": "/accounting", "label": "Accounting", "order": 50, "settings_href": "/settings/accounting", "_module": "celerp-accounting"}},
-    {"slot": "nav", "contrib": {"group": "Finance", "key": "reports", "href": "/reports", "label": "Reports", "order": 51, "_module": "celerp-reports"}},
+    {"slot": "nav", "contrib": {"group": "Finance", "key": "reconcile", "href": "/accounting/reconcile/start", "label": "Reconcile", "order": 52, "_module": "celerp-accounting"}},
+    {"slot": "nav", "contrib": {"group": "Finance", "key": "reports", "href": "/reports", "label": "Reports", "order": 53, "_module": "celerp-reports"}},
     {"slot": "nav", "contrib": {"group": "Inventory", "key": "manufacturing", "href": "/manufacturing", "label": "Manufacturing", "order": 40, "_module": "celerp-manufacturing"}},
     # --- projection_handler slots ---
     {

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -2329,6 +2329,50 @@ class TestCollapsibleSidebar:
         active_links += re.findall(r'nav-link--active[^>]*href="([^"]+)"', html)
         assert "/settings/general" not in active_links
 
+    @pytest.mark.asyncio
+    async def test_sidebar_highlights_sold_inventory_entry(self, ui_client):
+        with patch("ui.api_client.get_valuation", new=AsyncMock(return_value={"category_counts": {}, "count_by_status": {"sold": 1}, "item_count": 1})), \
+             patch("ui.api_client.list_items", new=AsyncMock(return_value={"items": [], "total": 0})), \
+             patch("ui.api_client.get_locations", new=AsyncMock(return_value={"items": []})), \
+             patch("ui.api_client.get_all_category_schemas", new=AsyncMock(return_value={})), \
+             patch("ui.api_client.get_column_prefs", new=AsyncMock(return_value={})), \
+             patch("ui.api_client.get_item_schema", new=AsyncMock(return_value=[])), \
+             patch("ui.api_client.get_company", new=AsyncMock(return_value={"currency": "USD", "settings": {}})):
+            r = await ui_client.get("/inventory?status=sold", cookies=_authed())
+        assert r.status_code == 200
+        html = r.text
+        assert 'href="/inventory?status=sold"' in html
+        assert 'href="/inventory?status=sold" class="nav-link nav-link--active"' in html
+        assert 'href="/inventory" class="nav-link nav-link--active"' not in html
+
+    @pytest.mark.asyncio
+    async def test_sidebar_highlights_archived_inventory_entry(self, ui_client):
+        with patch("ui.api_client.get_valuation", new=AsyncMock(return_value={"category_counts": {}, "count_by_status": {"archived": 1}, "item_count": 1})), \
+             patch("ui.api_client.list_items", new=AsyncMock(return_value={"items": [], "total": 0})), \
+             patch("ui.api_client.get_locations", new=AsyncMock(return_value={"items": []})), \
+             patch("ui.api_client.get_all_category_schemas", new=AsyncMock(return_value={})), \
+             patch("ui.api_client.get_column_prefs", new=AsyncMock(return_value={})), \
+             patch("ui.api_client.get_item_schema", new=AsyncMock(return_value=[])), \
+             patch("ui.api_client.get_company", new=AsyncMock(return_value={"currency": "USD", "settings": {}})):
+            r = await ui_client.get("/inventory?status=archived", cookies=_authed())
+        assert r.status_code == 200
+        html = r.text
+        assert 'href="/inventory?status=archived"' in html
+        assert 'href="/inventory?status=archived" class="nav-link nav-link--active"' in html
+        assert 'href="/inventory" class="nav-link nav-link--active"' not in html
+
+    @pytest.mark.asyncio
+    async def test_sidebar_highlights_reconcile_entry(self, ui_client):
+        with (
+            patch("ui.api_client.get_company", new=AsyncMock(return_value={"currency": "USD"})),
+            patch("ui.api_client.get_bank_accounts", new=AsyncMock(return_value={"items": [{"id": "b1", "bank_name": "Kasikorn", "account_number": "1234", "is_active": True}]})),
+        ):
+            r = await ui_client.get("/accounting/reconcile/start", cookies=_authed())
+        assert r.status_code == 200
+        html = r.text
+        assert 'href="/accounting/reconcile/start" class="nav-link nav-link--active"' in html
+        assert 'href="/accounting" class="nav-link nav-link--active"' not in html
+
 
 # ── T3: Date range filters on reports ────────────────────────────────────────
 

--- a/ui/components/shell.py
+++ b/ui/components/shell.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import hashlib
 import os
 from pathlib import Path
+from urllib.parse import parse_qs, urlparse
 
 from fasthtml.common import *
 
@@ -370,7 +371,7 @@ def base_shell(*content, title: str = "Celerp", nav_active: str = "", companies:
         Head(*head_items),
         Body(
             Div(
-                _sidebar(nav_active, lang=lang, role=role),
+                _sidebar(nav_active, lang=lang, role=role, request=request),
                 Div(
                     _topbar(companies or [], lang=lang),
                     _HEALTH_BANNER_HTML,
@@ -497,7 +498,49 @@ _SIDEBAR_JS = """
 """
 
 
-def _sidebar(active: str, lang: str = "en", role: str = "owner") -> FT:
+def _resolve_active_nav_key(active: str, all_items: list[dict], request=None) -> str:
+    """Resolve the exact active sidebar key from the current URL.
+
+    Falls back to the route-provided `active` key when the current request does not
+    match a more specific nav item. This keeps route code DRY while allowing query-
+    and path-sensitive sidebar entries like sold/archived inventory and reconcile.
+    """
+    if request is None:
+        return active
+
+    current_path = request.url.path.rstrip("/") or "/"
+    current_query = request.url.query
+    current_params = parse_qs(current_query, keep_blank_values=True)
+
+    def _matches(item: dict) -> bool:
+        href = str(item.get("href") or "").strip()
+        if not href.startswith("/"):
+            return False
+        parsed = urlparse(href)
+        item_path = parsed.path.rstrip("/") or "/"
+        if current_path != item_path:
+            return False
+        item_params = parse_qs(parsed.query, keep_blank_values=True)
+        for key, values in item_params.items():
+            if current_params.get(key) != values:
+                return False
+        return True
+
+    best_match = None
+    best_score = (-1, -1)
+    for item in all_items:
+        if not _matches(item):
+            continue
+        parsed = urlparse(str(item.get("href") or ""))
+        score = (len(parse_qs(parsed.query, keep_blank_values=True)), len(parsed.path))
+        if score > best_score:
+            best_match = item
+            best_score = score
+
+    return str(best_match.get("key") or active) if best_match else active
+
+
+def _sidebar(active: str, lang: str = "en", role: str = "owner", request=None) -> FT:
     """Build sidebar entirely from module nav slots + kernel entries."""
     from collections import defaultdict
 
@@ -528,6 +571,7 @@ def _sidebar(active: str, lang: str = "en", role: str = "owner") -> FT:
 
     # Filter by role
     all_items = [item for item in all_items if _allowed(item)]
+    active = _resolve_active_nav_key(active, all_items, request=request)
 
     # Separate top-level (group=None) from grouped items
     top_level = [item for item in all_items if not item.get("group")]


### PR DESCRIPTION
$## Summary\n- resolve active sidebar entry from the current request URL instead of relying only on a coarse route key\n- correctly highlight Sold Inventory, Archived Inventory, and Reconcile entries in Electron and any other packaged routes using the same shell\n- align the UI test slot fixture with the real module nav manifest and add regression tests for these paths\n\n## Testing\n- python3 -m pytest tests/test_ui.py -k "sidebar_highlights_sold_inventory_entry or sidebar_highlights_archived_inventory_entry or sidebar_highlights_reconcile_entry or sidebar_inventory_settings_highlighted or sidebar_accounting_settings_highlighted" --no-cov --no-header -p no:cacheprovider --tb=no --disable-warnings