### PR TITLE
fix: invoice payment display and Pro-forma counter

### DIFF
--- a/default_modules/celerp-docs/celerp_docs/doc_projections.py
+++ b/default_modules/celerp-docs/celerp_docs/doc_projections.py
@@ -37,6 +37,12 @@ def apply_documents_event(state: dict, event_type: str, data: dict) -> dict:
     elif event_type == "doc.updated":
         for field, change in data["fields_changed"].items():
             current[field] = change.get("new")
+        # If total changed (e.g. line items added/removed on a draft), recalculate outstanding
+        # based on how much has already been paid - never let outstanding go negative.
+        if "total" in data.get("fields_changed", {}) or "line_items" in data.get("fields_changed", {}):
+            paid = float(current.get("amount_paid", 0) or 0)
+            total = float(current.get("total", 0) or 0)
+            current["amount_outstanding"] = max(0.0, total - paid)
     elif event_type == "doc.linked":
         current.setdefault("linked", [])
         current["linked"].append({"entity_id": data["entity_id"], "entity_type": data["entity_type"]})

--- a/tests/test_routers/test_doc_workflows.py
+++ b/tests/test_routers/test_doc_workflows.py
@@ -494,3 +494,61 @@ async def test_list_docs_overdue_only_filter(client, session):
     today = date.today().isoformat()
     for item in r.json().get("items", []):
         assert item.get("due_date", "9999") < today, f"Overdue filter returned non-overdue doc: {item}"
+
+
+@pytest.mark.anyio
+async def test_amount_outstanding_recalculated_after_line_items_added(client, session):
+    """Regression: adding line items after creation must update amount_outstanding.
+
+    Previously, a new doc with no line items got amount_outstanding=0 (total=0).
+    After adding line items the total increased but outstanding stayed 0, causing
+    the payment section to show 'Paid in Full' for an unpaid invoice.
+    """
+    token = await _register(client)
+    # Create invoice with a single line item so we can inspect state
+    doc_id = await _create_invoice(client, token, subtotal=500, tax=0, total=500)
+    r = await client.get(f"/docs/{doc_id}", headers=_h(token))
+    assert r.status_code == 200
+    state = r.json()
+    # outstanding must equal total when no payment has been made
+    assert float(state["amount_outstanding"]) == pytest.approx(float(state["total"]), abs=0.01), (
+        f"amount_outstanding {state['amount_outstanding']} != total {state['total']} on fresh invoice"
+    )
+    assert float(state["amount_outstanding"]) > 0, "outstanding must be > 0 for an unpaid invoice"
+
+
+@pytest.mark.anyio
+async def test_amount_outstanding_after_patch_line_items(client, session):
+    """Regression: patching line_items (or total) must keep amount_outstanding in sync."""
+    token = await _register(client)
+    doc_id = await _create_invoice(client, token, subtotal=100, tax=0, total=100)
+
+    # Patch total upward (simulates adding a line item via the standard fields_changed format)
+    r = await client.patch(
+        f"/docs/{doc_id}",
+        headers=_h(token),
+        json={"fields_changed": {"total": {"old": 100, "new": 300}, "subtotal": {"old": 100, "new": 300}}},
+    )
+    assert r.status_code == 200
+
+    r = await client.get(f"/docs/{doc_id}", headers=_h(token))
+    state = r.json()
+    # outstanding must track the new total (no payment made)
+    assert float(state["amount_outstanding"]) == pytest.approx(300.0, abs=0.01), (
+        f"outstanding {state['amount_outstanding']} should be 300 after total patched to 300"
+    )
+
+
+@pytest.mark.anyio
+async def test_invoice_status_cards_include_proforma(client, session):
+    """Regression: Pro-forma card must appear in invoice status card set alongside All Issued."""
+    from ui.routes.documents import _doc_status_cards
+    summary = {
+        "count_by_status": {"draft": 3, "final": 5, "sent": 2, "paid": 1, "void": 1},
+        "all_issued_count": 8,
+        "awaiting_payment_count": 7,
+        "overdue_count": 0,
+    }
+    html = str(_doc_status_cards([], "", summary, "USD", doc_type="invoice", lang="en"))
+    assert "Pro" in html or "pro" in html.lower(), "Pro-forma card missing from invoice status cards"
+    assert "All Issued" in html or "all_issued" in html.lower(), "All Issued card missing from invoice status cards"

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -9537,16 +9537,20 @@ class TestProFormaLabel:
             status_label = "Pro Forma" if dt == "invoice" and "draft" == "draft" else "draft".replace("_", " ").title()
             assert status_label == "Draft", f"{dt} should show Draft"
 
-    def test_invoice_status_cards_exclude_proforma(self):
-        """Invoice status cards show All Issued, Awaiting Payment, Overdue, Paid, Void - no Draft/Pro Forma card."""
+    def test_invoice_status_cards_include_proforma(self):
+        """Invoice status cards show Pro Forma, All Issued, Awaiting Payment, Overdue, Paid, Void.
+
+        Pro Forma card is shown alongside All Issued so users can see the draft count at a glance.
+        The Drafts tab also shows Pro Forma for navigation; both coexist intentionally.
+        """
         from ui.routes.documents import _doc_status_cards
         from fasthtml.common import to_xml
         html = to_xml(_doc_status_cards([], "", doc_type="invoice"))
+        assert "Pro Forma" in html  # draft count visible in card bar
         assert "All Issued" in html
         assert "Awaiting Payment" in html
         assert "Overdue" in html
-        assert ">Draft<" not in html
-        assert "Pro Forma" not in html  # draft invoices live in the drafts tab, not status cards
+        assert ">Draft<" not in html  # raw "Draft" label not shown (it's "Pro Forma")
 
     def test_drafts_tab_label_for_invoice(self):
         """Drafts tab shows 'Pro Forma' for invoice doc type."""

--- a/ui/routes/documents.py
+++ b/ui/routes/documents.py
@@ -4485,6 +4485,7 @@ def _doc_status_cards(docs: list[dict], active_status: str, summary: dict | None
     # ------------------------------------------------------------------
     if doc_type == "invoice":
         _cbs = _sm.get("count_by_status") or {}
+        draft_cnt  = _cbs.get("draft", 0)
         all_issued = _sm.get("all_issued_count", _sm.get("non_void_count", 0))
         awaiting   = _sm.get("awaiting_payment_count", 0)
         overdue    = _sm.get("overdue_count", 0)
@@ -4492,8 +4493,14 @@ def _doc_status_cards(docs: list[dict], active_status: str, summary: dict | None
         sent_cnt   = _cbs.get("sent", 0)
         void_cnt   = _cbs.get("void", 0)
 
+        # Active key for "pro_forma" card: the main drafts-tab handles navigation but
+        # we also need a card so users can see the draft count at a glance.
+        if active_status == "draft":
+            _active_key = "draft"
+
         invoice_cards = [
-            {"label": t("status.all_issued", lang),       "count": all_issued, "total": 0.0, "status": "all_issued",       "color": "blue",   "_url": f"{base_url}&status_in={_ALL_ISSUED_STATUSES}", "_active_key": "all_issued"},
+            {"label": t("status.pro_forma", lang),        "count": draft_cnt,  "total": 0.0, "status": "draft",             "color": "gray"},
+            {"label": t("status.all_issued", lang),       "count": all_issued, "total": 0.0, "status": "all_issued",        "color": "blue",   "_url": f"{base_url}&status_in={_ALL_ISSUED_STATUSES}", "_active_key": "all_issued"},
             {"label": t("doc.sent", lang),                "count": sent_cnt,   "total": 0.0, "status": "sent",              "color": "blue"},
             {"label": t("status.awaiting_payment", lang), "count": awaiting,   "total": 0.0, "status": "awaiting_payment",  "color": "yellow", "_url": f"{base_url}&status_in={_AWAITING_STATUSES}",   "_active_key": "awaiting_payment"},
             {"label": t("status.overdue", lang),          "count": overdue,    "total": 0.0, "status": "overdue",           "color": "red",    "_url": f"{base_url}&status_in={_AWAITING_STATUSES}&overdue_only=1", "_active_key": "overdue"},


### PR DESCRIPTION
## Summary

### Bug 1: "Paid in Full" shown on unpaid invoices
Root cause: `doc.created` sets `amount_outstanding = total` at creation time (total=0 if no items yet). When line items are added later via `doc.updated`, `total` increases but `amount_outstanding` stayed at 0 - making the payment panel show "Paid in Full" for an invoice with $0 paid.

Fix: `apply_documents_event` now recalculates `amount_outstanding = max(0, total - amount_paid)` whenever `total` or `line_items` are patched via `doc.updated`.

### Bug 2: Pro-forma counter removed accidentally
The previous PR removed the Pro-forma card from invoice status cards when restructuring for "All Issued". Users had no way to see draft invoice count from the card bar.

Fix: Pro-forma card restored as the first card in the invoice status bar.

### Tests
- `test_amount_outstanding_recalculated_after_line_items_added`
- `test_amount_outstanding_after_patch_line_items`
- `test_invoice_status_cards_include_proforma`