### PR TITLE
fix: move artifactName to platform level in electron build config

### DIFF
--- a/electron/package.json
+++ b/electron/package.json
@@ -74,13 +74,13 @@
     ],
     "win": {
       "icon": "assets/icon.ico",
+      "artifactName": "Celerp-Setup.exe",
       "target": [
         {
           "target": "nsis",
           "arch": [
             "x64"
-          ],
-          "artifactName": "Celerp-Setup.exe"
+          ]
         }
       ]
     },
@@ -91,26 +91,26 @@
       "gatekeeperAssess": false,
       "entitlements": "build/entitlements.mac.plist",
       "entitlementsInherit": "build/entitlements.mac.plist",
+      "artifactName": "Celerp-mac.dmg",
       "target": [
         {
           "target": "dmg",
           "arch": [
             "arm64"
-          ],
-          "artifactName": "Celerp-mac.dmg"
+          ]
         }
       ]
     },
     "linux": {
       "icon": "assets/icon.png",
       "category": "Office",
+      "artifactName": "Celerp.AppImage",
       "target": [
         {
           "target": "AppImage",
           "arch": [
             "x64"
-          ],
-          "artifactName": "Celerp.AppImage"
+          ]
         }
       ]
     },

--- a/tests/test_electron_build_config.py
+++ b/tests/test_electron_build_config.py
@@ -16,12 +16,10 @@ def _artifact_names() -> dict[str, str]:
     pkg = json.loads(_PKG.read_text())
     result: dict[str, str] = {}
     for platform in ("mac", "win", "linux"):
-        targets = pkg["build"][platform]["target"]
-        # targets is a list of {target, arch, artifactName} objects
-        for t in targets:
-            if isinstance(t, dict) and "artifactName" in t:
-                result[platform] = t["artifactName"]
-                break
+        section = pkg["build"][platform]
+        # artifactName lives at the platform level (not inside target[])
+        if "artifactName" in section:
+            result[platform] = section["artifactName"]
     return result
 
 
@@ -41,13 +39,11 @@ def test_stable_artifact_names():
 
 
 def test_all_platforms_have_artifact_name():
-    """Every platform target must declare an explicit artifactName (no implicit versioned names)."""
+    """Every platform must declare an explicit artifactName at the platform level."""
     pkg = json.loads(_PKG.read_text())
     for platform in ("mac", "win", "linux"):
-        targets = pkg["build"][platform]["target"]
-        for t in targets:
-            if isinstance(t, dict):
-                assert "artifactName" in t, (
-                    f"Platform '{platform}' target {t!r} is missing artifactName. "
-                    "electron-builder will fall back to a versioned name, breaking stable links."
-                )
+        section = pkg["build"][platform]
+        assert "artifactName" in section, (
+            f"Platform '{platform}' is missing artifactName at the platform level. "
+            "electron-builder will fall back to a versioned name, breaking stable links."
+        )


### PR DESCRIPTION
Fixes build failure introduced in #83.

`artifactName` inside `target[]` objects is only valid for `dmg` (mac). For `win` (nsis) and `linux` (AppImage) it must sit at the platform level. Moved all three to platform level and updated the unit test to match.