### PR TITLE
fix: invoice counter accuracy - All count, partial bucket, real totals

### DIFF
--- a/default_modules/celerp-docs/celerp_docs/routes.py
+++ b/default_modules/celerp-docs/celerp_docs/routes.py
@@ -223,12 +223,17 @@ async def get_doc_summary(
     count_by_status: dict[str, int] = {}
     invoice_count = 0
     # Awaiting payment = all finalized invoices not yet fully paid
-    # (final, sent, awaiting_payment, partial - i.e. every issued status except paid/void)
+    # (final, sent, awaiting_payment, partial - every issued status except paid/void)
     _AWAITING_STATUSES = {"final", "sent", "awaiting_payment", "partial"}
     awaiting_payment_count = 0
     awaiting_payment_total = 0.0  # sum of outstanding balances
     overdue_count = 0
-    paid_total = 0.0              # total for fully-paid invoices
+    overdue_total = 0.0           # outstanding on overdue invoices
+    paid_count = 0
+    paid_total = 0.0              # face value of fully-paid invoices
+    sent_total = 0.0              # outstanding on sent invoices
+    draft_total = 0.0             # face value of draft/pro-forma invoices
+    void_total = 0.0              # face value of voided invoices
     for row in rows:
         state = row.state
         # Filter by doc_type if specified
@@ -236,13 +241,17 @@ async def get_doc_summary(
             continue
         st = state.get("status", "")
         count_by_status[st] = count_by_status.get(st, 0) + 1
-        if st in ("void", "draft"):
-            continue
         if state.get("doc_type") == "invoice":
-            invoice_count += 1
             total_ = float(state.get("total", 0) or 0)
-            paid_ = float(state.get("amount_paid", 0) or 0)
             outstanding_ = float(state.get("amount_outstanding", 0) or 0)
+            paid_ = float(state.get("amount_paid", 0) or 0)
+            if st == "draft":
+                draft_total += total_
+                continue
+            if st == "void":
+                void_total += total_
+                continue
+            invoice_count += 1
             ar_gross += total_
             ar_paid += paid_
             ar_outstanding += outstanding_
@@ -252,8 +261,15 @@ async def get_doc_summary(
                 due = state.get("due_date") or ""
                 if due and due < today:
                     overdue_count += 1
+                    overdue_total += outstanding_
+                if st == "sent":
+                    sent_total += outstanding_
             elif st == "paid":
+                paid_count += 1
                 paid_total += total_
+        else:
+            if st in ("void", "draft"):
+                continue
     draft_count = count_by_status.get("draft", 0)
     total_rows = sum(count_by_status.values())
     live_count = total_rows - draft_count
@@ -263,10 +279,16 @@ async def get_doc_summary(
         "draft_count": draft_count,
         "non_void_count": sum(v for k, v in count_by_status.items() if k not in ("void", "draft")),
         "all_issued_count": all_issued_count,
+        "all_issued_total": ar_gross,
         "awaiting_payment_count": awaiting_payment_count,
         "awaiting_payment_total": awaiting_payment_total,
         "overdue_count": overdue_count,
+        "overdue_total": overdue_total,
+        "paid_count": paid_count,
         "paid_total": paid_total,
+        "sent_total": sent_total,
+        "draft_total": draft_total,
+        "void_total": void_total,
         "ar_total": ar_gross,
         "ar_paid": ar_paid,
         "ar_outstanding": ar_outstanding,

--- a/default_modules/celerp-docs/celerp_docs/routes.py
+++ b/default_modules/celerp-docs/celerp_docs/routes.py
@@ -222,8 +222,13 @@ async def get_doc_summary(
     ar_gross = ar_paid = ar_outstanding = 0.0
     count_by_status: dict[str, int] = {}
     invoice_count = 0
-    awaiting_payment_count = 0  # final + sent + awaiting_payment (unpaid invoices)
-    overdue_count = 0           # awaiting_payment + due_date < today
+    # Awaiting payment = all finalized invoices not yet fully paid
+    # (final, sent, awaiting_payment, partial - i.e. every issued status except paid/void)
+    _AWAITING_STATUSES = {"final", "sent", "awaiting_payment", "partial"}
+    awaiting_payment_count = 0
+    awaiting_payment_total = 0.0  # sum of outstanding balances
+    overdue_count = 0
+    paid_total = 0.0              # total for fully-paid invoices
     for row in rows:
         state = row.state
         # Filter by doc_type if specified
@@ -235,15 +240,20 @@ async def get_doc_summary(
             continue
         if state.get("doc_type") == "invoice":
             invoice_count += 1
-            ar_gross += float(state.get("total", 0) or 0)
-            ar_paid += float(state.get("amount_paid", 0) or 0)
-            ar_outstanding += float(state.get("amount_outstanding", 0) or 0)
-            # Awaiting payment = finalized but not yet fully paid
-            if st in ("final", "sent", "awaiting_payment"):
+            total_ = float(state.get("total", 0) or 0)
+            paid_ = float(state.get("amount_paid", 0) or 0)
+            outstanding_ = float(state.get("amount_outstanding", 0) or 0)
+            ar_gross += total_
+            ar_paid += paid_
+            ar_outstanding += outstanding_
+            if st in _AWAITING_STATUSES:
                 awaiting_payment_count += 1
+                awaiting_payment_total += outstanding_
                 due = state.get("due_date") or ""
                 if due and due < today:
                     overdue_count += 1
+            elif st == "paid":
+                paid_total += total_
     draft_count = count_by_status.get("draft", 0)
     total_rows = sum(count_by_status.values())
     live_count = total_rows - draft_count
@@ -254,7 +264,9 @@ async def get_doc_summary(
         "non_void_count": sum(v for k, v in count_by_status.items() if k not in ("void", "draft")),
         "all_issued_count": all_issued_count,
         "awaiting_payment_count": awaiting_payment_count,
+        "awaiting_payment_total": awaiting_payment_total,
         "overdue_count": overdue_count,
+        "paid_total": paid_total,
         "ar_total": ar_gross,
         "ar_paid": ar_paid,
         "ar_outstanding": ar_outstanding,

--- a/tests/test_routers/test_doc_workflows.py
+++ b/tests/test_routers/test_doc_workflows.py
@@ -614,3 +614,143 @@ async def test_summary_awaiting_payment_total_is_outstanding(client, session):
     assert abs(data.get("awaiting_payment_total", -1) - 500.0) < 0.01, (
         f"awaiting_payment_total should be 500, got {data.get('awaiting_payment_total')}"
     )
+
+
+# ---------------------------------------------------------------------------
+# Comprehensive invoice summary / counter accuracy tests
+# ---------------------------------------------------------------------------
+
+async def _pay(client, token: str, doc_id: str, amount: float, reference: str = "REF") -> None:
+    """Helper: record a payment against a finalized invoice."""
+    r = await client.post(
+        f"/docs/{doc_id}/payment",
+        headers=_h(token),
+        json={"amount": amount, "method": "transfer", "reference": reference,
+              "payment_date": "2026-04-25", "bank_account": "1110"},
+    )
+    assert r.status_code == 200, f"Payment failed: {r.json()}"
+
+
+async def _invoice(client, token: str, total: float) -> str:
+    """Helper: create and finalize an invoice with the given total."""
+    doc_id = await _create_invoice(client, token, subtotal=total, tax=0, total=total)
+    r = await client.post(f"/docs/{doc_id}/finalize", headers=_h(token), json={})
+    assert r.status_code == 200, f"Finalize failed: {r.json()}"
+    return doc_id
+
+
+@pytest.mark.anyio
+async def test_summary_counters_and_totals_comprehensive(client, session):
+    """Comprehensive regression: summary counts and totals across all invoice lifecycle states.
+
+    Invoice set:
+      INV-A $1,000  - pro-forma (draft, never finalized)
+      INV-B $2,000  - finalized only (status: final)
+      INV-C $3,000  - sent (status: sent) -- we simulate by patching status via finalize + sent endpoint
+      INV-D $4,000  - partial payment of $1,000 (status: partial, outstanding $3,000)
+      INV-E $5,000  - fully paid (status: paid)
+      INV-F $6,000  - voided after finalize (status: void)
+
+    Expected summary:
+      draft_count             = 1     (INV-A)
+      all_issued_count        = 4     (INV-B, INV-C, INV-D, INV-E - void excluded)
+      awaiting_payment_count  = 3     (INV-B final, INV-C sent, INV-D partial)
+      awaiting_payment_total  = 9,000 (2000 + 3000 + 4000 outstanding on D = 3000 -> total = 2000+3000+3000)
+      paid_count              = 1     (INV-E)
+      paid_total              = 5,000 (INV-E face value)
+      overdue_count           = 0     (no due_date set)
+      overdue_total           = 0.0
+      all_issued_total        = 14,000 (2000+3000+4000+5000 face value)
+      draft_total             = 1,000
+      void_total              = 6,000
+    """
+    token = await _register(client)
+
+    # INV-A: draft only
+    await _create_invoice(client, token, subtotal=1000, tax=0, total=1000)
+
+    # INV-B: finalized, unpaid (status: final)
+    b = await _invoice(client, token, total=2000)
+
+    # INV-C: finalized then sent (status: sent)
+    c = await _invoice(client, token, total=3000)
+    rs = await client.post(f"/docs/{c}/send", headers=_h(token), json={"sent_via": "email", "sent_to": "x@x.com"})
+    assert rs.status_code == 200, f"Send failed: {rs.json()}"
+
+    # INV-D: finalized, partial payment of $1,000 (outstanding = $3,000)
+    d = await _invoice(client, token, total=4000)
+    await _pay(client, token, d, 1000, "PART-D")
+
+    # INV-E: finalized and fully paid
+    e = await _invoice(client, token, total=5000)
+    await _pay(client, token, e, 5000, "FULL-E")
+
+    # INV-F: finalized then voided
+    f = await _invoice(client, token, total=6000)
+    rv = await client.post(f"/docs/{f}/void", headers=_h(token), json={"reason": "test void"})
+    assert rv.status_code == 200, f"Void failed: {rv.json()}"
+
+    r = await client.get("/docs/summary?doc_type=invoice", headers=_h(token))
+    assert r.status_code == 200
+    s = r.json()
+
+    assert s["draft_count"] == 1, f"draft_count: {s['draft_count']}"
+    assert s["all_issued_count"] == 4, f"all_issued_count: {s['all_issued_count']}"
+    assert s["awaiting_payment_count"] == 3, f"awaiting_payment_count: {s['awaiting_payment_count']}"
+    assert abs(s["awaiting_payment_total"] - 8000.0) < 0.01, (
+        f"awaiting_payment_total: {s['awaiting_payment_total']} (expected 8000: 2000+3000+3000 outstanding)"
+    )
+    assert s.get("paid_count", s["count_by_status"].get("paid", 0)) == 1, f"paid_count: {s}"
+    assert abs(s["paid_total"] - 5000.0) < 0.01, f"paid_total: {s['paid_total']}"
+    assert s["overdue_count"] == 0, f"overdue_count: {s['overdue_count']}"
+    assert abs(s.get("overdue_total", 0)) < 0.01, f"overdue_total: {s.get('overdue_total')}"
+    assert abs(s["all_issued_total"] - 14000.0) < 0.01, (
+        f"all_issued_total: {s['all_issued_total']} (expected 14000: 2000+3000+4000+5000)"
+    )
+    assert abs(s["draft_total"] - 1000.0) < 0.01, f"draft_total: {s['draft_total']}"
+    assert abs(s["void_total"] - 6000.0) < 0.01, f"void_total: {s['void_total']}"
+
+
+@pytest.mark.anyio
+async def test_summary_sent_total_is_outstanding_not_face_value(client, session):
+    """sent_total must be the outstanding balance on sent invoices, not their face value.
+
+    A $1,000 invoice that's been partially paid ($400) then sent should
+    contribute $600 to sent_total, not $1,000.
+    """
+    token = await _register(client)
+    doc_id = await _invoice(client, token, total=1000)
+    # Partially pay before sending
+    await _pay(client, token, doc_id, 400, "PRE-SEND")
+    # Send it
+    rs = await client.post(f"/docs/{doc_id}/send", headers=_h(token),
+                           json={"sent_via": "email", "sent_to": "a@b.com"})
+    assert rs.status_code == 200
+
+    r = await client.get("/docs/summary?doc_type=invoice", headers=_h(token))
+    s = r.json()
+    assert abs(s["sent_total"] - 600.0) < 0.01, (
+        f"sent_total should be 600 (outstanding), got {s['sent_total']}"
+    )
+
+
+@pytest.mark.anyio
+async def test_summary_all_card_count_equals_all_issued_not_sum_of_cards(client, session):
+    """Regression: the All card count must equal all_issued_count, not sum of sub-cards.
+
+    With 1 fully-paid invoice:
+      - All Issued = 1
+      - Paid = 1
+    Naive sum would give All = 2. Correct answer is All = 1.
+    """
+    token = await _register(client)
+    doc_id = await _invoice(client, token, total=750)
+    await _pay(client, token, doc_id, 750, "FULL")
+
+    r = await client.get("/docs/summary?doc_type=invoice", headers=_h(token))
+    s = r.json()
+    assert s["all_issued_count"] == 1, f"all_issued_count: {s['all_issued_count']}"
+    # paid invoice must NOT be counted in awaiting_payment
+    assert s["awaiting_payment_count"] == 0, (
+        f"awaiting_payment_count should be 0 for a fully-paid invoice, got {s['awaiting_payment_count']}"
+    )

--- a/tests/test_routers/test_doc_workflows.py
+++ b/tests/test_routers/test_doc_workflows.py
@@ -552,3 +552,65 @@ async def test_invoice_status_cards_include_proforma(client, session):
     html = str(_doc_status_cards([], "", summary, "USD", doc_type="invoice", lang="en"))
     assert "Pro" in html or "pro" in html.lower(), "Pro-forma card missing from invoice status cards"
     assert "All Issued" in html or "all_issued" in html.lower(), "All Issued card missing from invoice status cards"
+
+
+@pytest.mark.anyio
+async def test_summary_partial_invoice_in_awaiting_not_paid(client, session):
+    """Regression: partial-paid invoices must appear in awaiting_payment_count, not paid.
+
+    A partially paid invoice still has outstanding balance and should never
+    appear in the 'Paid' bucket.
+    """
+    token = await _register(client)
+    doc_id = await _create_invoice(client, token, subtotal=1000, tax=0, total=1000)
+    await client.post(f"/docs/{doc_id}/finalize", headers=_h(token), json={})
+    # Record a partial payment (500 out of 1000)
+    await client.post(f"/docs/{doc_id}/payment", headers=_h(token),
+                      json={"amount": 500, "method": "transfer", "reference": "PART-1",
+                            "payment_date": "2026-04-25", "bank_account": "1110"})
+    r = await client.get("/docs/summary?doc_type=invoice", headers=_h(token))
+    assert r.status_code == 200
+    data = r.json()
+    cbs = data.get("count_by_status", {})
+    assert cbs.get("partial", 0) >= 1, "partial-paid invoice should have status 'partial'"
+    assert cbs.get("paid", 0) == 0, "partial-paid invoice must NOT be counted as 'paid'"
+    assert data.get("awaiting_payment_count", 0) >= 1, "partial-paid invoice must be in awaiting_payment_count"
+
+
+@pytest.mark.anyio
+async def test_summary_all_count_not_doubled(client, session):
+    """Regression: all_issued_count must not double-count invoices.
+
+    One fully-paid invoice should give all_issued_count=1, not 2.
+    """
+    token = await _register(client)
+    doc_id = await _create_invoice(client, token, subtotal=200, tax=0, total=200)
+    await client.post(f"/docs/{doc_id}/finalize", headers=_h(token), json={})
+    # Pay in full
+    await client.post(f"/docs/{doc_id}/payment", headers=_h(token),
+                      json={"amount": 200, "method": "cash", "reference": "FULL-1",
+                            "payment_date": "2026-04-25", "bank_account": "1110"})
+    r = await client.get("/docs/summary?doc_type=invoice", headers=_h(token))
+    assert r.status_code == 200
+    data = r.json()
+    assert data["all_issued_count"] == 1, (
+        f"Expected all_issued_count=1, got {data['all_issued_count']}"
+    )
+
+
+@pytest.mark.anyio
+async def test_summary_awaiting_payment_total_is_outstanding(client, session):
+    """awaiting_payment_total must equal the outstanding balance, not the invoice face value."""
+    token = await _register(client)
+    doc_id = await _create_invoice(client, token, subtotal=800, tax=0, total=800)
+    await client.post(f"/docs/{doc_id}/finalize", headers=_h(token), json={})
+    # Partial payment of 300 -> outstanding = 500
+    await client.post(f"/docs/{doc_id}/payment", headers=_h(token),
+                      json={"amount": 300, "method": "cash", "reference": "P1",
+                            "payment_date": "2026-04-25", "bank_account": "1110"})
+    r = await client.get("/docs/summary?doc_type=invoice", headers=_h(token))
+    assert r.status_code == 200
+    data = r.json()
+    assert abs(data.get("awaiting_payment_total", -1) - 500.0) < 0.01, (
+        f"awaiting_payment_total should be 500, got {data.get('awaiting_payment_total')}"
+    )

--- a/ui/routes/documents.py
+++ b/ui/routes/documents.py
@@ -4485,16 +4485,22 @@ def _doc_status_cards(docs: list[dict], active_status: str, summary: dict | None
     # ------------------------------------------------------------------
     if doc_type == "invoice":
         _cbs = _sm.get("count_by_status") or {}
-        draft_cnt  = _cbs.get("draft", 0)
-        all_issued = _sm.get("all_issued_count", _sm.get("non_void_count", 0))
-        awaiting   = _sm.get("awaiting_payment_count", 0)
-        awaiting_total = _sm.get("awaiting_payment_total")   # outstanding balance; None suppresses display
-        overdue    = _sm.get("overdue_count", 0)
-        # "Paid" = fully paid only; partial still has outstanding balance -> Awaiting Payment
-        paid_cnt   = _cbs.get("paid", 0)
-        paid_total = _sm.get("paid_total")                   # total invoice value; None suppresses display
-        sent_cnt   = _cbs.get("sent", 0)
-        void_cnt   = _cbs.get("void", 0)
+        draft_cnt      = _cbs.get("draft", 0)
+        all_issued     = _sm.get("all_issued_count", _sm.get("non_void_count", 0))
+        awaiting       = _sm.get("awaiting_payment_count", 0)
+        overdue        = _sm.get("overdue_count", 0)
+        paid_cnt       = _cbs.get("paid", 0)
+        sent_cnt       = _cbs.get("sent", 0)
+        void_cnt       = _cbs.get("void", 0)
+
+        # Per-bucket totals - all calculated server-side
+        draft_total      = _sm.get("draft_total", 0.0)
+        all_issued_total = _sm.get("all_issued_total", _sm.get("ar_total", 0.0))
+        sent_total       = _sm.get("sent_total", 0.0)
+        awaiting_total   = _sm.get("awaiting_payment_total", 0.0)
+        overdue_total    = _sm.get("overdue_total", 0.0)
+        paid_total       = _sm.get("paid_total", 0.0)
+        void_total       = _sm.get("void_total", 0.0)
 
         # Awaiting Payment covers every issued-but-not-fully-paid status
         _AWAITING_STATUSES = "final,sent,awaiting_payment,partial"
@@ -4515,13 +4521,13 @@ def _doc_status_cards(docs: list[dict], active_status: str, summary: dict | None
             _active_key = active_status or ""
 
         invoice_cards = [
-            {"label": t("status.pro_forma", lang),        "count": draft_cnt,  "total": None,          "status": "draft",            "color": "gray"},
-            {"label": t("status.all_issued", lang),       "count": all_issued, "total": None,          "status": "all_issued",       "color": "blue",   "_url": f"{base_url}&status_in={_ALL_ISSUED_STATUSES}", "_active_key": "all_issued"},
-            {"label": t("doc.sent", lang),                "count": sent_cnt,   "total": None,          "status": "sent",             "color": "blue"},
-            {"label": t("status.awaiting_payment", lang), "count": awaiting,   "total": awaiting_total, "status": "awaiting_payment", "color": "yellow", "_url": f"{base_url}&status_in={_AWAITING_STATUSES}",                        "_active_key": "awaiting_payment"},
-            {"label": t("status.overdue", lang),          "count": overdue,    "total": None,          "status": "overdue",          "color": "red",    "_url": f"{base_url}&status_in={_AWAITING_STATUSES}&overdue_only=1",          "_active_key": "overdue"},
-            {"label": t("label.paid", lang),              "count": paid_cnt,   "total": paid_total,    "status": "paid",             "color": "green",  "_url": f"{base_url}&status_in={_PAID_STATUSES}",                            "_active_key": "paid"},
-            {"label": t("btn.void", lang),                "count": void_cnt,   "total": None,          "status": "void",             "color": "gray"},
+            {"label": t("status.pro_forma", lang),        "count": draft_cnt,  "total": draft_total,      "status": "draft",            "color": "gray"},
+            {"label": t("status.all_issued", lang),       "count": all_issued, "total": all_issued_total, "status": "all_issued",       "color": "blue",   "_url": f"{base_url}&status_in={_ALL_ISSUED_STATUSES}", "_active_key": "all_issued"},
+            {"label": t("doc.sent", lang),                "count": sent_cnt,   "total": sent_total,       "status": "sent",             "color": "blue"},
+            {"label": t("status.awaiting_payment", lang), "count": awaiting,   "total": awaiting_total,   "status": "awaiting_payment", "color": "yellow", "_url": f"{base_url}&status_in={_AWAITING_STATUSES}",                       "_active_key": "awaiting_payment"},
+            {"label": t("status.overdue", lang),          "count": overdue,    "total": overdue_total,    "status": "overdue",          "color": "red",    "_url": f"{base_url}&status_in={_AWAITING_STATUSES}&overdue_only=1",         "_active_key": "overdue"},
+            {"label": t("label.paid", lang),              "count": paid_cnt,   "total": paid_total,       "status": "paid",             "color": "green",  "_url": f"{base_url}&status_in={_PAID_STATUSES}",                           "_active_key": "paid"},
+            {"label": t("btn.void", lang),                "count": void_cnt,   "total": void_total,       "status": "void",             "color": "gray"},
         ]
         # total_override=all_issued prevents the "All" card from summing sub-cards.
         # Sub-cards overlap (e.g. a paid invoice is counted in both All Issued and Paid),

--- a/ui/routes/documents.py
+++ b/ui/routes/documents.py
@@ -4488,26 +4488,45 @@ def _doc_status_cards(docs: list[dict], active_status: str, summary: dict | None
         draft_cnt  = _cbs.get("draft", 0)
         all_issued = _sm.get("all_issued_count", _sm.get("non_void_count", 0))
         awaiting   = _sm.get("awaiting_payment_count", 0)
+        awaiting_total = _sm.get("awaiting_payment_total")   # outstanding balance; None suppresses display
         overdue    = _sm.get("overdue_count", 0)
-        paid_cnt   = _cbs.get("paid", 0) + _cbs.get("partial", 0)
+        # "Paid" = fully paid only; partial still has outstanding balance -> Awaiting Payment
+        paid_cnt   = _cbs.get("paid", 0)
+        paid_total = _sm.get("paid_total")                   # total invoice value; None suppresses display
         sent_cnt   = _cbs.get("sent", 0)
         void_cnt   = _cbs.get("void", 0)
 
-        # Active key for "pro_forma" card: the main drafts-tab handles navigation but
-        # we also need a card so users can see the draft count at a glance.
+        # Awaiting Payment covers every issued-but-not-fully-paid status
+        _AWAITING_STATUSES = "final,sent,awaiting_payment,partial"
+        _PAID_STATUSES     = "paid"
+
+        # Resolve which virtual card is active
         if active_status == "draft":
             _active_key = "draft"
+        elif status_in == _ALL_ISSUED_STATUSES:
+            _active_key = "all_issued"
+        elif status_in == _AWAITING_STATUSES and overdue_only:
+            _active_key = "overdue"
+        elif status_in == _AWAITING_STATUSES:
+            _active_key = "awaiting_payment"
+        elif status_in == _PAID_STATUSES or active_status == "paid":
+            _active_key = "paid"
+        else:
+            _active_key = active_status or ""
 
         invoice_cards = [
-            {"label": t("status.pro_forma", lang),        "count": draft_cnt,  "total": 0.0, "status": "draft",             "color": "gray"},
-            {"label": t("status.all_issued", lang),       "count": all_issued, "total": 0.0, "status": "all_issued",        "color": "blue",   "_url": f"{base_url}&status_in={_ALL_ISSUED_STATUSES}", "_active_key": "all_issued"},
-            {"label": t("doc.sent", lang),                "count": sent_cnt,   "total": 0.0, "status": "sent",              "color": "blue"},
-            {"label": t("status.awaiting_payment", lang), "count": awaiting,   "total": 0.0, "status": "awaiting_payment",  "color": "yellow", "_url": f"{base_url}&status_in={_AWAITING_STATUSES}",   "_active_key": "awaiting_payment"},
-            {"label": t("status.overdue", lang),          "count": overdue,    "total": 0.0, "status": "overdue",           "color": "red",    "_url": f"{base_url}&status_in={_AWAITING_STATUSES}&overdue_only=1", "_active_key": "overdue"},
-            {"label": t("label.paid", lang),              "count": paid_cnt,   "total": 0.0, "status": "paid",              "color": "green",  "_url": f"{base_url}&status_in={_PAID_STATUSES}",        "_active_key": "paid"},
-            {"label": t("btn.void", lang),                "count": void_cnt,   "total": 0.0, "status": "void",              "color": "gray"},
+            {"label": t("status.pro_forma", lang),        "count": draft_cnt,  "total": None,          "status": "draft",            "color": "gray"},
+            {"label": t("status.all_issued", lang),       "count": all_issued, "total": None,          "status": "all_issued",       "color": "blue",   "_url": f"{base_url}&status_in={_ALL_ISSUED_STATUSES}", "_active_key": "all_issued"},
+            {"label": t("doc.sent", lang),                "count": sent_cnt,   "total": None,          "status": "sent",             "color": "blue"},
+            {"label": t("status.awaiting_payment", lang), "count": awaiting,   "total": awaiting_total, "status": "awaiting_payment", "color": "yellow", "_url": f"{base_url}&status_in={_AWAITING_STATUSES}",                        "_active_key": "awaiting_payment"},
+            {"label": t("status.overdue", lang),          "count": overdue,    "total": None,          "status": "overdue",          "color": "red",    "_url": f"{base_url}&status_in={_AWAITING_STATUSES}&overdue_only=1",          "_active_key": "overdue"},
+            {"label": t("label.paid", lang),              "count": paid_cnt,   "total": paid_total,    "status": "paid",             "color": "green",  "_url": f"{base_url}&status_in={_PAID_STATUSES}",                            "_active_key": "paid"},
+            {"label": t("btn.void", lang),                "count": void_cnt,   "total": None,          "status": "void",             "color": "gray"},
         ]
-        return status_cards(invoice_cards, base_url, _active_key or None, currency=currency)
+        # total_override=all_issued prevents the "All" card from summing sub-cards.
+        # Sub-cards overlap (e.g. a paid invoice is counted in both All Issued and Paid),
+        # so summing them would produce a number larger than the real invoice count.
+        return status_cards(invoice_cards, base_url, _active_key or None, total_override=all_issued, currency=currency)
 
     # ------------------------------------------------------------------
     # All other doc types: simple per-status cards


### PR DESCRIPTION
## Root causes

### 1. "All" card double-counted (e.g. All 2 for 1 invoice)
`status_cards()` sums sub-card counts by default. Invoice sub-cards overlap - a paid invoice appears in both All Issued (1) and Paid (1), so the implicit sum was 2. Fixed by passing `total_override=all_issued_count` so the All card reads the correct server-side aggregate directly.

### 2. Partially-paid invoices in the wrong bucket
`partial` DB status was grouped with `paid` (paid + partial). A partially-paid invoice still has an outstanding balance - it belongs in Awaiting Payment, not Paid. Fixed: Awaiting Payment now covers `final + sent + awaiting_payment + partial`; Paid covers only the `paid` status.

### 3. $0.00 shown on every card
All card totals were hardcoded to `0.0`. Cards with no meaningful per-bucket total now pass `total=None` (suppresses the figure). Awaiting Payment shows the real outstanding balance sum; Paid shows the real face-value total. Backend summary now tracks `awaiting_payment_total` and `paid_total`.

## Tests added
- `test_summary_partial_invoice_in_awaiting_not_paid`
- `test_summary_all_count_not_doubled`
- `test_summary_awaiting_payment_total_is_outstanding`