### PR TITLE
fix: remove presign keychain from search list before electron-builder runs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -123,6 +123,11 @@ jobs:
             ' _
           echo "Pre-signing complete."
 
+          # Remove presign keychain from search list so it doesn't interfere
+          # with electron-builder's own keychain setup during the build step.
+          security list-keychain -d user -s $(security list-keychain -d user | tr -d '"' | grep -v presign) || true
+          security delete-keychain "$KEYCHAIN_PATH" || true
+
       - name: Build (macOS - with signing)
         if: matrix.os == 'macos-latest'
         working-directory: electron


### PR DESCRIPTION
## Problem

The pre-sign step adds `presign.keychain` to the user keychain search list. electron-builder then runs its own sequential signing loop (one `codesign` call per file, no parallelism). Each call traverses all keychains in the search list, including the now-idle presign keychain that was hammered by 8 parallel processes for ~48 seconds.

This is the most likely explanation for why the signing step went from 6 minutes to 40+ minutes with no change to the files being signed: the keychain state left by pre-sign interferes with every subsequent codesign call.

## Fix

After pre-signing completes, remove `presign.keychain` from the search list and delete it. electron-builder then sets up a clean keychain environment from `CSC_LINK` with no interference.