### PR TITLE
fix(ci): simplify mac signing - CSC_LINK base64 direct, hard fail if unsigned

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,27 +49,6 @@ jobs:
         working-directory: electron
         run: pnpm install --frozen-lockfile
 
-      - name: Import Apple Developer certificate (macOS only)
-        if: matrix.os == 'macos-latest'
-        env:
-          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
-          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
-        run: |
-          KEYCHAIN_PATH="$RUNNER_TEMP/build.keychain"
-          CERT_PATH="$RUNNER_TEMP/certificate.p12"
-          echo "$APPLE_CERTIFICATE" | base64 --decode > "$CERT_PATH"
-          security create-keychain -p "temp-password" "$KEYCHAIN_PATH"
-          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
-          security unlock-keychain -p "temp-password" "$KEYCHAIN_PATH"
-          security import "$CERT_PATH" -k "$KEYCHAIN_PATH" -P "$APPLE_CERTIFICATE_PASSWORD" -T /usr/bin/codesign
-          security list-keychain -d user -s "$KEYCHAIN_PATH"
-          security set-key-partition-list -S apple-tool:,apple: -s -k "temp-password" "$KEYCHAIN_PATH"
-          # Verify the cert loaded correctly - must show "Developer ID Application"
-          security find-identity -v -p codesigning "$KEYCHAIN_PATH"
-          # Keep CERT_PATH alive for CSC_LINK (ephemeral runner - safe)
-          echo "CERT_PATH=$CERT_PATH" >> "$GITHUB_ENV"
-          echo "KEYCHAIN_PASSWORD=temp-password" >> "$GITHUB_ENV"
-
       - name: Set Electron version from git tag
         if: startsWith(github.ref, 'refs/tags/')
         shell: bash
@@ -113,9 +92,23 @@ jobs:
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-          CSC_LINK: ${{ env.CERT_PATH }}
+          CSC_LINK: ${{ secrets.APPLE_CERTIFICATE }}
           CSC_KEY_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
         run: ${{ matrix.build_cmd }}
+
+      - name: Verify Mac app is signed (fail build if not)
+        if: matrix.os == 'macos-latest'
+        run: |
+          APP_PATH="electron/dist/mac-arm64/Celerp.app"
+          echo "Verifying signature on $APP_PATH..."
+          codesign --verify --deep --strict --verbose=2 "$APP_PATH"
+          # Confirm it's signed with a real Developer ID (not ad-hoc)
+          TEAM=$(codesign -dv "$APP_PATH" 2>&1 | grep TeamIdentifier | cut -d= -f2)
+          if [ -z "$TEAM" ] || [ "$TEAM" = "not set" ]; then
+            echo "ERROR: App is not signed with a Developer ID certificate."
+            exit 1
+          fi
+          echo "Signed OK. TeamIdentifier=$TEAM"
 
       - name: Build (Windows / Linux - no signing)
         if: matrix.os != 'macos-latest'

--- a/electron/scripts/notarize.js
+++ b/electron/scripts/notarize.js
@@ -22,17 +22,21 @@ exports.default = async function notarizing(context) {
   const appName = context.packager.appInfo.productFilename;
   const appPath = `${appOutDir}/${appName}.app`;
 
-  // Guard: abort if the app was not signed with a Developer ID (ad-hoc or no signature).
-  // Notarizing an unsigned app always fails with "code has no resources".
+  // Guard: fail loudly if the app is not signed with a Developer ID.
+  // Notarizing an ad-hoc or unsigned app always fails with "code has no resources".
+  // Better to catch it here with a clear message than a cryptic notarize error.
+  let sigInfo;
   try {
-    const result = execSync(`codesign -dv "${appPath}" 2>&1`).toString();
-    if (result.includes('adhoc') || result.includes('TeamIdentifier=not set')) {
-      console.log('Notarization skipped: app is not signed with a Developer ID certificate.');
-      return;
-    }
+    sigInfo = execSync(`codesign -dv "${appPath}" 2>&1`).toString();
   } catch (e) {
-    console.log('Notarization skipped: could not verify app signature:', e.message);
-    return;
+    throw new Error(`App is not signed - codesign check failed: ${e.message}`);
+  }
+  if (sigInfo.includes('adhoc') || sigInfo.includes('TeamIdentifier=not set')) {
+    throw new Error(
+      'App was built with ad-hoc or no Developer ID signature. ' +
+      'Check that CSC_LINK and CSC_KEY_PASSWORD are set correctly in CI. ' +
+      'Refusing to notarize unsigned app.'
+    );
   }
 
   console.log(`Notarizing ${appPath} …`);


### PR DESCRIPTION
## Changes

- Remove manual keychain import step (was conflicting with electron-builder's own temp keychain)
- `CSC_LINK` now receives base64 secret directly per electron-builder docs
- Added `Verify Mac app is signed` step: `codesign --verify --deep --strict` + TeamIdentifier check - build fails hard if unsigned
- `notarize.js` now throws instead of silently skipping if app is ad-hoc signed
- Windows/Linux: `CSC_IDENTITY_AUTO_DISCOVERY=false` to skip signing entirely
