### PR TITLE
ci: clear release assets before upload to support retags

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,6 +89,33 @@ jobs:
           "$PY" -m pip install --upgrade pip
           "$PY" -m pip install .
 
+      - name: Clear existing release assets (retag support)
+        if: startsWith(github.ref, 'refs/tags/v')
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${GITHUB_REF_NAME}"
+          RELEASE_ID=$(curl -s -H "Authorization: token $GH_TOKEN" \
+            "https://api.github.com/repos/celerp/celerp/releases/tags/$TAG" | jq -r '.id // empty')
+          if [ -z "$RELEASE_ID" ]; then
+            echo "No existing release for $TAG - nothing to clear"
+            exit 0
+          fi
+          echo "Release $RELEASE_ID found for $TAG - clearing assets"
+          ASSET_IDS=$(curl -s -H "Authorization: token $GH_TOKEN" \
+            "https://api.github.com/repos/celerp/celerp/releases/$RELEASE_ID/assets" | jq -r '.[].id')
+          if [ -z "$ASSET_IDS" ]; then
+            echo "No assets to delete"
+            exit 0
+          fi
+          for ASSET_ID in $ASSET_IDS; do
+            echo "Deleting asset $ASSET_ID"
+            curl -s -X DELETE -H "Authorization: token $GH_TOKEN" \
+              "https://api.github.com/repos/celerp/celerp/releases/assets/$ASSET_ID"
+          done
+          echo "Assets cleared"
+
       - name: Build macOS (production - signed + notarized)
         if: matrix.os == 'macos-latest' && startsWith(github.ref, 'refs/tags/v')
         timeout-minutes: 130

--- a/electron/package.json
+++ b/electron/package.json
@@ -91,7 +91,6 @@
       "gatekeeperAssess": false,
       "entitlements": "build/entitlements.mac.plist",
       "entitlementsInherit": "build/entitlements.mac.plist",
-      "artifactName": "Celerp-mac.dmg",
       "target": [
         {
           "target": "dmg",
@@ -106,6 +105,9 @@
           ]
         }
       ]
+    },
+    "dmg": {
+      "artifactName": "Celerp-mac.dmg"
     },
     "linux": {
       "icon": "assets/icon.png",
@@ -130,7 +132,8 @@
       "provider": "github",
       "owner": "celerp",
       "repo": "celerp",
-      "releaseType": "release"
+      "releaseType": "release",
+      "allowOverwrite": true
     }
   },
   "jest": {

--- a/electron/package.json
+++ b/electron/package.json
@@ -132,8 +132,7 @@
       "provider": "github",
       "owner": "celerp",
       "repo": "celerp",
-      "releaseType": "release",
-      "allowOverwrite": true
+      "releaseType": "release"
     }
   },
   "jest": {

--- a/tests/test_electron_build_config.py
+++ b/tests/test_electron_build_config.py
@@ -40,13 +40,3 @@ def test_mac_has_zip_target():
         "electron-updater on macOS requires a zip for the update payload (dmg is for fresh installs only)."
     )
     assert "dmg" in targets, "Mac build is missing the 'dmg' target for fresh installs."
-
-
-def test_publish_allow_overwrite():
-    """publish.allowOverwrite must be true so re-tagging overwrites existing release assets."""
-    pkg = json.loads(_PKG.read_text())
-    publish = pkg["build"].get("publish", {})
-    assert publish.get("allowOverwrite") is True, (
-        "publish.allowOverwrite must be true. Without it, re-tagging silently skips uploading "
-        "assets that already exist on the release."
-    )

--- a/tests/test_electron_build_config.py
+++ b/tests/test_electron_build_config.py
@@ -11,39 +11,42 @@ from pathlib import Path
 _PKG = Path(__file__).parent.parent / "electron" / "package.json"
 
 
-def _artifact_names() -> dict[str, str]:
-    """Return {platform: artifactName} from the build config."""
-    pkg = json.loads(_PKG.read_text())
-    result: dict[str, str] = {}
-    for platform in ("mac", "win", "linux"):
-        section = pkg["build"][platform]
-        # artifactName lives at the platform level (not inside target[])
-        if "artifactName" in section:
-            result[platform] = section["artifactName"]
-    return result
-
-
 def test_stable_artifact_names():
     """Each platform must use the stable filename that the website links to."""
-    names = _artifact_names()
-    assert names.get("mac") == "Celerp-mac.dmg", (
-        f"Mac artifactName must be 'Celerp-mac.dmg', got {names.get('mac')!r}. "
-        "Changing this breaks website download links and electron-updater YML references."
-    )
-    assert names.get("win") == "Celerp-Setup.exe", (
-        f"Win artifactName must be 'Celerp-Setup.exe', got {names.get('win')!r}."
-    )
-    assert names.get("linux") == "Celerp.AppImage", (
-        f"Linux artifactName must be 'Celerp.AppImage', got {names.get('linux')!r}."
-    )
-
-
-def test_all_platforms_have_artifact_name():
-    """Every platform must declare an explicit artifactName at the platform level."""
     pkg = json.loads(_PKG.read_text())
-    for platform in ("mac", "win", "linux"):
-        section = pkg["build"][platform]
-        assert "artifactName" in section, (
-            f"Platform '{platform}' is missing artifactName at the platform level. "
-            "electron-builder will fall back to a versioned name, breaking stable links."
-        )
+    build = pkg["build"]
+
+    # mac: artifactName lives in the dedicated "dmg" section (not "mac" level,
+    # because "mac" also builds a zip and a platform-level name would apply to both)
+    assert build.get("dmg", {}).get("artifactName") == "Celerp-mac.dmg", (
+        f"dmg.artifactName must be 'Celerp-mac.dmg', got {build.get('dmg', {}).get('artifactName')!r}. "
+        "Changing this breaks website download links."
+    )
+    # win and linux: artifactName at the platform level
+    assert build["win"].get("artifactName") == "Celerp-Setup.exe", (
+        f"win.artifactName must be 'Celerp-Setup.exe', got {build['win'].get('artifactName')!r}."
+    )
+    assert build["linux"].get("artifactName") == "Celerp.AppImage", (
+        f"linux.artifactName must be 'Celerp.AppImage', got {build['linux'].get('artifactName')!r}."
+    )
+
+
+def test_mac_has_zip_target():
+    """Mac build must include a zip target so electron-updater can deliver updates."""
+    pkg = json.loads(_PKG.read_text())
+    targets = [t["target"] for t in pkg["build"]["mac"]["target"] if isinstance(t, dict)]
+    assert "zip" in targets, (
+        "Mac build is missing a 'zip' target. "
+        "electron-updater on macOS requires a zip for the update payload (dmg is for fresh installs only)."
+    )
+    assert "dmg" in targets, "Mac build is missing the 'dmg' target for fresh installs."
+
+
+def test_publish_allow_overwrite():
+    """publish.allowOverwrite must be true so re-tagging overwrites existing release assets."""
+    pkg = json.loads(_PKG.read_text())
+    publish = pkg["build"].get("publish", {})
+    assert publish.get("allowOverwrite") is True, (
+        "publish.allowOverwrite must be true. Without it, re-tagging silently skips uploading "
+        "assets that already exist on the release."
+    )


### PR DESCRIPTION
Adds a pre-upload step that deletes existing GitHub release assets for the current tag before electron-builder runs. This allows retags to overwrite assets cleanly without hitting the 2-hour electron-builder restriction.

- Exits cleanly if no release exists yet
- Deletes all existing assets if release exists
- No effect on dev (non-tag) builds