### PR TITLE
fix: electron-builder uploads YML metadata on tag builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -106,7 +106,7 @@ jobs:
         env:
           CSC_LINK: ${{ secrets.APPLE_CERTIFICATE }}
           CSC_KEY_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
-        run: pnpm run build:mac
+        run: pnpm run build:mac -- --publish never
 
       - name: Build (Windows / Linux - release tag)
         if: matrix.os != 'macos-latest' && startsWith(github.ref, 'refs/tags/v')
@@ -121,7 +121,7 @@ jobs:
         working-directory: electron
         env:
           CSC_IDENTITY_AUTO_DISCOVERY: "false"
-        run: ${{ matrix.build_cmd }}
+        run: ${{ matrix.build_cmd }} -- --publish never
 
 
       - name: Verify YML artifact names

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,14 +21,17 @@ jobs:
         include:
           - os: ubuntu-latest
             build_cmd: pnpm run build:linux
+            platform_flag: --linux
             standalone_dir: linux-x64
             pbs_triple: x86_64-unknown-linux-gnu
           - os: windows-latest
             build_cmd: pnpm run build:win
+            platform_flag: --win
             standalone_dir: win-x64
             pbs_triple: x86_64-pc-windows-msvc
           - os: macos-latest
             build_cmd: pnpm run build:mac
+            platform_flag: --mac
             standalone_dir: mac-arm64
             pbs_triple: aarch64-apple-darwin
 
@@ -106,7 +109,7 @@ jobs:
         env:
           CSC_LINK: ${{ secrets.APPLE_CERTIFICATE }}
           CSC_KEY_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
-        run: pnpm run build:mac -- --publish never
+        run: pnpm exec electron-builder ${{ matrix.platform_flag }} --publish never
 
       - name: Build (Windows / Linux - release tag)
         if: matrix.os != 'macos-latest' && startsWith(github.ref, 'refs/tags/v')
@@ -121,7 +124,7 @@ jobs:
         working-directory: electron
         env:
           CSC_IDENTITY_AUTO_DISCOVERY: "false"
-        run: ${{ matrix.build_cmd }} -- --publish never
+        run: pnpm exec electron-builder ${{ matrix.platform_flag }} --publish never
 
 
       - name: Verify YML artifact names

--- a/electron/package.json
+++ b/electron/package.json
@@ -9,9 +9,9 @@
   "scripts": {
     "start": "electron .",
     "dev": "CELERP_DEV_MODE=1 electron .",
-    "build:win": "electron-builder --win --publish never",
-    "build:linux": "electron-builder --linux --publish never",
-    "build:mac": "electron-builder --mac --publish never",
+    "build:win": "electron-builder --win",
+    "build:linux": "electron-builder --linux",
+    "build:mac": "electron-builder --mac",
     "test": "NODE_ENV=development jest --forceExit"
   },
   "dependencies": {


### PR DESCRIPTION
Fix: remove `--publish never` from scripts so that electron updater works.