### PR TITLE
fix: overnight bug cluster - allow_splitting, item crash, i18n, test isolation, suite clean

### DIFF
--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -4808,6 +4808,111 @@ class TestBulkActionsPhase1to5:
         assert b"No items selected" in r.content
 
 
+class TestBulkSelectionClear:
+    """Regression: after destructive bulk actions (merge/delete/expire/archive/transfer),
+    the server must send HX-Trigger: celerpSelectionClear so the client resets
+    CelerpSelection. Without this, sessionStorage retains stale IDs and the toolbar
+    shows phantom 'N selected' after a merge deactivates source items.
+    """
+
+    @pytest.mark.asyncio
+    async def test_bulk_merge_success_sends_selection_clear_trigger(self, ui_client):
+        """Merge success response must include HX-Trigger: celerpSelectionClear."""
+        merge_result = {"id": "item:merged-1"}
+        items_data = [
+            {"entity_id": "item:a", "sku": "A", "quantity": 5, "attributes": {}},
+            {"entity_id": "item:b", "sku": "B", "quantity": 3, "attributes": {}},
+        ]
+        with (
+            patch("ui.api_client.get_item", new=AsyncMock(side_effect=items_data)),
+            patch("ui.api_client.merge_items", new=AsyncMock(return_value=merge_result)),
+        ):
+            r = await ui_client.post(
+                "/api/items/bulk/merge",
+                content=b"selected=item%3Aa&selected=item%3Ab&target_sku_from=item%3Aa",
+                headers={"content-type": "application/x-www-form-urlencoded"},
+                cookies=_authed(),
+            )
+        assert r.status_code == 200
+        trigger = r.headers.get("hx-trigger", "")
+        assert "celerpSelectionClear" in trigger, (
+            f"Merge success must send HX-Trigger: celerpSelectionClear; got: {trigger!r}"
+        )
+        assert b"merged successfully" in r.content.lower() or b"merged" in r.content.lower()
+
+    @pytest.mark.asyncio
+    async def test_bulk_delete_success_sends_selection_clear_trigger(self, ui_client):
+        """Delete success response must include HX-Trigger: celerpSelectionClear."""
+        with patch("ui.api_client.bulk_delete", new=AsyncMock(return_value={"deleted": 2})):
+            r = await ui_client.post(
+                "/api/items/bulk/delete",
+                content=b"selected=item%3Aa&selected=item%3Ab",
+                headers={"content-type": "application/x-www-form-urlencoded"},
+                cookies=_authed(),
+            )
+        assert r.status_code == 200
+        trigger = r.headers.get("hx-trigger", "")
+        assert "celerpSelectionClear" in trigger, (
+            f"Delete success must send HX-Trigger: celerpSelectionClear; got: {trigger!r}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_bulk_expire_success_sends_selection_clear_trigger(self, ui_client):
+        """Expire success response must include HX-Trigger: celerpSelectionClear."""
+        with patch("ui.api_client.bulk_expire", new=AsyncMock(return_value={"expired": 1})):
+            r = await ui_client.post(
+                "/api/items/bulk/expire",
+                content=b"selected=item%3Aa",
+                headers={"content-type": "application/x-www-form-urlencoded"},
+                cookies=_authed(),
+            )
+        assert r.status_code == 200
+        trigger = r.headers.get("hx-trigger", "")
+        assert "celerpSelectionClear" in trigger, (
+            f"Expire success must send HX-Trigger: celerpSelectionClear; got: {trigger!r}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_bulk_archive_success_sends_selection_clear_trigger(self, ui_client):
+        """Archive (status) success response must include HX-Trigger: celerpSelectionClear."""
+        with patch("ui.api_client.bulk_set_status", new=AsyncMock(return_value={"updated": 2})):
+            r = await ui_client.post(
+                "/api/items/bulk/status",
+                content=b"selected=item%3Aa&selected=item%3Ab&bulk_status=archived",
+                headers={"content-type": "application/x-www-form-urlencoded"},
+                cookies=_authed(),
+            )
+        assert r.status_code == 200
+        trigger = r.headers.get("hx-trigger", "")
+        assert "celerpSelectionClear" in trigger, (
+            f"Archive success must send HX-Trigger: celerpSelectionClear; got: {trigger!r}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_bulk_transfer_success_sends_selection_clear_trigger(self, ui_client):
+        """Transfer success response must include HX-Trigger: celerpSelectionClear."""
+        with patch("ui.api_client.bulk_transfer", new=AsyncMock(return_value={"updated": 1})):
+            r = await ui_client.post(
+                "/api/items/bulk/transfer",
+                content=b"selected=item%3Aa&bulk_location_id=loc%3A1",
+                headers={"content-type": "application/x-www-form-urlencoded"},
+                cookies=_authed(),
+            )
+        assert r.status_code == 200
+        trigger = r.headers.get("hx-trigger", "")
+        assert "celerpSelectionClear" in trigger, (
+            f"Transfer success must send HX-Trigger: celerpSelectionClear; got: {trigger!r}"
+        )
+
+    def test_bulk_js_listens_for_selection_clear_event(self):
+        """JS source must register a celerpSelectionClear event listener."""
+        src = (Path(__file__).parent.parent / "ui" / "components" / "table.py").read_text()
+        assert "celerpSelectionClear" in src, (
+            "table.py JS must listen for celerpSelectionClear to reset selection after destructive bulk actions"
+        )
+        assert "CelerpSelection.clear()" in src
+
+
 class TestSprint5ContactCreation:
     """T4: Contact creation."""
 

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -1410,8 +1410,10 @@ class TestInventoryCategoryTabs:
             r = await ui_client.get("/inventory", cookies=_authed())
         assert r.status_code == 200
         assert b"inventory-content" in r.content
-        # Category tab links must NOT use the stale #data-table target
-        assert b"#data-table" not in r.content
+        # Category tab links must NOT use the stale #data-table as an hx-target
+        # (the string 'data-table' may appear in JS as a DOM id reference, so
+        # we check specifically for the HTMX attribute form)
+        assert b'hx-target="#data-table"' not in r.content
         # Must use /inventory/content as the HTMX endpoint
         assert b"/inventory/content" in r.content
 

--- a/ui/components/table.py
+++ b/ui/components/table.py
@@ -891,6 +891,14 @@ function sendToTypeChanged(docType){
       updateBulkToolbar();
     }
   });
+  document.body.addEventListener('celerpSelectionClear',function(){
+    CelerpSelection.clear();
+    document.querySelectorAll('.row-select').forEach(function(cb){cb.checked=false});
+    var selectAll=document.querySelector('#data-table thead .col-checkbox input');
+    if(selectAll) selectAll.checked=false;
+    updateBulkToolbar();
+    _resetBulkActions();
+  });
   document.body.addEventListener('htmx:afterSwap',function(e){
     if(e.detail&&e.detail.target){
       var tid=e.detail.target.id;

--- a/ui/routes/inventory.py
+++ b/ui/routes/inventory.py
@@ -953,6 +953,25 @@ function celerpPrintLabel(entityId, templateId) {
 
     # ── Bulk actions (list-level) ─────────────────────────────────────────────
 
+    def _bulk_destructive_success(message: str, redirect_qs: str = "") -> Response:
+        """Return a bulk-action success response that clears the client-side selection.
+
+        Sends HX-Trigger: celerpSelectionClear so the JS handler resets CelerpSelection
+        and the toolbar before the table reloads.  Used for all destructive bulk actions
+        (merge, delete, archive, expire) where source items leave the visible table.
+        """
+        from starlette.responses import HTMLResponse
+        content = Div(
+            P(message, cls="flash flash--success"),
+            id="bulk-action-result",
+            hx_trigger="load delay:1s",
+            hx_get=f"/inventory/content{redirect_qs}",
+            hx_target="#inventory-content",
+            hx_swap="outerHTML",
+            **({"hx_push_url": f"/inventory{redirect_qs}"} if redirect_qs else {}),
+        )
+        return HTMLResponse(to_xml(content), headers={"HX-Trigger": "celerpSelectionClear"})
+
     @app.post("/api/items/bulk/status")
     async def bulk_item_status(request: Request):
         token = _token(request)
@@ -970,14 +989,7 @@ function celerpPrintLabel(entityId, templateId) {
         except APIError as e:
             return Div(P(str(e.detail), cls="flash flash--error"), id="bulk-action-result")
         updated = result.get("updated", len(entity_ids))
-        return Div(
-            P(f"{updated} item(s) updated to '{status}'.", cls="flash flash--success"),
-            id="bulk-action-result",
-            hx_trigger="load delay:1s",
-            hx_get="/inventory/content",
-            hx_target="#inventory-content",
-            hx_swap="outerHTML",
-        )
+        return _bulk_destructive_success(f"{updated} item(s) updated to '{status}'.")
 
     @app.post("/api/items/bulk/transfer")
     async def bulk_item_transfer(request: Request):
@@ -996,14 +1008,7 @@ function celerpPrintLabel(entityId, templateId) {
         except APIError as e:
             return Div(P(str(e.detail), cls="flash flash--error"), id="bulk-action-result")
         updated = result.get("updated", len(entity_ids))
-        return Div(
-            P(f"{updated} item(s) transferred.", cls="flash flash--success"),
-            id="bulk-action-result",
-            hx_trigger="load delay:1s",
-            hx_get="/inventory/content",
-            hx_target="#inventory-content",
-            hx_swap="outerHTML",
-        )
+        return _bulk_destructive_success(f"{updated} item(s) transferred.")
 
     @app.post("/api/items/bulk/delete")
     async def bulk_item_delete(request: Request):
@@ -1019,14 +1024,7 @@ function celerpPrintLabel(entityId, templateId) {
         except APIError as e:
             return Div(P(str(e.detail), cls="flash flash--error"), id="bulk-action-result")
         deleted = result.get("deleted", len(entity_ids))
-        return Div(
-            P(f"{deleted} item(s) deleted.", cls="flash flash--success"),
-            id="bulk-action-result",
-            hx_trigger="load delay:1s",
-            hx_get="/inventory/content",
-            hx_target="#inventory-content",
-            hx_swap="outerHTML",
-        )
+        return _bulk_destructive_success(f"{deleted} item(s) deleted.")
 
     # ── Bulk expire ──────────────────────────────────────────────────────
 
@@ -1044,14 +1042,7 @@ function celerpPrintLabel(entityId, templateId) {
         except APIError as e:
             return Div(P(str(e.detail), cls="flash flash--error"), id="bulk-action-result")
         expired = result.get("expired", len(entity_ids))
-        return Div(
-            P(f"{expired} item(s) expired.", cls="flash flash--success"),
-            id="bulk-action-result",
-            hx_trigger="load delay:1s",
-            hx_get="/inventory/content",
-            hx_target="#inventory-content",
-            hx_swap="outerHTML",
-        )
+        return _bulk_destructive_success(f"{expired} item(s) expired.")
 
     # ── Bulk merge (direct — no preview modal) ───────────────────────────
 
@@ -1104,15 +1095,7 @@ function celerpPrintLabel(entityId, templateId) {
         target_item = next((it for it in items if it.get("entity_id") == target_sku_from or it.get("id") == target_sku_from), None)
         target_sku = target_item.get("sku", "") if target_item else ""
         redirect_qs = f"?q={target_sku}" if target_sku else ""
-        return Div(
-            P(t("inv.items_merged_successfully"), cls="flash flash--success"),
-            id="bulk-action-result",
-            hx_trigger="load delay:1s",
-            hx_get=f"/inventory/content{redirect_qs}",
-            hx_target="#inventory-content",
-            hx_swap="outerHTML",
-            hx_push_url=f"/inventory{redirect_qs}",
-        )
+        return _bulk_destructive_success(t("inv.items_merged_successfully"), redirect_qs)
 
     # ── Bulk split (simplified single-qty) ───────────────────────────────
 
@@ -1175,13 +1158,9 @@ function celerpPrintLabel(entityId, templateId) {
             return Div(P(str(e.detail), cls="flash flash--error"), id="bulk-action-result")
         from urllib.parse import quote
         remaining_qty = current_qty - split_qty
-        return Div(
-            P(f"Split: {orig_sku} ({remaining_qty}) + {new_sku} ({split_qty}).", cls="flash flash--success"),
-            id="bulk-action-result",
-            hx_trigger="load delay:1s",
-            hx_get=f"/inventory/content?q={quote(orig_sku)}",
-            hx_target="#inventory-content",
-            hx_swap="outerHTML",
+        return _bulk_destructive_success(
+            f"Split: {orig_sku} ({remaining_qty}) + {new_sku} ({split_qty}).",
+            f"?q={quote(orig_sku)}",
         )
 
     # ── Send-to search (HTMX dropdown) ───────────────────────────────────


### PR DESCRIPTION
## Summary

Full overnight fix run. 16 commits, 0 test failures (3198 passed).

### Fixes
- **allow_splitting enforcement**: persist in event state, enforce in split/merge/fulfillment, fix UI conditional rendering for legacy items
- **Item page crash**: `t` → `tpl` typo in `item_label_templates` endpoint causing AttributeError
- **Silent HTMX errors**: global `#global-ui-error` flash banner in base_shell with `htmx:responseError` listener
- **Electron release versioning**: DMG/app version derived from git tag, static artifact names
- **Split semantics**: single-child remainder split allowed, UI/API contract aligned
- **i18n**: translated all untranslated strings across 10 languages (ar, de, es, fr, id, it, ja, pt, th, vi)
- **Test isolation**: `test_config.py` module reload leaked stale `settings` into `celerp.main`, causing 2 cross-file failures; fixed with autouse fixture
- **Category tabs test**: over-broad assertion narrowed to `hx-target` attribute check only
- **Bulk action UX**: clear client selection after destructive bulk operations
- **Sidebar highlight**: resolve active tab from request URL correctly