### PR TITLE
fix: Mac DMG signing + notarization, doctor JE prefix match, item.fulfilled quantity fix, and misc UI/fulfillment fixes

### DIFF
--- a/electron/pnpm-lock.yaml
+++ b/electron/pnpm-lock.yaml
@@ -15,6 +15,9 @@ importers:
         specifier: ^17.9.0-beta.16
         version: 17.9.0-beta.16
     devDependencies:
+      '@electron/notarize':
+        specifier: ^2.5.0
+        version: 2.5.0
       electron:
         specifier: ^30.0.0
         version: 30.5.1


### PR DESCRIPTION
## Summary

This PR bundles all work from `fix/dmg-version-and-item-split`:

### Mac DMG signing + notarization
- Entitlements plist, `scripts/notarize.js`, `@electron/notarize` dep
- `hardenedRuntime: true` in electron-builder config
- CI step to import Apple Developer cert into temp keychain
- Lockfile updated to include `@electron/notarize`

### `item.fulfilled` projection bug fix
- Was setting `quantity = quantity_fulfilled` (the sold amount) instead of `quantity = 0`
- `quantity_fulfilled` now stored separately for unfulfill restore

### Doctor JE prefix match
- Doctor now detects any `po.received:*` key (prefix match) instead of exact match
- Fixes regression introduced when `unique_suffix` was added to `create_for_po_received`

### Fulfillment architecture v4 + refinements
- Denylist approach, Revert button, service-only handling, CSS selector fix
- Customer returns via credit note with COGS JE reversal
- Vendor bill receive fixes: SKU attribute inheritance, re-receive after revert
- Per-line `receive_as` (stock/expense) on vendor docs

### UI/UX
- Action bar 3-group layout
- Per-doc-type status cards
- Dashboard Cost Value and Retail Value fix
- Category column on vendor docs

### Tests
- 836 tests pass; 4 pre-existing unrelated failures
