### PR TITLE
fix: invoice counters - All Issued, Awaiting Payment, Overdue

### DIFF
--- a/default_modules/celerp-docs/celerp_docs/routes.py
+++ b/default_modules/celerp-docs/celerp_docs/routes.py
@@ -163,6 +163,7 @@ async def _get_doc(session: AsyncSession, company_id, entity_id: str) -> Project
 async def list_docs(
     doc_type: str | None = None,
     status: str | None = None,
+    status_in: str | None = None,
     exclude_status: str | None = None,
     date_from: str | None = None,
     date_to: str | None = None,
@@ -170,15 +171,24 @@ async def list_docs(
     contact_id: str | None = None,
     limit: int | None = None,
     offset: int = 0,
+    overdue_only: bool = False,
     company_id: str = Depends(get_current_company_id),
     session: AsyncSession = Depends(get_session),
 ) -> dict:
+    from datetime import date as _date_cls
+    today = _date_cls.today().isoformat()
     rows = (await session.execute(select(Projection).where(Projection.company_id == company_id, Projection.entity_type == "doc"))).scalars().all()
     out = [r.state | {"id": r.entity_id} for r in rows]
     if doc_type:
         out = [x for x in out if x.get("doc_type") == doc_type]
     if status:
         out = [x for x in out if x.get("status") == status]
+    if status_in:
+        _allowed = set(status_in.split(","))
+        out = [x for x in out if x.get("status") in _allowed]
+    if overdue_only:
+        # Overdue = awaiting payment + due_date before today
+        out = [x for x in out if x.get("due_date") and x["due_date"] < today]
     if exclude_status:
         out = [x for x in out if x.get("status") != exclude_status]
     if date_from:
@@ -206,10 +216,14 @@ async def get_doc_summary(
     company_id: str = Depends(get_current_company_id),
     session: AsyncSession = Depends(get_session),
 ) -> dict:
+    from datetime import date as _date_cls
+    today = _date_cls.today().isoformat()
     rows = (await session.execute(select(Projection).where(Projection.company_id == company_id, Projection.entity_type == "doc"))).scalars().all()
     ar_gross = ar_paid = ar_outstanding = 0.0
     count_by_status: dict[str, int] = {}
     invoice_count = 0
+    awaiting_payment_count = 0  # final + sent + awaiting_payment (unpaid invoices)
+    overdue_count = 0           # awaiting_payment + due_date < today
     for row in rows:
         state = row.state
         # Filter by doc_type if specified
@@ -224,13 +238,23 @@ async def get_doc_summary(
             ar_gross += float(state.get("total", 0) or 0)
             ar_paid += float(state.get("amount_paid", 0) or 0)
             ar_outstanding += float(state.get("amount_outstanding", 0) or 0)
+            # Awaiting payment = finalized but not yet fully paid
+            if st in ("final", "sent", "awaiting_payment"):
+                awaiting_payment_count += 1
+                due = state.get("due_date") or ""
+                if due and due < today:
+                    overdue_count += 1
     draft_count = count_by_status.get("draft", 0)
     total_rows = sum(count_by_status.values())
     live_count = total_rows - draft_count
+    all_issued_count = live_count - count_by_status.get("void", 0)
     return {
         "total_count": live_count,
         "draft_count": draft_count,
         "non_void_count": sum(v for k, v in count_by_status.items() if k not in ("void", "draft")),
+        "all_issued_count": all_issued_count,
+        "awaiting_payment_count": awaiting_payment_count,
+        "overdue_count": overdue_count,
         "ar_total": ar_gross,
         "ar_paid": ar_paid,
         "ar_outstanding": ar_outstanding,

--- a/tests/test_routers/test_doc_workflows.py
+++ b/tests/test_routers/test_doc_workflows.py
@@ -431,3 +431,66 @@ async def test_list_docs_date_filter_uses_issue_date(client, session):
     assert r.status_code == 200
     data = r.json()
     assert data["total"] >= 1, f"Expected at least 1 doc with date_from={today}, got 0"
+
+
+# ---------------------------------------------------------------------------
+# Invoice counter / status card correctness
+# ---------------------------------------------------------------------------
+
+@pytest.mark.anyio
+async def test_summary_awaiting_payment_counts_finalized(client, session):
+    """Summary awaiting_payment_count includes finalized (non-draft, non-paid) invoices."""
+    token = await _register(client)
+    # Create and finalize an invoice
+    doc_id = await _create_invoice(client, token)
+    await client.post(f"/docs/{doc_id}/finalize", headers=_h(token), json={})
+    r = await client.get("/docs/summary?doc_type=invoice", headers=_h(token))
+    assert r.status_code == 200
+    data = r.json()
+    assert data["awaiting_payment_count"] >= 1, f"Expected awaiting_payment_count>=1, got {data}"
+    assert data["all_issued_count"] >= 1
+
+
+@pytest.mark.anyio
+async def test_summary_excludes_draft_from_all_issued(client, session):
+    """Summary all_issued_count does not count draft invoices."""
+    token = await _register(client)
+    # Create but do NOT finalize
+    await client.post("/docs", headers=_h(token), json={"doc_type": "invoice"})
+    r = await client.get("/docs/summary?doc_type=invoice", headers=_h(token))
+    assert r.status_code == 200
+    data = r.json()
+    assert data["all_issued_count"] == 0, f"Draft must not count as issued, got {data}"
+    assert data["awaiting_payment_count"] == 0
+
+
+@pytest.mark.anyio
+async def test_list_docs_status_in_filter(client, session):
+    """status_in param returns docs matching any of the listed statuses."""
+    token = await _register(client)
+    doc_id = await _create_invoice(client, token)
+    # Finalize -> status becomes 'final'
+    await client.post(f"/docs/{doc_id}/finalize", headers=_h(token), json={})
+    r = await client.get("/docs?doc_type=invoice&status_in=final,sent,awaiting_payment", headers=_h(token))
+    assert r.status_code == 200
+    data = r.json()
+    assert data["total"] >= 1
+    for item in data["items"]:
+        assert item.get("status") in ("final", "sent", "awaiting_payment"), f"Unexpected status: {item.get('status')}"
+
+
+@pytest.mark.anyio
+async def test_list_docs_overdue_only_filter(client, session):
+    """overdue_only=1 returns only docs with due_date before today."""
+    from datetime import date, timedelta
+    token = await _register(client)
+    doc_id = await _create_invoice(client, token)
+    # Finalize
+    await client.post(f"/docs/{doc_id}/finalize", headers=_h(token), json={})
+    # No overdue docs yet (no due_date)
+    r = await client.get("/docs?doc_type=invoice&status_in=final,sent,awaiting_payment&overdue_only=1", headers=_h(token))
+    assert r.status_code == 200
+    # All results must have due_date < today
+    today = date.today().isoformat()
+    for item in r.json().get("items", []):
+        assert item.get("due_date", "9999") < today, f"Overdue filter returned non-overdue doc: {item}"

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -9537,13 +9537,16 @@ class TestProFormaLabel:
             status_label = "Pro Forma" if dt == "invoice" and "draft" == "draft" else "draft".replace("_", " ").title()
             assert status_label == "Draft", f"{dt} should show Draft"
 
-    def test_invoice_status_card_shows_proforma(self):
-        """Invoice status cards use 'Pro Forma' label for draft."""
+    def test_invoice_status_cards_exclude_proforma(self):
+        """Invoice status cards show All Issued, Awaiting Payment, Overdue, Paid, Void - no Draft/Pro Forma card."""
         from ui.routes.documents import _doc_status_cards
         from fasthtml.common import to_xml
         html = to_xml(_doc_status_cards([], "", doc_type="invoice"))
-        assert "Pro Forma" in html
-        assert ">Draft<" not in html  # invoice cards should NOT say Draft
+        assert "All Issued" in html
+        assert "Awaiting Payment" in html
+        assert "Overdue" in html
+        assert ">Draft<" not in html
+        assert "Pro Forma" not in html  # draft invoices live in the drafts tab, not status cards
 
     def test_drafts_tab_label_for_invoice(self):
         """Drafts tab shows 'Pro Forma' for invoice doc type."""

--- a/ui/components/table.py
+++ b/ui/components/table.py
@@ -82,14 +82,22 @@ def status_cards(cards: list[dict], base_url: str, active_status: str | None = N
 
     cards: [{"label": "Paid", "count": 489, "total": 2990000.0, "status": "paid", "color": "green"}, ...]
     Clicking a card navigates to base_url?status=<status>.
+    Cards may include a "_url" key to override the generated href entirely.
+    Cards may include "_active_key" to override which value is compared against active_status.
     "All" card (status=None/"") is always first and clears the filter.
     total_override: if provided, the "All" card shows this count instead of summing cards.
     """
-    def _card(label: str, count: int, total: float | None, status: str | None, color: str) -> FT:
-        is_active = (active_status or "") == (status or "")
+    def _card(label: str, count: int, total: float | None, status: str | None, color: str, href_override: str | None = None, active_key: str | None = None) -> FT:
+        _cmp = active_key if active_key is not None else (status or "")
+        is_active = (active_status or "") == _cmp
         color_cls = color if color in _STATUS_CARD_COLORS else "gray"
         cls = f"status-card status-card--{color_cls}" + (" status-card--active" if is_active else "")
-        href = base_url if not status else f"{base_url}{'&' if '?' in base_url else '?'}status={status}"
+        if href_override:
+            href = href_override
+        elif not status:
+            href = base_url
+        else:
+            href = f"{base_url}{'&' if '?' in base_url else '?'}status={status}"
         inner = [
             Span(label, cls="status-card-label"),
             Span(str(count), cls="status-card-count"),
@@ -108,6 +116,8 @@ def status_cards(cards: list[dict], base_url: str, active_status: str | None = N
             c.get("total"),
             c.get("status"),
             c.get("color", "gray"),
+            href_override=c.get("_url"),
+            active_key=c.get("_active_key"),
         ))
     return Div(*els, cls="status-cards")
 

--- a/ui/locales/ar.json
+++ b/ui/locales/ar.json
@@ -1143,5 +1143,6 @@
   "settings.passwords_do_not_match": "كلمتا المرور غير متطابقتين",
   "settings.password_min_length": "يجب أن تتكون كلمة المرور من 8 أحرف على الأقل",
   "settings.password_changed": "تم تغيير كلمة المرور بنجاح",
-  "btn.change_password": "تغيير كلمة المرور"
+  "btn.change_password": "تغيير كلمة المرور",
+  "status.all_issued": "جميع الفواتير الصادرة"
 }

--- a/ui/locales/de.json
+++ b/ui/locales/de.json
@@ -1143,5 +1143,6 @@
   "settings.passwords_do_not_match": "Die Passwörter stimmen nicht überein",
   "settings.password_min_length": "Das Passwort muss mindestens 8 Zeichen lang sein",
   "settings.password_changed": "Passwort erfolgreich geändert",
-  "btn.change_password": "Passwort ändern"
+  "btn.change_password": "Passwort ändern",
+  "status.all_issued": "Alle ausgestellten"
 }

--- a/ui/locales/en.json
+++ b/ui/locales/en.json
@@ -976,6 +976,7 @@
   "status.final": "Final",
   "status.issued": "Issued",
   "status.overdue": "Overdue",
+  "status.all_issued": "All Issued",
   "status.pro_forma": "Pro Forma",
   "status.purchase_order": "Purchase Order",
   "th.account": "Account",

--- a/ui/locales/es.json
+++ b/ui/locales/es.json
@@ -1143,5 +1143,6 @@
   "settings.passwords_do_not_match": "Las contraseñas no coinciden",
   "settings.password_min_length": "La contraseña debe tener al menos 8 caracteres",
   "settings.password_changed": "Contraseña cambiada correctamente",
-  "btn.change_password": "Cambiar contraseña"
+  "btn.change_password": "Cambiar contraseña",
+  "status.all_issued": "Todas las emitidas"
 }

--- a/ui/locales/fr.json
+++ b/ui/locales/fr.json
@@ -1143,5 +1143,6 @@
   "settings.passwords_do_not_match": "Les mots de passe ne correspondent pas",
   "settings.password_min_length": "Le mot de passe doit comporter au moins 8 caractères",
   "settings.password_changed": "Mot de passe modifié avec succès",
-  "btn.change_password": "Changer le mot de passe"
+  "btn.change_password": "Changer le mot de passe",
+  "status.all_issued": "Toutes émises"
 }

--- a/ui/locales/id.json
+++ b/ui/locales/id.json
@@ -1143,5 +1143,6 @@
   "settings.passwords_do_not_match": "Kata sandi tidak cocok",
   "settings.password_min_length": "Kata sandi minimal 8 karakter",
   "settings.password_changed": "Kata sandi berhasil diubah",
-  "btn.change_password": "Ganti Kata Sandi"
+  "btn.change_password": "Ganti Kata Sandi",
+  "status.all_issued": "Semua Diterbitkan"
 }

--- a/ui/locales/it.json
+++ b/ui/locales/it.json
@@ -1143,5 +1143,6 @@
   "settings.passwords_do_not_match": "Le password non corrispondono",
   "settings.password_min_length": "La password deve contenere almeno 8 caratteri",
   "settings.password_changed": "Password modificata con successo",
-  "btn.change_password": "Cambia password"
+  "btn.change_password": "Cambia password",
+  "status.all_issued": "Tutte le emesse"
 }

--- a/ui/locales/ja.json
+++ b/ui/locales/ja.json
@@ -1143,5 +1143,6 @@
   "settings.passwords_do_not_match": "パスワードが一致しません",
   "settings.password_min_length": "パスワードは8文字以上にしてください",
   "settings.password_changed": "パスワードが正常に変更されました",
-  "btn.change_password": "パスワードを変更"
+  "btn.change_password": "パスワードを変更",
+  "status.all_issued": "発行済み一覧"
 }

--- a/ui/locales/pt.json
+++ b/ui/locales/pt.json
@@ -1143,5 +1143,6 @@
   "settings.passwords_do_not_match": "As senhas não coincidem",
   "settings.password_min_length": "A senha deve ter pelo menos 8 caracteres",
   "settings.password_changed": "Senha alterada com sucesso",
-  "btn.change_password": "Alterar senha"
+  "btn.change_password": "Alterar senha",
+  "status.all_issued": "Todas emitidas"
 }

--- a/ui/locales/th.json
+++ b/ui/locales/th.json
@@ -1143,5 +1143,6 @@
   "settings.passwords_do_not_match": "รหัสผ่านไม่ตรงกัน",
   "settings.password_min_length": "รหัสผ่านต้องมีอย่างน้อย 8 ตัวอักษร",
   "settings.password_changed": "เปลี่ยนรหัสผ่านเรียบร้อยแล้ว",
-  "btn.change_password": "เปลี่ยนรหัสผ่าน"
+  "btn.change_password": "เปลี่ยนรหัสผ่าน",
+  "status.all_issued": "ออกใบแจ้งหนี้แล้วทั้งหมด"
 }

--- a/ui/locales/vi.json
+++ b/ui/locales/vi.json
@@ -1143,5 +1143,6 @@
   "settings.passwords_do_not_match": "Mật khẩu không khớp",
   "settings.password_min_length": "Mật khẩu phải có ít nhất 8 ký tự",
   "settings.password_changed": "Đổi mật khẩu thành công",
-  "btn.change_password": "Đổi mật khẩu"
+  "btn.change_password": "Đổi mật khẩu",
+  "status.all_issued": "Tất cả đã phát hành"
 }

--- a/ui/routes/documents.py
+++ b/ui/routes/documents.py
@@ -295,6 +295,8 @@ def setup_routes(app):
         q = request.query_params.get("q", "")
         doc_type = request.query_params.get("type", "") or request.query_params.get("doc_type", "")
         status = request.query_params.get("status", "")
+        status_in = request.query_params.get("status_in", "")
+        overdue_only = request.query_params.get("overdue_only", "") in ("1", "true")
         view = request.query_params.get("view", "")  # "drafts" = drafts-only mode
         page = int(request.query_params.get("page", 1))
         sort = request.query_params.get("sort", "date")
@@ -332,7 +334,7 @@ def setup_routes(app):
         effective_status = status
         if is_drafts_view:
             effective_status = "draft"
-        elif not status:
+        elif not status and not status_in:
             effective_status = "exclude_draft"  # backend must support this param
 
         try:
@@ -341,7 +343,13 @@ def setup_routes(app):
                 params["q"] = q
             if doc_type:
                 params["doc_type"] = doc_type
-            if effective_status == "exclude_draft":
+            if is_drafts_view:
+                params["status"] = "draft"
+            elif status_in:
+                params["status_in"] = status_in
+                if overdue_only:
+                    params["overdue_only"] = "1"
+            elif effective_status == "exclude_draft":
                 params["exclude_status"] = "draft"
             elif effective_status:
                 params["status"] = effective_status
@@ -392,7 +400,7 @@ def setup_routes(app):
                 _date_filter_bar("/docs", date_from, date_to, preset, extra_params=f"&{extra}" if extra else "", lang=lang),
             ]),
             _summary_bar(summary, doc_type, currency, lang),
-            _doc_status_cards(docs, status, summary, currency, doc_type=doc_type, lang=lang),
+            _doc_status_cards(docs, status, summary, currency, doc_type=doc_type, lang=lang, status_in=status_in, overdue_only=overdue_only),
             _doc_table(
                 docs,
                 sort=sort,
@@ -4439,22 +4447,65 @@ def _doc_history_section(ledger: list[dict]) -> FT:
     )
 
 
-def _doc_status_cards(docs: list[dict], active_status: str, summary: dict | None = None, currency: str | None = None, doc_type: str = "", lang: str = "en") -> FT:
+def _doc_status_cards(docs: list[dict], active_status: str, summary: dict | None = None, currency: str | None = None, doc_type: str = "", lang: str = "en", status_in: str = "", overdue_only: bool = False) -> FT:
     """Aggregate counts/totals per status and render status_cards.
 
     Card definitions are doc-type-aware: only statuses valid for the
     document lifecycle are shown.
+
+    Invoice counters use virtual statuses backed by composite DB status sets:
+      - all_issued   = every non-draft, non-void invoice
+      - awaiting_payment = final + sent + awaiting_payment (not yet fully paid)
+      - overdue      = awaiting_payment + due_date < today
+      - paid         = paid + partial
+    These are resolved by the summary endpoint and rendered with the correct
+    filter URLs (?status_in=... or ?overdue_only=1).
     """
-    # Per-doc-type card definitions: (status_key, label, color)
+    _sm = summary or {}
+    base_url = f"/docs?type={doc_type}" if doc_type else "/docs"
+
+    # Determine which virtual card key is currently active for invoice cards
+    _ALL_ISSUED_STATUSES = "final,sent,awaiting_payment,paid,partial,overdue"
+    _AWAITING_STATUSES   = "final,sent,awaiting_payment"
+    _PAID_STATUSES       = "paid,partial"
+    _active_key: str
+    if status_in == _ALL_ISSUED_STATUSES:
+        _active_key = "all_issued"
+    elif status_in == _AWAITING_STATUSES and overdue_only:
+        _active_key = "overdue"
+    elif status_in == _AWAITING_STATUSES:
+        _active_key = "awaiting_payment"
+    elif status_in == _PAID_STATUSES:
+        _active_key = "paid"
+    else:
+        _active_key = active_status or ""  # fallback: exact status match (sent, void, etc.)
+
+    # ------------------------------------------------------------------
+    # Invoice: custom card set using virtual/aggregate counts from summary
+    # ------------------------------------------------------------------
+    if doc_type == "invoice":
+        _cbs = _sm.get("count_by_status") or {}
+        all_issued = _sm.get("all_issued_count", _sm.get("non_void_count", 0))
+        awaiting   = _sm.get("awaiting_payment_count", 0)
+        overdue    = _sm.get("overdue_count", 0)
+        paid_cnt   = _cbs.get("paid", 0) + _cbs.get("partial", 0)
+        sent_cnt   = _cbs.get("sent", 0)
+        void_cnt   = _cbs.get("void", 0)
+
+        invoice_cards = [
+            {"label": t("status.all_issued", lang),       "count": all_issued, "total": 0.0, "status": "all_issued",       "color": "blue",   "_url": f"{base_url}&status_in={_ALL_ISSUED_STATUSES}", "_active_key": "all_issued"},
+            {"label": t("doc.sent", lang),                "count": sent_cnt,   "total": 0.0, "status": "sent",              "color": "blue"},
+            {"label": t("status.awaiting_payment", lang), "count": awaiting,   "total": 0.0, "status": "awaiting_payment",  "color": "yellow", "_url": f"{base_url}&status_in={_AWAITING_STATUSES}",   "_active_key": "awaiting_payment"},
+            {"label": t("status.overdue", lang),          "count": overdue,    "total": 0.0, "status": "overdue",           "color": "red",    "_url": f"{base_url}&status_in={_AWAITING_STATUSES}&overdue_only=1", "_active_key": "overdue"},
+            {"label": t("label.paid", lang),              "count": paid_cnt,   "total": 0.0, "status": "paid",              "color": "green",  "_url": f"{base_url}&status_in={_PAID_STATUSES}",        "_active_key": "paid"},
+            {"label": t("btn.void", lang),                "count": void_cnt,   "total": 0.0, "status": "void",              "color": "gray"},
+        ]
+        return status_cards(invoice_cards, base_url, _active_key or None, currency=currency)
+
+    # ------------------------------------------------------------------
+    # All other doc types: simple per-status cards
+    # ------------------------------------------------------------------
     _CARDS_BY_TYPE: dict[str, list[tuple[str, str, str]]] = {
-        "invoice": [
-            ("draft", t("status.pro_forma", lang), "gray"),
-            ("sent", t("doc.sent", lang), "blue"),
-            ("awaiting_payment", t("status.awaiting_payment", lang), "yellow"),
-            ("paid", t("label.paid", lang), "green"),
-            ("overdue", t("status.overdue", lang), "red"),
-            ("void", t("btn.void", lang), "gray"),
-        ],
         "purchase_order": [
             ("draft", t("status.purchase_order", lang), "gray"),
             ("sent", t("doc.sent", lang), "blue"),
@@ -4505,7 +4556,7 @@ def _doc_status_cards(docs: list[dict], active_status: str, summary: dict | None
     card_defs = _CARDS_BY_TYPE.get(doc_type, _DEFAULT_CARDS)
 
     # Use API-level counts from summary when available (full dataset, not just current page)
-    api_counts = (summary or {}).get("count_by_status", {})
+    api_counts = (_sm).get("count_by_status", {})
     counts: dict[str, int] = {s: api_counts.get(s, 0) for s, _, _ in card_defs}
     totals: dict[str, float] = {s: 0.0 for s, _, _ in card_defs}
     for d in docs:
@@ -4522,7 +4573,6 @@ def _doc_status_cards(docs: list[dict], active_status: str, summary: dict | None
         {"label": label, "count": counts[s], "total": totals[s], "status": s, "color": color}
         for s, label, color in card_defs
     ]
-    base_url = f"/docs?type={doc_type}" if doc_type else "/docs"
     return status_cards(cards, base_url, active_status or None, currency=currency)
 
 


### PR DESCRIPTION
## Summary

- Renames "All" counter to "All Issued" (excludes draft/pro-forma)
- Fixes "Awaiting Payment" to include all unpaid finalized invoices (`final` + `sent` + `awaiting_payment`), not just the `awaiting_payment` DB status
- Adds `status_in` (comma-separated) param to `list_docs` for multi-status filtering
- Adds `all_issued_count`, `awaiting_payment_count`, `overdue_count` to `get_doc_summary`
- Regression tests included