### PR TITLE
fix(ci): signIgnore python standalone to prevent electron-builder re-signing

### DIFF
--- a/electron/package.json
+++ b/electron/package.json
@@ -96,6 +96,9 @@
             "arm64"
           ]
         }
+      ],
+      "signIgnore": [
+        "Contents/Resources/app/python/"
       ]
     },
     "linux": {


### PR DESCRIPTION
Pre-sign step signed Python .so/.dylib in parallel (~2min) but electron-builder was re-signing them all sequentially anyway (~60min). Setting mac.signIgnore to skip Contents/Resources/app/python/ so electron-builder only signs the handful of Electron framework binaries. Build should complete in under 5 minutes.