### PR TITLE
chore(ci): increase build timeout to 120 minutes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
             pbs_triple: aarch64-apple-darwin
 
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 60
+    timeout-minutes: 120
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Safety margin while we confirm the signIgnore fix works as expected.