### PR TITLE
fix(ci): pass CSC_LINK/CSC_KEY_PASSWORD to electron-builder for Mac signing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -109,6 +109,8 @@ jobs:
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          CSC_LINK: ${{ secrets.APPLE_CERTIFICATE }}
+          CSC_KEY_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
         run: ${{ matrix.build_cmd }}
 
       - name: Normalize artifact names


### PR DESCRIPTION
## Root cause

The previous CI was importing the Apple Developer cert into the system keychain, but electron-builder ignores the system keychain - it has its own signing mechanism. It fell back to ad-hoc signing (`Signature=adhoc`, `TeamIdentifier=not set`).

## Fix

Pass `CSC_LINK` (base64 p12 cert) and `CSC_KEY_PASSWORD` to the Build step. These are the canonical electron-builder env vars for code signing. electron-builder handles the import itself.
