### PR TITLE
fix: increase notarization timeout to 2h

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
             pbs_triple: aarch64-apple-darwin
 
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 60
+    timeout-minutes: 180
 
     steps:
       - uses: actions/checkout@v4
@@ -144,7 +144,7 @@ jobs:
 
       - name: Notarize Mac DMG
         if: matrix.os == 'macos-latest'
-        timeout-minutes: 30
+        timeout-minutes: 130
         env:
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
@@ -157,7 +157,7 @@ jobs:
             --password "$APPLE_APP_SPECIFIC_PASSWORD" \
             --team-id "$APPLE_TEAM_ID" \
             --wait \
-            --timeout 25m \
+            --timeout 2h \
             --verbose
           echo "Stapling notarization ticket..."
           xcrun stapler staple "$DMG_PATH"


### PR DESCRIPTION
Notarization was timing out after 25m but Apple was still processing (status: In Progress). Increase notarytool --timeout to 2h, step timeout-minutes to 130, job timeout-minutes to 180.