### PR TITLE
fix: exclude embedded-postgres from signing loop + asar/asarUnpack cleanup

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -105,22 +105,25 @@ jobs:
 
           IDENTITY="EEC6C15E6827071A403257986E6379A650C62AFB"
           PYTHON_DIR="electron/python-standalone/mac-arm64/python"
+          POSTGRES_DIR="electron/node_modules/@embedded-postgres/darwin-arm64"
 
-          echo "Pre-signing all Python Mach-O binaries in parallel..."
-          # Must cover ALL Mach-O binaries - not just .so/.dylib.
-          # Plain executables (python3.12, sqlite3_diff, sqlite3_showwal, etc.)
-          # ship with no extension and also require Developer ID + --timestamp
-          # + hardened runtime for notarization to pass.
-          find "$PYTHON_DIR" -type f -print0 | \
-            xargs -0 -P 8 sh -c '
-              for f do
-                if file "$f" | grep -q "Mach-O"; then
-                  codesign --force --sign "'"$IDENTITY"'" \
-                    --timestamp --options runtime \
-                    --keychain "'"$KEYCHAIN_PATH"'" "$f" 2>&1
-                fi
-              done
-            ' _
+          sign_macho_in_dir() {
+            local dir="$1"
+            echo "Pre-signing Mach-O binaries in: $dir"
+            find "$dir" -type f -print0 | \
+              xargs -0 -P 8 sh -c '
+                for f do
+                  if file "$f" | grep -q "Mach-O"; then
+                    codesign --force --sign "'"$IDENTITY"'" \
+                      --timestamp --options runtime \
+                      --keychain "'"$KEYCHAIN_PATH"'" "$f" 2>&1
+                  fi
+                done
+              ' _
+          }
+
+          sign_macho_in_dir "$PYTHON_DIR"
+          sign_macho_in_dir "$POSTGRES_DIR"
           echo "Pre-signing complete."
 
           # Remove presign keychain from search list so it doesn't interfere

--- a/electron/package.json
+++ b/electron/package.json
@@ -31,7 +31,9 @@
     "directories": {
       "output": "dist"
     },
+    "asar": true,
     "asarUnpack": [
+      "**/*.node",
       "node_modules/@embedded-postgres/**"
     ],
     "files": [
@@ -98,7 +100,8 @@
         }
       ],
       "signIgnore": [
-        "Contents/Resources/python/"
+        "Contents/Resources/python/",
+        "Contents/Resources/app.asar.unpacked/node_modules/@embedded-postgres/"
       ]
     },
     "linux": {


### PR DESCRIPTION
## Root causes fixed

### 1. embedded-postgres ~94 Mach-O binaries not excluded (biggest problem)

`signIgnore` only covered `Contents/Resources/python/`. The embedded-postgres package (postgres, pg_dump, pg_restore, libpq, ~80 `.so` extension modules) lands at `Contents/Resources/app.asar.unpacked/node_modules/@embedded-postgres/` - completely different path, not matched. All ~94 binaries were being signed sequentially by `@electron/osx-sign` with a timestamp server round-trip each.

Fix: added to `signIgnore` + added to the parallel pre-sign step.

### 2. Retry loop multiplies time by up to 3x

`macCodeSign.sign()` wraps the entire sequential signing loop in `retry(..., 3 attempts, 5s delay)`. A single transient timestamp server timeout on file #200 restarts from file #1. Reducing the total file count to just Electron framework files minimizes the retry risk.

### 3. asar + asarUnpack cleanup

- Made `asar: true` explicit (was implicit default - risky if electron-builder ever changes default)
- Added `**/*.node` to `asarUnpack` (best practice for native node addons)

## Expected result

electron-builder now signs only ~20-50 Electron framework files. At 1-2s each: ~1-2 minutes total.