### PR TITLE
fix(ci): correct Mac code signing - use cert file path, guard notarize against unsigned apps

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -106,7 +106,8 @@ jobs:
           "$PY" -m pip install --upgrade pip
           "$PY" -m pip install .
 
-      - name: Build
+      - name: Build (macOS - with signing)
+        if: matrix.os == 'macos-latest'
         working-directory: electron
         env:
           APPLE_ID: ${{ secrets.APPLE_ID }}
@@ -114,6 +115,13 @@ jobs:
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
           CSC_LINK: ${{ env.CERT_PATH }}
           CSC_KEY_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+        run: ${{ matrix.build_cmd }}
+
+      - name: Build (Windows / Linux - no signing)
+        if: matrix.os != 'macos-latest'
+        working-directory: electron
+        env:
+          CSC_IDENTITY_AUTO_DISCOVERY: "false"
         run: ${{ matrix.build_cmd }}
 
       - name: Normalize artifact names

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,15 +57,18 @@ jobs:
         run: |
           KEYCHAIN_PATH="$RUNNER_TEMP/build.keychain"
           CERT_PATH="$RUNNER_TEMP/certificate.p12"
-          echo "$APPLE_CERTIFICATE" | base64 --decode -o "$CERT_PATH"
+          echo "$APPLE_CERTIFICATE" | base64 --decode > "$CERT_PATH"
           security create-keychain -p "temp-password" "$KEYCHAIN_PATH"
           security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
           security unlock-keychain -p "temp-password" "$KEYCHAIN_PATH"
-          security import "$CERT_PATH" -k "$KEYCHAIN_PATH" -P "$APPLE_CERTIFICATE_PASSWORD" -T /usr/bin/codesign -T /usr/bin/security
+          security import "$CERT_PATH" -k "$KEYCHAIN_PATH" -P "$APPLE_CERTIFICATE_PASSWORD" -T /usr/bin/codesign
           security list-keychain -d user -s "$KEYCHAIN_PATH"
           security set-key-partition-list -S apple-tool:,apple: -s -k "temp-password" "$KEYCHAIN_PATH"
-          rm -f "$CERT_PATH"
-          echo "Certificate imported successfully"
+          # Verify the cert loaded correctly - must show "Developer ID Application"
+          security find-identity -v -p codesigning "$KEYCHAIN_PATH"
+          # Keep CERT_PATH alive for CSC_LINK (ephemeral runner - safe)
+          echo "CERT_PATH=$CERT_PATH" >> "$GITHUB_ENV"
+          echo "KEYCHAIN_PASSWORD=temp-password" >> "$GITHUB_ENV"
 
       - name: Set Electron version from git tag
         if: startsWith(github.ref, 'refs/tags/')
@@ -109,7 +112,7 @@ jobs:
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-          CSC_LINK: ${{ secrets.APPLE_CERTIFICATE }}
+          CSC_LINK: ${{ env.CERT_PATH }}
           CSC_KEY_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
         run: ${{ matrix.build_cmd }}
 

--- a/electron/scripts/notarize.js
+++ b/electron/scripts/notarize.js
@@ -3,6 +3,7 @@
 // Only runs when APPLE_ID env var is set (i.e. CI with secrets populated).
 
 const { notarize } = require('@electron/notarize');
+const { execSync } = require('child_process');
 
 exports.default = async function notarizing(context) {
   const { electronPlatformName, appOutDir } = context;
@@ -20,6 +21,19 @@ exports.default = async function notarizing(context) {
 
   const appName = context.packager.appInfo.productFilename;
   const appPath = `${appOutDir}/${appName}.app`;
+
+  // Guard: abort if the app was not signed with a Developer ID (ad-hoc or no signature).
+  // Notarizing an unsigned app always fails with "code has no resources".
+  try {
+    const result = execSync(`codesign -dv "${appPath}" 2>&1`).toString();
+    if (result.includes('adhoc') || result.includes('TeamIdentifier=not set')) {
+      console.log('Notarization skipped: app is not signed with a Developer ID certificate.');
+      return;
+    }
+  } catch (e) {
+    console.log('Notarization skipped: could not verify app signature:', e.message);
+    return;
+  }
 
   console.log(`Notarizing ${appPath} …`);
   await notarize({


### PR DESCRIPTION
## Root cause analysis

Two compounding bugs:

**1. `CSC_LINK` must be a file path, not raw base64**
`electron-builder` on macOS expects `CSC_LINK` to be a path to a `.p12` file, not the base64 string itself. Passing raw base64 caused it to find 0 valid identities and fall back to ad-hoc signing.

Fix: keep the decoded `certificate.p12` file alive (was deleted prematurely), export `CERT_PATH` via `GITHUB_ENV`, pass it as `CSC_LINK`.

**2. `afterSign` notarize hook ran on unsigned app**
`notarize.js` was attempting to notarize an ad-hoc signed app, which always fails with `code has no resources but signature indicates they must be present`.

Fix: `notarize.js` now runs `codesign -dv` and aborts gracefully if the app has `adhoc` or missing `TeamIdentifier`.

**Bonus**: added `security find-identity -v` to CI output so cert loading issues are immediately visible.
