### PR TITLE
fix: pre-sign all Mach-O binaries in Python dir, not just .so/.dylib

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -106,11 +106,21 @@ jobs:
           IDENTITY="EEC6C15E6827071A403257986E6379A650C62AFB"
           PYTHON_DIR="electron/python-standalone/mac-arm64/python"
 
-          echo "Pre-signing Python native extensions in parallel..."
-          find "$PYTHON_DIR" \( -name "*.so" -o -name "*.dylib" \) -print0 | \
-            xargs -0 -P 8 -I {} codesign --force --sign "$IDENTITY" \
-              --timestamp --options runtime \
-              --keychain "$KEYCHAIN_PATH" {}
+          echo "Pre-signing all Python Mach-O binaries in parallel..."
+          # Must cover ALL Mach-O binaries - not just .so/.dylib.
+          # Plain executables (python3.12, sqlite3_diff, sqlite3_showwal, etc.)
+          # ship with no extension and also require Developer ID + --timestamp
+          # + hardened runtime for notarization to pass.
+          find "$PYTHON_DIR" -type f -print0 | \
+            xargs -0 -P 8 sh -c '
+              for f do
+                if file "$f" | grep -q "Mach-O"; then
+                  codesign --force --sign "'"$IDENTITY"'" \
+                    --timestamp --options runtime \
+                    --keychain "'"$KEYCHAIN_PATH"'" "$f" 2>&1
+                fi
+              done
+            ' _
           echo "Pre-signing complete."
 
       - name: Build (macOS - with signing)


### PR DESCRIPTION
## Problem

The pre-sign step filtered by `*.so` and `*.dylib` extension. Python standalone ships plain Mach-O executables with no extension (`python3.12`, `sqlite3_diff`, `sqlite3_showwal`, `sqlite3_showtmlog`, etc.). These were skipped entirely, landing in the bundle unsigned - causing Apple notarization to reject with:

- `The binary is not signed with a valid Developer ID certificate.`
- `The signature does not include a secure timestamp.`
- `The executable does not have the hardened runtime enabled.`

## Fix

Replace the `find -name "*.so" -o -name "*.dylib"` filter with `file "$f" | grep -q "Mach-O"` to detect all Mach-O binaries regardless of extension. Same `--timestamp --options runtime` flags. Still runs 8 parallel codesign processes.