### PR TITLE
fix: correct signIgnore path + re-sign Electron helpers with secure timestamp

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -124,34 +124,6 @@ jobs:
           CSC_KEY_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
         run: ${{ matrix.build_cmd }}
 
-      - name: Re-sign Electron helpers with secure timestamp
-        if: matrix.os == 'macos-latest'
-        env:
-          CSC_LINK: ${{ secrets.APPLE_CERTIFICATE }}
-          CSC_KEY_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
-        run: |
-          # electron-builder signs helpers without --timestamp; Apple requires it for notarization.
-          # Re-sign all helper .app bundles (and the main app) with --timestamp.
-          IDENTITY="EEC6C15E6827071A403257986E6379A650C62AFB"
-          APP_PATH="electron/dist/mac-arm64/Celerp.app"
-
-          # Re-sign helpers first (deepest first so parent signatures stay valid)
-          find "$APP_PATH/Contents/Frameworks" -name "*.app" | sort -r | while read HELPER; do
-            echo "Re-signing: $HELPER"
-            codesign --force --sign "$IDENTITY" \
-              --timestamp --options runtime \
-              --entitlements electron/build/entitlements.mac.plist \
-              "$HELPER"
-          done
-
-          # Re-sign the main app bundle
-          echo "Re-signing main app..."
-          codesign --force --sign "$IDENTITY" \
-            --timestamp --options runtime \
-            --entitlements electron/build/entitlements.mac.plist \
-            "$APP_PATH"
-          echo "Re-signing complete."
-
       - name: Verify Mac app is signed (fail build if not)
         if: matrix.os == 'macos-latest'
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
             pbs_triple: aarch64-apple-darwin
 
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 120
+    timeout-minutes: 60
 
     steps:
       - uses: actions/checkout@v4
@@ -123,6 +123,34 @@ jobs:
           CSC_LINK: ${{ secrets.APPLE_CERTIFICATE }}
           CSC_KEY_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
         run: ${{ matrix.build_cmd }}
+
+      - name: Re-sign Electron helpers with secure timestamp
+        if: matrix.os == 'macos-latest'
+        env:
+          CSC_LINK: ${{ secrets.APPLE_CERTIFICATE }}
+          CSC_KEY_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+        run: |
+          # electron-builder signs helpers without --timestamp; Apple requires it for notarization.
+          # Re-sign all helper .app bundles (and the main app) with --timestamp.
+          IDENTITY="EEC6C15E6827071A403257986E6379A650C62AFB"
+          APP_PATH="electron/dist/mac-arm64/Celerp.app"
+
+          # Re-sign helpers first (deepest first so parent signatures stay valid)
+          find "$APP_PATH/Contents/Frameworks" -name "*.app" | sort -r | while read HELPER; do
+            echo "Re-signing: $HELPER"
+            codesign --force --sign "$IDENTITY" \
+              --timestamp --options runtime \
+              --entitlements electron/build/entitlements.mac.plist \
+              "$HELPER"
+          done
+
+          # Re-sign the main app bundle
+          echo "Re-signing main app..."
+          codesign --force --sign "$IDENTITY" \
+            --timestamp --options runtime \
+            --entitlements electron/build/entitlements.mac.plist \
+            "$APP_PATH"
+          echo "Re-signing complete."
 
       - name: Verify Mac app is signed (fail build if not)
         if: matrix.os == 'macos-latest'

--- a/electron/package.json
+++ b/electron/package.json
@@ -98,7 +98,7 @@
         }
       ],
       "signIgnore": [
-        "Contents/Resources/app/python/"
+        "Contents/Resources/python/"
       ]
     },
     "linux": {


### PR DESCRIPTION
## Root causes fixed

### 1. Wrong `signIgnore` path (30+ min hang)

Python `extraResources` maps `python-standalone/${os}-${arch}` → `python`, so files land at `Contents/Resources/python/`. Our `signIgnore` pattern was `Contents/Resources/app/python/` which never matched, so electron-builder re-signed every `.so`/`.dylib` in the Python distribution one by one - causing a 30+ minute silent hang.

Fix: `Contents/Resources/python/`

### 2. Electron helpers missing `--timestamp` (notarization rejection)

electron-builder signs helper `.app` bundles but does not pass `--timestamp`. Apple requires a secure timestamp on all binaries for notarization. Fix: added a re-sign step after electron-builder that re-signs all `Contents/Frameworks/*.app` bundles and the main app with `--timestamp --options runtime`.

### 3. Job timeout reduced back to 60 min

The 120 min timeout was a workaround for the hang. With the root cause fixed, 60 min is sufficient.