### PR TITLE
fix(ci): move notarization to explicit xcrun step with 25min hard timeout

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -102,13 +102,33 @@ jobs:
           APP_PATH="electron/dist/mac-arm64/Celerp.app"
           echo "Verifying signature on $APP_PATH..."
           codesign --verify --deep --strict --verbose=2 "$APP_PATH"
-          # Confirm it's signed with a real Developer ID (not ad-hoc)
           TEAM=$(codesign -dv "$APP_PATH" 2>&1 | grep TeamIdentifier | cut -d= -f2)
           if [ -z "$TEAM" ] || [ "$TEAM" = "not set" ]; then
             echo "ERROR: App is not signed with a Developer ID certificate."
             exit 1
           fi
           echo "Signed OK. TeamIdentifier=$TEAM"
+
+      - name: Notarize Mac DMG
+        if: matrix.os == 'macos-latest'
+        timeout-minutes: 30
+        env:
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          DMG_PATH=$(ls electron/dist/*.dmg | head -1)
+          echo "Submitting for notarization: $DMG_PATH"
+          xcrun notarytool submit "$DMG_PATH" \
+            --apple-id "$APPLE_ID" \
+            --password "$APPLE_APP_SPECIFIC_PASSWORD" \
+            --team-id "$APPLE_TEAM_ID" \
+            --wait \
+            --timeout 25m \
+            --verbose
+          echo "Stapling notarization ticket..."
+          xcrun stapler staple "$DMG_PATH"
+          echo "Notarization and stapling complete."
 
       - name: Build (Windows / Linux - no signing)
         if: matrix.os != 'macos-latest'

--- a/electron/package.json
+++ b/electron/package.json
@@ -1,7 +1,7 @@
 {
   "name": "celerp",
   "version": "1.0.0",
-  "description": "Free business software — inventory, invoicing, and operations in one place.",
+  "description": "Free business software \u2014 inventory, invoicing, and operations in one place.",
   "main": "main.js",
   "author": "Data Universal Limited",
   "license": "BSL-1.1",
@@ -27,7 +27,7 @@
   "build": {
     "appId": "com.celerp.app",
     "productName": "Celerp",
-    "copyright": "Copyright © 2026 Data Universal Limited",
+    "copyright": "Copyright \u00a9 2026 Data Universal Limited",
     "directories": {
       "output": "dist"
     },
@@ -98,7 +98,6 @@
         }
       ]
     },
-    "afterSign": "scripts/notarize.js",
     "linux": {
       "icon": "assets/icon.png",
       "category": "Office",

--- a/electron/scripts/notarize.js
+++ b/electron/scripts/notarize.js
@@ -5,6 +5,8 @@
 const { notarize } = require('@electron/notarize');
 const { execSync } = require('child_process');
 
+const NOTARIZE_TIMEOUT_MS = 20 * 60 * 1000; // 20 minutes
+
 exports.default = async function notarizing(context) {
   const { electronPlatformName, appOutDir } = context;
   if (electronPlatformName !== 'darwin') return;
@@ -24,7 +26,6 @@ exports.default = async function notarizing(context) {
 
   // Guard: fail loudly if the app is not signed with a Developer ID.
   // Notarizing an ad-hoc or unsigned app always fails with "code has no resources".
-  // Better to catch it here with a clear message than a cryptic notarize error.
   let sigInfo;
   try {
     sigInfo = execSync(`codesign -dv "${appPath}" 2>&1`).toString();
@@ -39,13 +40,25 @@ exports.default = async function notarizing(context) {
     );
   }
 
-  console.log(`Notarizing ${appPath} …`);
-  await notarize({
-    tool: 'notarytool',
-    appPath,
-    appleId,
-    appleIdPassword,
-    teamId,
-  });
+  console.log(`Notarizing ${appPath} … (timeout: ${NOTARIZE_TIMEOUT_MS / 60000} min)`);
+
+  const timeoutPromise = new Promise((_, reject) =>
+    setTimeout(
+      () => reject(new Error(`Notarization timed out after ${NOTARIZE_TIMEOUT_MS / 60000} minutes. Apple notarization service may be slow or unreachable.`)),
+      NOTARIZE_TIMEOUT_MS
+    )
+  );
+
+  await Promise.race([
+    notarize({
+      tool: 'notarytool',
+      appPath,
+      appleId,
+      appleIdPassword,
+      teamId,
+    }),
+    timeoutPromise,
+  ]);
+
   console.log('Notarization complete.');
 };


### PR DESCRIPTION
## Root cause

From the logs: signing took ~1 second (working fine), then `notarytool` hung for exactly 59 minutes before the job was killed. The `afterSign` hook in `notarize.js` had no timeout - it would wait forever for Apple's notarization service.

## Fix

- Remove `afterSign` hook from `package.json` - it ran inside electron-builder with no timeout control
- Add explicit `Notarize Mac DMG` CI step using `xcrun notarytool` with:
  - `--timeout 25m` so it fails with a clear message if Apple is slow
  - `timeout-minutes: 30` at the step level as a hard backstop
  - `--verbose` for diagnostics
  - `xcrun stapler staple` after success to embed the notarization ticket
- Signing still done by electron-builder via `CSC_LINK` (was already working correctly)
- `notarize.js` kept in repo but no longer invoked
