### PR TITLE
fix: remove notarization creds from Build step to prevent auto-notarize

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,9 +89,10 @@ jobs:
         if: matrix.os == 'macos-latest'
         working-directory: electron
         env:
-          APPLE_ID: ${{ secrets.APPLE_ID }}
-          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
-          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          # Pass only signing credentials - NOT notarization credentials.
+          # Passing APPLE_ID/APPLE_APP_SPECIFIC_PASSWORD causes electron-builder
+          # to notarize internally before our post-sign step runs, which fails
+          # because python and postgres binaries aren't signed yet.
           CSC_LINK: ${{ secrets.APPLE_CERTIFICATE }}
           CSC_KEY_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
         run: ${{ matrix.build_cmd }}


### PR DESCRIPTION
## Root cause

The Build step had `APPLE_ID`, `APPLE_APP_SPECIFIC_PASSWORD`, and `APPLE_TEAM_ID` set. electron-builder detects these and triggers its **own built-in notarization** automatically after signing - before our post-sign step ever runs. That notarization fails because python and embedded-postgres binaries are not yet signed (they are in `signIgnore`).

## Fix

Remove the three notarization env vars from the Build step. Pass only `CSC_LINK` + `CSC_KEY_PASSWORD` (signing only). The explicit Notarize step (which runs after post-sign) keeps the notarization credentials.

**Flow is now correctly:**
1. Build: electron-builder signs ~20-50 Electron framework files only
2. Post-sign: python + postgres signed in parallel 
3. Verify signature
4. Notarize: explicit `xcrun notarytool` with all binaries properly signed