### PR TITLE
fix: remove notarization from CI - notarize manually on Mac

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
             pbs_triple: aarch64-apple-darwin
 
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 180
+    timeout-minutes: 60
 
     steps:
       - uses: actions/checkout@v4
@@ -141,27 +141,6 @@ jobs:
           CSC_LINK: ${{ secrets.APPLE_CERTIFICATE }}
           CSC_KEY_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
         run: pnpm run build:mac
-
-      - name: Notarize Mac DMG
-        if: matrix.os == 'macos-latest'
-        timeout-minutes: 130
-        env:
-          APPLE_ID: ${{ secrets.APPLE_ID }}
-          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
-          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-        run: |
-          DMG_PATH=$(ls electron/dist/*.dmg | head -1)
-          echo "Submitting for notarization: $DMG_PATH"
-          xcrun notarytool submit "$DMG_PATH" \
-            --apple-id "$APPLE_ID" \
-            --password "$APPLE_APP_SPECIFIC_PASSWORD" \
-            --team-id "$APPLE_TEAM_ID" \
-            --wait \
-            --timeout 2h \
-            --verbose
-          echo "Stapling notarization ticket..."
-          xcrun stapler staple "$DMG_PATH"
-          echo "Notarization and stapling complete."
 
       - name: Build (Windows / Linux - no signing)
         if: matrix.os != 'macos-latest'


### PR DESCRIPTION
Apple notarization is unreliable in CI (queue times vary wildly, 90+ min waits). CI now produces a signed-but-unnotarized DMG and uploads it to releases. Notarization is done manually on Mac with `xcrun notarytool submit --wait` (no timeout), then the stapled DMG is uploaded to replace the release asset.