### PR TITLE
fix(ci): increase mac build timeout to 60min for signing+notarization

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
             pbs_triple: aarch64-apple-darwin
 
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 30
+    timeout-minutes: 60
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Problem

Signing started successfully (`• signing file=...` with a real Developer ID identity) but the job hit the 30-minute timeout during `codesign`. The `codesign --timestamp` call contacts Apple's timestamp authority server which can legitimately take several minutes in CI.

## Fix

Increase `timeout-minutes` from 30 to 60. The signing + notarization pipeline (codesign + notarytool upload/poll) can realistically take 20-40 minutes on a cold runner.
