### PR TITLE
fix(ci): set mac.timestamp=none to skip per-file TSA calls during signing

### DIFF
--- a/electron/package.json
+++ b/electron/package.json
@@ -96,7 +96,8 @@
             "arm64"
           ]
         }
-      ]
+      ],
+      "timestamp": "none"
     },
     "linux": {
       "icon": "assets/icon.png",


### PR DESCRIPTION
Signing was taking ~60min because codesign contacted Apple timestamp server once per binary. Python standalone has 100s of .so/.dylib files. Setting mac.timestamp=none skips per-file TSA calls. notarytool adds a single timestamp for the whole submission so the DMG is still Gatekeeper-valid.