### PR TITLE
fix: invoice page crash after payment, Pro-forma card, payment display

### DIFF
--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -3035,6 +3035,37 @@ class TestSprint4Payment:
             r = await ui_client.get("/docs/doc:INV-2026-0001", cookies=_authed())
         assert b"Record Payment" not in r.content
 
+    @pytest.mark.asyncio
+    async def test_invoice_page_renders_after_payment_recorded(self, ui_client):
+        """Regression: invoice page must not crash after a payment is recorded.
+
+        Bug: _payment_section referenced _is_manager from the outer _doc_detail
+        scope, causing NameError when the payment history loop tried to render
+        the void button for an active payment.
+        """
+        doc_with_payment = {
+            **_SENT_DOC,
+            "status": "partial",
+            "amount_paid": 1000,
+            "amount_outstanding": 9000,
+            "payments": [
+                {
+                    "index": 0,
+                    "amount": 1000,
+                    "currency": "USD",
+                    "method": "transfer",
+                    "reference": "TXN-1",
+                    "payment_date": "2026-04-25",
+                    "bank_account": "1110",
+                    "status": "active",
+                }
+            ],
+        }
+        with patch("ui.api_client.get_doc", new=AsyncMock(return_value=doc_with_payment)):
+            r = await ui_client.get("/docs/doc:INV-2026-0001", cookies=_authed())
+        assert r.status_code == 200, f"Invoice page crashed after payment: {r.status_code}"
+        assert b"1,000" in r.content or b"payment" in r.content.lower()
+
 
 class TestSprint4Polish:
     """T6: doc detail polish."""

--- a/ui/routes/documents.py
+++ b/ui/routes/documents.py
@@ -2795,7 +2795,7 @@ def _tc_dropdown(entity_id: str, doc: dict, tc_templates: list[dict], doc_type: 
     ]
 
 
-def _payment_section(doc: dict, bank_accounts: list[dict] | None = None) -> FT:
+def _payment_section(doc: dict, bank_accounts: list[dict] | None = None, is_manager: bool = True) -> FT:
     """Shared payment/credit section for invoices, bills, and credit notes.
 
     DRY: one function, different labels based on doc_type.
@@ -2854,7 +2854,7 @@ def _payment_section(doc: dict, bank_accounts: list[dict] | None = None) -> FT:
         if voided:
             void_reason = p.get("void_reason") or ""
             void_cell = Td(Span(t("doc.voided"), cls="badge badge--void", title=void_reason))
-        elif not voided and _is_manager:
+        elif not voided and is_manager:
             void_cell = Td(
                 Details(
                     Summary("🗑", cls="btn btn--ghost btn--xs", title="Void this payment"),
@@ -4286,7 +4286,7 @@ async function celerpCsvImport(input, entityId) {{
             cls="doc-section doc-section--totals",
         ),
         # Payment section (invoices, bills, credit notes - not drafts/voids)
-        _payment_section(doc, bank_accounts=bank_accounts),
+        _payment_section(doc, bank_accounts=bank_accounts, is_manager=_is_manager),
         # Term & Conditions + Note to customer (2 columns)
         Div(
             Div(


### PR DESCRIPTION
## Changes

### fix: NameError crash on invoice page after payment recorded
`_payment_section` referenced `_is_manager` from the enclosing `_doc_detail` scope - a free-variable bug that caused a 500 error the moment a payment existed and the page re-rendered. Fixed by adding `is_manager: bool = True` param and passing `_is_manager` from the call site. Regression test added.

### fix: "Paid in Full" shown on unpaid invoices
`amount_outstanding` was set to 0 at `doc.created` (total=0 if no items yet). Adding line items updated `total` but left `amount_outstanding` at 0. Fixed: `apply_documents_event` now recalculates outstanding whenever `total` or `line_items` change in `doc.updated`.

### fix: Pro-forma counter missing from invoice status bar
The previous counter redesign accidentally removed the Pro-forma (draft) card. Restored as the first card in the invoice status bar so users can see draft count at a glance.

### test: update stale ProFormaLabel test
Existing test asserted Pro-forma was excluded from status cards - updated to match the new intentional behavior.