### PR TITLE
fix: pre-sign python/postgres before electron-builder, single DMG build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,44 +85,34 @@ jobs:
           "$PY" -m pip install --upgrade pip
           "$PY" -m pip install .
 
-      - name: Build (macOS - app bundle only, no DMG yet)
-        if: matrix.os == 'macos-latest'
-        working-directory: electron
-        env:
-          # Pass only signing credentials - NOT notarization credentials.
-          # We build only the .app bundle here (target=dir); the DMG is created
-          # after post-signing so all binaries are properly signed before packaging.
-          CSC_LINK: ${{ secrets.APPLE_CERTIFICATE }}
-          CSC_KEY_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
-        run: pnpm run build:mac -- --dir
-
-      - name: Post-sign Python and PostgreSQL binaries in parallel
+      - name: Pre-sign Python and PostgreSQL binaries (macOS)
         if: matrix.os == 'macos-latest'
         env:
           CSC_LINK: ${{ secrets.APPLE_CERTIFICATE }}
           CSC_KEY_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
         run: |
-          # electron-builder signed the Electron framework files and skipped python/ and
-          # embedded-postgres/ via signIgnore. Now sign those two directories in parallel
-          # (8 workers) then re-sign the main .app bundle to seal the updated signatures.
-          APP_PATH="electron/dist/mac-arm64/Celerp.app"
+          # Sign all Mach-O binaries in the Python standalone and embedded-postgres
+          # node_modules BEFORE electron-builder runs. electron-builder will skip
+          # these directories via signIgnore, so their signatures are preserved.
+          #
+          # We use a dedicated short-lived keychain to avoid interfering with the
+          # electron-builder keychain that is created in the Build step.
           IDENTITY="EEC6C15E6827071A403257986E6379A650C62AFB"
+          CERT_PATH="$RUNNER_TEMP/presign.p12"
+          KEYCHAIN_PATH="$RUNNER_TEMP/presign.keychain-db"
 
-          # Set up a short-lived keychain for codesign
-          CERT_PATH="$RUNNER_TEMP/postsign.p12"
-          KEYCHAIN_PATH="$RUNNER_TEMP/postsign.keychain"
           echo "$CSC_LINK" | base64 --decode > "$CERT_PATH"
-          security create-keychain -p "postsign" "$KEYCHAIN_PATH"
+          security create-keychain -p "presign" "$KEYCHAIN_PATH"
           security set-keychain-settings -lut 3600 "$KEYCHAIN_PATH"
-          security unlock-keychain -p "postsign" "$KEYCHAIN_PATH"
+          security unlock-keychain -p "presign" "$KEYCHAIN_PATH"
           security import "$CERT_PATH" -k "$KEYCHAIN_PATH" -P "$CSC_KEY_PASSWORD" -T /usr/bin/codesign
           security list-keychain -d user -s "$KEYCHAIN_PATH" $(security list-keychain -d user | tr -d '"')
-          security set-key-partition-list -S apple-tool:,apple: -s -k "postsign" "$KEYCHAIN_PATH"
+          security set-key-partition-list -S apple-tool:,apple: -s -k "presign" "$KEYCHAIN_PATH"
           rm -f "$CERT_PATH"
 
           sign_macho_in_dir() {
             local dir="$1"
-            echo "Signing Mach-O binaries in: $dir"
+            echo "Pre-signing Mach-O binaries in: $dir"
             find "$dir" -type f -print0 | \
               xargs -0 -P 8 sh -c '
                 for f do
@@ -133,43 +123,24 @@ jobs:
                   fi
                 done
               ' _
+            echo "Done signing: $dir"
           }
 
-          sign_macho_in_dir "$APP_PATH/Contents/Resources/python"
-          sign_macho_in_dir "$APP_PATH/Contents/Resources/app.asar.unpacked/node_modules/@embedded-postgres"
+          sign_macho_in_dir "electron/python-standalone/mac-arm64/python"
+          sign_macho_in_dir "electron/node_modules/@embedded-postgres"
 
-          # Re-sign the top-level .app to incorporate the updated inner signatures
-          echo "Re-sealing main app bundle..."
-          codesign --force --sign "$IDENTITY" \
-            --timestamp --options runtime \
-            --entitlements electron/build/entitlements.mac.plist \
-            --keychain "$KEYCHAIN_PATH" \
-            "$APP_PATH"
-          echo "Post-signing complete."
+          # Remove presign keychain from the search list so electron-builder's
+          # own keychain setup is not confused by a second keychain containing
+          # the same certificate.
+          security list-keychain -d user -s $(security list-keychain -d user | tr -d '"' | grep -v presign)
 
-      - name: Package DMG (after post-signing)
+      - name: Build (macOS)
         if: matrix.os == 'macos-latest'
         working-directory: electron
         env:
           CSC_LINK: ${{ secrets.APPLE_CERTIFICATE }}
           CSC_KEY_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
-        run: |
-          # Build only the DMG from the already-signed .app bundle.
-          # electron-builder will re-use the existing dist/mac-arm64/Celerp.app.
-          pnpm run build:mac -- --prepackaged dist/mac-arm64/Celerp.app
-
-      - name: Verify Mac app is signed (fail build if not)
-        if: matrix.os == 'macos-latest'
-        run: |
-          APP_PATH="electron/dist/mac-arm64/Celerp.app"
-          echo "Verifying signature on $APP_PATH..."
-          codesign --verify --deep --strict --verbose=2 "$APP_PATH"
-          TEAM=$(codesign -dv "$APP_PATH" 2>&1 | grep TeamIdentifier | cut -d= -f2)
-          if [ -z "$TEAM" ] || [ "$TEAM" = "not set" ]; then
-            echo "ERROR: App is not signed with a Developer ID certificate."
-            exit 1
-          fi
-          echo "Signed OK. TeamIdentifier=$TEAM"
+        run: pnpm run build:mac
 
       - name: Notarize Mac DMG
         if: matrix.os == 'macos-latest'


### PR DESCRIPTION
## Problem

PR #74 (post-build parallel sign) failed notarization with `Invalid` status.

Root cause: `pnpm run build:mac -- --prepackaged dist/mac-arm64/Celerp.app` causes electron-builder to **re-sign the .app** when packaging the DMG, which overwrites the python/postgres signatures we just applied in the post-sign step. Apple then sees unsigned inner binaries → Invalid.

## Fix

Revert to pre-sign approach, with two key corrections over the previous attempt:

1. **Sign source dirs** (`electron/python-standalone/mac-arm64/` and `electron/node_modules/@embedded-postgres/`) BEFORE electron-builder copies them - so electron-builder copies already-signed binaries, then skips re-signing via `signIgnore`.
2. **Single build call**: `pnpm run build:mac` builds the full DMG directly. No `--dir` + `--prepackaged` split. No double build.
3. **Keychain cleanup**: presign keychain removed from search list before electron-builder runs to avoid cert conflict.

## Why this works

- electron-builder copies `python-standalone/mac-arm64/python/` → `Contents/Resources/python/`
- electron-builder copies `node_modules/@embedded-postgres/` → `Contents/Resources/app.asar.unpacked/node_modules/@embedded-postgres/`
- `signIgnore` tells electron-builder to skip both of those destination paths
- The binaries inside are already signed from the pre-sign step
- electron-builder signs only the Electron framework files (~20-50 files, ~1-2 min)
- DMG is produced in one shot → notarize that DMG