### PR TITLE
Electron build config tests + CI YML verification

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -124,6 +124,33 @@ jobs:
         run: ${{ matrix.build_cmd }}
 
 
+      - name: Verify YML artifact names
+        if: "!startsWith(github.ref, 'refs/tags/v')"
+        shell: bash
+        run: |
+          # Confirm electron-builder's generated YML files reference the stable filenames.
+          # This catches any regression where artifactName reverts to a versioned name.
+          FAIL=0
+          check_yml() {
+            local yml="$1" expected="$2"
+            if [ ! -f "$yml" ]; then
+              echo "SKIP: $yml not produced on this platform (expected)"
+              return
+            fi
+            if grep -q "url: $expected" "$yml"; then
+              echo "OK: $yml -> $expected"
+            else
+              echo "FAIL: $yml does not reference '$expected'"
+              echo "  Contents:"
+              cat "$yml"
+              FAIL=1
+            fi
+          }
+          check_yml electron/dist/latest-mac.yml   "Celerp-mac.dmg"
+          check_yml electron/dist/latest.yml        "Celerp-Setup.exe"
+          check_yml electron/dist/latest-linux.yml  "Celerp.AppImage"
+          exit $FAIL
+
       - name: Upload artifacts (dev builds only)
         if: "!startsWith(github.ref, 'refs/tags/v')"
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -97,7 +97,7 @@ jobs:
           APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: pnpm run build:mac -- --publish onTagOrDraft
+        run: pnpm run build:mac -- --publish always
 
       - name: Build macOS (dev - signed only, no notarization)
         if: matrix.os == 'macos-latest' && !startsWith(github.ref, 'refs/tags/v')
@@ -114,7 +114,7 @@ jobs:
         env:
           CSC_IDENTITY_AUTO_DISCOVERY: "false"
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: ${{ matrix.build_cmd }} -- --publish onTagOrDraft
+        run: ${{ matrix.build_cmd }} -- --publish always
 
       - name: Build (Windows / Linux - dev build)
         if: matrix.os != 'macos-latest' && !startsWith(github.ref, 'refs/tags/v')
@@ -124,17 +124,8 @@ jobs:
         run: ${{ matrix.build_cmd }}
 
 
-      - name: Normalize artifact names
-        shell: bash
-        run: |
-          cd electron/dist
-          # Static names so website download links never need updating.
-          for f in *.exe; do [ -f "$f" ] && mv "$f" Celerp-Setup.exe; done
-          for f in *.dmg; do [ -f "$f" ] && mv "$f" Celerp-mac.dmg; done
-          for f in *.AppImage; do [ -f "$f" ] && mv "$f" Celerp.AppImage; done
-          ls -la Celerp-* 2>/dev/null || echo "No matching artifacts"
-
-      - name: Upload artifacts
+      - name: Upload artifacts (dev builds only)
+        if: "!startsWith(github.ref, 'refs/tags/v')"
         uses: actions/upload-artifact@v4
         with:
           name: binaries-${{ matrix.os }}
@@ -143,17 +134,6 @@ jobs:
             electron/dist/Celerp-mac.dmg
             electron/dist/Celerp.AppImage
           if-no-files-found: warn
-
-      - name: Release (version tag)
-        if: startsWith(github.ref, 'refs/tags/v')
-        uses: softprops/action-gh-release@v2
-        with:
-          files: |
-            electron/dist/Celerp-Setup.exe
-            electron/dist/Celerp-mac.dmg
-            electron/dist/Celerp.AppImage
-          draft: false
-          prerelease: false
 
       - name: Release (dev build)
         if: "!startsWith(github.ref, 'refs/tags/v')"

--- a/electron/package.json
+++ b/electron/package.json
@@ -1,7 +1,7 @@
 {
   "name": "celerp",
   "version": "1.0.0",
-  "description": "Free business software — inventory, invoicing, and operations in one place.",
+  "description": "Free business software \u2014 inventory, invoicing, and operations in one place.",
   "main": "main.js",
   "author": "Data Universal Limited",
   "license": "BSL-1.1",
@@ -26,7 +26,7 @@
   "build": {
     "appId": "com.celerp.app",
     "productName": "Celerp",
-    "copyright": "Copyright © 2026 Data Universal Limited",
+    "copyright": "Copyright \u00a9 2026 Data Universal Limited",
     "directories": {
       "output": "dist"
     },
@@ -79,7 +79,8 @@
           "target": "nsis",
           "arch": [
             "x64"
-          ]
+          ],
+          "artifactName": "Celerp-Setup.exe"
         }
       ]
     },
@@ -95,7 +96,8 @@
           "target": "dmg",
           "arch": [
             "arm64"
-          ]
+          ],
+          "artifactName": "Celerp-mac.dmg"
         }
       ]
     },
@@ -107,7 +109,8 @@
           "target": "AppImage",
           "arch": [
             "x64"
-          ]
+          ],
+          "artifactName": "Celerp.AppImage"
         }
       ]
     },

--- a/tests/test_electron_build_config.py
+++ b/tests/test_electron_build_config.py
@@ -1,0 +1,53 @@
+"""
+Verify electron/package.json is configured for stable installer filenames.
+
+Stable names are required so that:
+  - Website download links never change
+  - electron-updater's latest-*.yml files reference the correct asset name
+"""
+import json
+from pathlib import Path
+
+_PKG = Path(__file__).parent.parent / "electron" / "package.json"
+
+
+def _artifact_names() -> dict[str, str]:
+    """Return {platform: artifactName} from the build config."""
+    pkg = json.loads(_PKG.read_text())
+    result: dict[str, str] = {}
+    for platform in ("mac", "win", "linux"):
+        targets = pkg["build"][platform]["target"]
+        # targets is a list of {target, arch, artifactName} objects
+        for t in targets:
+            if isinstance(t, dict) and "artifactName" in t:
+                result[platform] = t["artifactName"]
+                break
+    return result
+
+
+def test_stable_artifact_names():
+    """Each platform must use the stable filename that the website links to."""
+    names = _artifact_names()
+    assert names.get("mac") == "Celerp-mac.dmg", (
+        f"Mac artifactName must be 'Celerp-mac.dmg', got {names.get('mac')!r}. "
+        "Changing this breaks website download links and electron-updater YML references."
+    )
+    assert names.get("win") == "Celerp-Setup.exe", (
+        f"Win artifactName must be 'Celerp-Setup.exe', got {names.get('win')!r}."
+    )
+    assert names.get("linux") == "Celerp.AppImage", (
+        f"Linux artifactName must be 'Celerp.AppImage', got {names.get('linux')!r}."
+    )
+
+
+def test_all_platforms_have_artifact_name():
+    """Every platform target must declare an explicit artifactName (no implicit versioned names)."""
+    pkg = json.loads(_PKG.read_text())
+    for platform in ("mac", "win", "linux"):
+        targets = pkg["build"][platform]["target"]
+        for t in targets:
+            if isinstance(t, dict):
+                assert "artifactName" in t, (
+                    f"Platform '{platform}' target {t!r} is missing artifactName. "
+                    "electron-builder will fall back to a versioned name, breaking stable links."
+                )


### PR DESCRIPTION
## What
2 genuine new commits on top of main:

1. `fix: updater - static artifact names + let electron-builder publish yml metadata on tag builds` - fixes the root cause of electron-updater showing "up to date" incorrectly (missing/mismatched latest-*.yml files)
2. `Add electron build config tests and CI YML verification step` - pytest locks the 3 stable artifact names; CI step verifies electron-builder actually generates YML with correct urls after every dev build

## Why
PR #81 was a regular merge so develop had 81 commits relative to main. This branch is cherry-picked from main so it shows exactly the 2 new commits.

## Verification
- `pytest tests/test_electron_build_config.py` - 2 passed