### PR TITLE
fix(electron): auto-updater, ShipIt fix, progress UI, log panel

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -111,8 +111,14 @@ jobs:
           fi
           for ASSET_ID in $ASSET_IDS; do
             echo "Deleting asset $ASSET_ID"
-            curl -s -X DELETE -H "Authorization: token $GH_TOKEN" \
-              "https://api.github.com/repos/celerp/celerp/releases/assets/$ASSET_ID"
+            STATUS=$(curl -s -o /dev/null -w "%{http_code}" -X DELETE \
+              -H "Authorization: token $GH_TOKEN" \
+              "https://api.github.com/repos/celerp/celerp/releases/assets/$ASSET_ID")
+            if [ "$STATUS" -ge 500 ]; then
+              echo "ERROR: DELETE asset $ASSET_ID returned HTTP $STATUS - aborting"
+              exit 1
+            fi
+            echo "Deleted asset $ASSET_ID (HTTP $STATUS)"
           done
           echo "Assets cleared"
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,6 +89,33 @@ jobs:
           "$PY" -m pip install --upgrade pip
           "$PY" -m pip install .
 
+      - name: Clear existing release assets (retag support)
+        if: startsWith(github.ref, 'refs/tags/v')
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${GITHUB_REF_NAME}"
+          RELEASE_ID=$(curl -s -H "Authorization: token $GH_TOKEN" \
+            "https://api.github.com/repos/celerp/celerp/releases/tags/$TAG" | jq -r '.id // empty')
+          if [ -z "$RELEASE_ID" ]; then
+            echo "No existing release for $TAG - nothing to clear"
+            exit 0
+          fi
+          echo "Release $RELEASE_ID found for $TAG - clearing assets"
+          ASSET_IDS=$(curl -s -H "Authorization: token $GH_TOKEN" \
+            "https://api.github.com/repos/celerp/celerp/releases/$RELEASE_ID/assets" | jq -r '.[].id')
+          if [ -z "$ASSET_IDS" ]; then
+            echo "No assets to delete"
+            exit 0
+          fi
+          for ASSET_ID in $ASSET_IDS; do
+            echo "Deleting asset $ASSET_ID"
+            curl -s -X DELETE -H "Authorization: token $GH_TOKEN" \
+              "https://api.github.com/repos/celerp/celerp/releases/assets/$ASSET_ID"
+          done
+          echo "Assets cleared"
+
       - name: Build macOS (production - signed + notarized)
         if: matrix.os == 'macos-latest' && startsWith(github.ref, 'refs/tags/v')
         timeout-minutes: 130

--- a/electron/main.js
+++ b/electron/main.js
@@ -552,8 +552,20 @@ ipcMain.handle("check-for-updates", () => {
 });
 
 // install-update: renderer triggers quit-and-install via window.celerp.installUpdate()
-ipcMain.on("install-update", () => {
-  autoUpdater.quitAndInstall();
+// ShipIt (Squirrel.Mac) aborts if ANY instance of the app is running when it tries to
+// replace the bundle. autoUpdater.quitAndInstall() calls app.quit() internally, but
+// Electron's process lingers long enough for ShipIt to see it and cancel. We kill
+// subprocesses first, then give them 500ms to exit before handing off to ShipIt.
+ipcMain.on("install-update", async () => {
+  if (uiProcess) uiProcess.kill();
+  if (apiProcess) apiProcess.kill();
+  if (pgInstance) {
+    try { await pgInstance.stop(); } catch (_) {}
+  }
+  // Small delay so OS can reap child processes before ShipIt checks
+  setTimeout(() => {
+    autoUpdater.quitAndInstall(true, true);
+  }, 500);
 });
 
 // get-version: renderer fetches the current app version

--- a/electron/main.js
+++ b/electron/main.js
@@ -493,13 +493,19 @@ function setupAutoUpdater() {
   });
 
   autoUpdater.on("download-progress", (progress) => {
-    sendLog(
-      "Downloading: " +
-        Math.round(progress.percent) +
-        "% (" +
-        Math.round(progress.bytesPerSecond / 1024) +
-        " KB/s)"
-    );
+    // Throttle log output to at most once per second to avoid flooding IPC/DOM.
+    // Progress bar updates are sent every tick (just a width change, cheap).
+    const now = Date.now();
+    if (!autoUpdater._lastProgressLog || now - autoUpdater._lastProgressLog >= 1000) {
+      autoUpdater._lastProgressLog = now;
+      sendLog(
+        "Downloading: " +
+          Math.round(progress.percent) +
+          "% (" +
+          Math.round(progress.bytesPerSecond / 1024) +
+          " KB/s)"
+      );
+    }
     if (mainWindow) mainWindow.webContents.send("download-progress", progress);
   });
 
@@ -517,7 +523,17 @@ function setupAutoUpdater() {
     if (mainWindow) mainWindow.webContents.send("update-not-available");
   });
 
-  autoUpdater.checkForUpdates().catch(() => {}); // errors handled by the "error" event above
+  // Delay initial check until the renderer has loaded and registered its IPC handlers.
+  // Firing immediately at app-ready risks emitting update-available/log events before
+  // the renderer's ipcRenderer.on(...) calls have run, silently dropping them.
+  if (mainWindow) {
+    mainWindow.webContents.once("did-finish-load", () => {
+      autoUpdater.checkForUpdates().catch(() => {}); // errors handled by the "error" event above
+    });
+  } else {
+    // Fallback: mainWindow not yet created (shouldn't happen in normal flow)
+    autoUpdater.checkForUpdates().catch(() => {});
+  }
 }
 
 function createWindow() {

--- a/electron/main.js
+++ b/electron/main.js
@@ -474,22 +474,46 @@ function setupAutoUpdater() {
   autoUpdater.autoInstallOnAppQuit = true;
   autoUpdater.allowPrerelease = false;
 
+  function sendLog(msg) {
+    if (mainWindow) mainWindow.webContents.send("update-log", String(msg));
+  }
+
+  autoUpdater.on("checking-for-update", () => {
+    sendLog("Checking for update...");
+  });
+
   autoUpdater.on("update-available", (info) => {
+    sendLog("Found version " + info.version + " — downloading...");
     if (mainWindow) mainWindow.webContents.send("update-available", info);
   });
 
   autoUpdater.on("update-not-available", () => {
+    sendLog("Already up to date.");
     if (mainWindow) mainWindow.webContents.send("update-not-available");
   });
 
+  autoUpdater.on("download-progress", (progress) => {
+    sendLog(
+      "Downloading: " +
+        Math.round(progress.percent) +
+        "% (" +
+        Math.round(progress.bytesPerSecond / 1024) +
+        " KB/s)"
+    );
+    if (mainWindow) mainWindow.webContents.send("download-progress", progress);
+  });
+
   autoUpdater.on("update-downloaded", (info) => {
+    sendLog("Download complete — ready to install v" + info.version);
     if (mainWindow) mainWindow.webContents.send("update-downloaded", info);
   });
 
   autoUpdater.on("error", (err) => {
     // Log only — update failures must never interrupt the user's work.
     // Also notify renderer so the UI can reset from "Checking..." state.
-    console.error("[updater] error:", err?.message ?? String(err));
+    const msg = err?.message ?? String(err);
+    console.error("[updater] error:", msg);
+    sendLog("Error: " + msg);
     if (mainWindow) mainWindow.webContents.send("update-not-available");
   });
 

--- a/electron/package.json
+++ b/electron/package.json
@@ -91,7 +91,6 @@
       "gatekeeperAssess": false,
       "entitlements": "build/entitlements.mac.plist",
       "entitlementsInherit": "build/entitlements.mac.plist",
-      "artifactName": "Celerp-mac.dmg",
       "target": [
         {
           "target": "dmg",
@@ -106,6 +105,9 @@
           ]
         }
       ]
+    },
+    "dmg": {
+      "artifactName": "Celerp-mac.dmg"
     },
     "linux": {
       "icon": "assets/icon.png",
@@ -130,7 +132,8 @@
       "provider": "github",
       "owner": "celerp",
       "repo": "celerp",
-      "releaseType": "release"
+      "releaseType": "release",
+      "allowOverwrite": true
     }
   },
   "jest": {

--- a/electron/package.json
+++ b/electron/package.json
@@ -132,8 +132,7 @@
       "provider": "github",
       "owner": "celerp",
       "repo": "celerp",
-      "releaseType": "release",
-      "allowOverwrite": true
+      "releaseType": "release"
     }
   },
   "jest": {

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -29,6 +29,12 @@ contextBridge.exposeInMainWorld("celerp", {
   // Register a callback for when no update is available (or an error occurred).
   onUpdateNotAvailable: (cb) => ipcRenderer.on("update-not-available", () => cb()),
 
+  // Register a callback for download progress events ({ percent, bytesPerSecond, transferred, total }).
+  onDownloadProgress: (cb) => ipcRenderer.on("download-progress", (_event, progress) => cb(progress)),
+
+  // Register a callback for updater log lines (string).
+  onUpdateLog: (cb) => ipcRenderer.on("update-log", (_event, msg) => cb(msg)),
+
   // Trigger a manual update check.
   checkForUpdates: () => ipcRenderer.invoke("check-for-updates"),
 

--- a/tests/test_electron_build_config.py
+++ b/tests/test_electron_build_config.py
@@ -40,13 +40,3 @@ def test_mac_has_zip_target():
         "electron-updater on macOS requires a zip for the update payload (dmg is for fresh installs only)."
     )
     assert "dmg" in targets, "Mac build is missing the 'dmg' target for fresh installs."
-
-
-def test_publish_allow_overwrite():
-    """publish.allowOverwrite must be true so re-tagging overwrites existing release assets."""
-    pkg = json.loads(_PKG.read_text())
-    publish = pkg["build"].get("publish", {})
-    assert publish.get("allowOverwrite") is True, (
-        "publish.allowOverwrite must be true. Without it, re-tagging silently skips uploading "
-        "assets that already exist on the release."
-    )

--- a/tests/test_electron_build_config.py
+++ b/tests/test_electron_build_config.py
@@ -11,39 +11,42 @@ from pathlib import Path
 _PKG = Path(__file__).parent.parent / "electron" / "package.json"
 
 
-def _artifact_names() -> dict[str, str]:
-    """Return {platform: artifactName} from the build config."""
-    pkg = json.loads(_PKG.read_text())
-    result: dict[str, str] = {}
-    for platform in ("mac", "win", "linux"):
-        section = pkg["build"][platform]
-        # artifactName lives at the platform level (not inside target[])
-        if "artifactName" in section:
-            result[platform] = section["artifactName"]
-    return result
-
-
 def test_stable_artifact_names():
     """Each platform must use the stable filename that the website links to."""
-    names = _artifact_names()
-    assert names.get("mac") == "Celerp-mac.dmg", (
-        f"Mac artifactName must be 'Celerp-mac.dmg', got {names.get('mac')!r}. "
-        "Changing this breaks website download links and electron-updater YML references."
-    )
-    assert names.get("win") == "Celerp-Setup.exe", (
-        f"Win artifactName must be 'Celerp-Setup.exe', got {names.get('win')!r}."
-    )
-    assert names.get("linux") == "Celerp.AppImage", (
-        f"Linux artifactName must be 'Celerp.AppImage', got {names.get('linux')!r}."
-    )
-
-
-def test_all_platforms_have_artifact_name():
-    """Every platform must declare an explicit artifactName at the platform level."""
     pkg = json.loads(_PKG.read_text())
-    for platform in ("mac", "win", "linux"):
-        section = pkg["build"][platform]
-        assert "artifactName" in section, (
-            f"Platform '{platform}' is missing artifactName at the platform level. "
-            "electron-builder will fall back to a versioned name, breaking stable links."
-        )
+    build = pkg["build"]
+
+    # mac: artifactName lives in the dedicated "dmg" section (not "mac" level,
+    # because "mac" also builds a zip and a platform-level name would apply to both)
+    assert build.get("dmg", {}).get("artifactName") == "Celerp-mac.dmg", (
+        f"dmg.artifactName must be 'Celerp-mac.dmg', got {build.get('dmg', {}).get('artifactName')!r}. "
+        "Changing this breaks website download links."
+    )
+    # win and linux: artifactName at the platform level
+    assert build["win"].get("artifactName") == "Celerp-Setup.exe", (
+        f"win.artifactName must be 'Celerp-Setup.exe', got {build['win'].get('artifactName')!r}."
+    )
+    assert build["linux"].get("artifactName") == "Celerp.AppImage", (
+        f"linux.artifactName must be 'Celerp.AppImage', got {build['linux'].get('artifactName')!r}."
+    )
+
+
+def test_mac_has_zip_target():
+    """Mac build must include a zip target so electron-updater can deliver updates."""
+    pkg = json.loads(_PKG.read_text())
+    targets = [t["target"] for t in pkg["build"]["mac"]["target"] if isinstance(t, dict)]
+    assert "zip" in targets, (
+        "Mac build is missing a 'zip' target. "
+        "electron-updater on macOS requires a zip for the update payload (dmg is for fresh installs only)."
+    )
+    assert "dmg" in targets, "Mac build is missing the 'dmg' target for fresh installs."
+
+
+def test_publish_allow_overwrite():
+    """publish.allowOverwrite must be true so re-tagging overwrites existing release assets."""
+    pkg = json.loads(_PKG.read_text())
+    publish = pkg["build"].get("publish", {})
+    assert publish.get("allowOverwrite") is True, (
+        "publish.allowOverwrite must be true. Without it, re-tagging silently skips uploading "
+        "assets that already exist on the release."
+    )

--- a/tests/test_electron_build_config.py
+++ b/tests/test_electron_build_config.py
@@ -261,3 +261,112 @@ def test_css_has_progress_bar_styles():
         "The log panel will have no styling."
     )
 
+
+
+# ---------------------------------------------------------------------------
+# Additional regression tests for Copilot review fixes
+# ---------------------------------------------------------------------------
+
+def test_main_initial_check_deferred_until_did_finish_load():
+    """The initial autoUpdater.checkForUpdates() must fire after did-finish-load.
+
+    Firing immediately at app-ready risks emitting IPC events before the renderer
+    has registered its ipcRenderer.on(...) handlers, silently dropping them.
+    """
+    src = _main_src()
+    assert "did-finish-load" in src, (
+        "main.js does not wait for 'did-finish-load' before calling the initial "
+        "checkForUpdates(). Events emitted before the renderer loads are silently dropped."
+    )
+    # The initial checkForUpdates call must be inside a did-finish-load callback
+    finish_load_idx = src.find("did-finish-load")
+    check_idx = src.find("checkForUpdates", finish_load_idx)
+    assert check_idx != -1, (
+        "checkForUpdates() is not called inside the did-finish-load handler. "
+        "Initial update checks may fire before the renderer is ready."
+    )
+
+
+def test_main_download_progress_log_throttled():
+    """download-progress handler must throttle sendLog calls (not log every tick).
+
+    download-progress fires many times per second. Logging every tick floods IPC
+    and causes excessive DOM work in the renderer.
+    """
+    src = _main_src()
+    # Find the download-progress handler
+    dp_idx = src.find('"download-progress"')
+    assert dp_idx != -1, "download-progress handler not found"
+    handler_block = src[dp_idx: dp_idx + 600]
+    # Must have some form of time-based throttle
+    assert "Date.now()" in handler_block or "throttle" in handler_block or "_lastProgressLog" in handler_block, (
+        "download-progress handler does not throttle sendLog calls. "
+        "Every progress tick will send an IPC message and trigger a DOM update."
+    )
+
+
+def test_main_download_progress_bar_unthrottled():
+    """Progress bar IPC must NOT be throttled - only the log sendLog call is throttled.
+
+    The bar update is a cheap CSS width change; throttling it would make it look laggy.
+    """
+    src = _main_src()
+    dp_idx = src.find('"download-progress"')
+    # Use a wider window - the handler can be longer than 600 chars
+    handler_block = src[dp_idx: dp_idx + 900]
+    assert 'send("download-progress"' in handler_block or "send('download-progress'" in handler_block, (
+        "download-progress IPC send to renderer not found in the handler block."
+    )
+
+
+def test_shell_append_log_uses_dom_append_not_text_content():
+    """appendLog must use DOM appendChild, not textContent +=.
+
+    textContent += re-reads and rewrites the entire string every call - O(n) per append.
+    With frequent progress events this causes jank.
+    """
+    src = _shell_src()
+    al_idx = src.find("function appendLog")
+    assert al_idx != -1, "appendLog function not found in shell.py"
+    func_block = src[al_idx: al_idx + 800]
+    assert "appendChild" in func_block, (
+        "appendLog uses textContent += instead of DOM appendChild. "
+        "This is O(n) per call and causes jank during frequent progress events."
+    )
+    # The O(n) pattern: logEl.textContent += should NOT appear inside appendLog
+    assert "logEl.textContent +=" not in func_block, (
+        "appendLog still uses textContent += concatenation. Replace with appendChild."
+    )
+
+
+def test_shell_append_log_caps_line_count():
+    """appendLog must cap the number of retained log lines to prevent DOM bloat."""
+    src = _shell_src()
+    al_idx = src.find("function appendLog")
+    func_block = src[al_idx: al_idx + 500]
+    assert "200" in func_block or "remove()" in func_block, (
+        "appendLog does not cap retained log lines. "
+        "Long downloads will accumulate hundreds of DOM nodes."
+    )
+
+
+def test_build_yml_delete_checks_http_status():
+    """build.yml asset deletion must check HTTP status and fail on 5xx errors.
+
+    Using curl -s without status checking means a failed delete (5xx) goes unnoticed,
+    and the subsequent publish step may fail with 'asset already exists'.
+    Using -f/-fsS would fail on 404 (asset not yet uploaded on first build), so we
+    check the status code explicitly and only fail on >= 500.
+    """
+    yml = (Path(__file__).parent.parent / ".github" / "workflows" / "build.yml").read_text()
+    clear_idx = yml.find("Clear existing release assets")
+    assert clear_idx != -1, "Asset-clearing step not found in build.yml"
+    step_block = yml[clear_idx: clear_idx + 1500]
+    assert "%{http_code}" in step_block, (
+        "build.yml DELETE step does not capture HTTP status code. "
+        "Use curl -w '%{http_code}' and fail on >= 500."
+    )
+    assert ">= 500" in step_block or "-ge 500" in step_block, (
+        "build.yml DELETE step does not fail on 5xx responses. "
+        "A server-side delete failure will silently allow a stale asset to remain."
+    )

--- a/tests/test_electron_build_config.py
+++ b/tests/test_electron_build_config.py
@@ -6,9 +6,12 @@ Stable names are required so that:
   - electron-updater's latest-*.yml files reference the correct asset name
 """
 import json
+import re
 from pathlib import Path
 
 _PKG = Path(__file__).parent.parent / "electron" / "package.json"
+_MAIN = Path(__file__).parent.parent / "electron" / "main.js"
+_PRELOAD = Path(__file__).parent.parent / "electron" / "preload.js"
 
 
 def test_stable_artifact_names():
@@ -40,3 +43,221 @@ def test_mac_has_zip_target():
         "electron-updater on macOS requires a zip for the update payload (dmg is for fresh installs only)."
     )
     assert "dmg" in targets, "Mac build is missing the 'dmg' target for fresh installs."
+
+
+# ---------------------------------------------------------------------------
+# main.js: updater event wiring
+# ---------------------------------------------------------------------------
+
+def _main_src() -> str:
+    return _MAIN.read_text()
+
+
+def test_main_emits_download_progress_ipc():
+    """main.js must listen to download-progress and forward it to the renderer."""
+    src = _main_src()
+    assert '"download-progress"' in src or "'download-progress'" in src, (
+        "main.js does not listen to the electron-updater 'download-progress' event. "
+        "The progress bar will never update."
+    )
+    assert "download-progress" in src and "send" in src, (
+        "main.js must call mainWindow.webContents.send('download-progress', ...) "
+        "to forward progress events to the renderer."
+    )
+
+
+def test_main_emits_update_log_ipc():
+    """main.js must send 'update-log' IPC messages to the renderer for the log panel."""
+    src = _main_src()
+    assert '"update-log"' in src or "'update-log'" in src, (
+        "main.js does not emit 'update-log' IPC messages. "
+        "The log panel in the update card will never receive any text."
+    )
+
+
+def test_main_listens_checking_for_update():
+    """main.js must handle the 'checking-for-update' autoUpdater event to log it."""
+    src = _main_src()
+    assert "checking-for-update" in src, (
+        "main.js does not handle the 'checking-for-update' autoUpdater event. "
+        "The log panel will show no entry when a check begins."
+    )
+
+
+def test_main_kill_subprocesses_before_quit_and_install():
+    """main.js must kill uiProcess/apiProcess before calling quitAndInstall.
+
+    ShipIt (Squirrel.Mac) aborts if the app process is still alive when it tries
+    to replace the bundle. Killing child processes first lets the OS reap them
+    before ShipIt does its check.
+    """
+    src = _main_src()
+    # Find the install-update handler block
+    match = re.search(r'ipcMain\.on\(["\']install-update["\'].*?}\);', src, re.DOTALL)
+    assert match, "ipcMain.on('install-update', ...) handler not found in main.js"
+    handler = match.group(0)
+    assert "uiProcess" in handler and ".kill()" in handler, (
+        "install-update handler must kill uiProcess before calling quitAndInstall."
+    )
+    assert "apiProcess" in handler and ".kill()" in handler, (
+        "install-update handler must kill apiProcess before calling quitAndInstall."
+    )
+    assert "quitAndInstall" in handler, (
+        "install-update handler must call autoUpdater.quitAndInstall()."
+    )
+    # The kill must come before quitAndInstall in source order
+    kill_pos = handler.index(".kill()")
+    quit_pos = handler.index("quitAndInstall")
+    assert kill_pos < quit_pos, (
+        "uiProcess/apiProcess must be killed BEFORE quitAndInstall is called, "
+        "otherwise ShipIt sees the app still running and aborts the install."
+    )
+
+
+# ---------------------------------------------------------------------------
+# preload.js: IPC bridge completeness
+# ---------------------------------------------------------------------------
+
+def _preload_src() -> str:
+    return _PRELOAD.read_text()
+
+
+def test_preload_exposes_on_download_progress():
+    """preload.js must expose onDownloadProgress so the renderer can show the progress bar."""
+    src = _preload_src()
+    assert "onDownloadProgress" in src, (
+        "preload.js does not expose 'onDownloadProgress'. "
+        "The renderer cannot receive download-progress events and the progress bar will never update."
+    )
+    assert "download-progress" in src, (
+        "preload.js must listen on the 'download-progress' IPC channel in onDownloadProgress."
+    )
+
+
+def test_preload_exposes_on_update_log():
+    """preload.js must expose onUpdateLog so the renderer can populate the log panel."""
+    src = _preload_src()
+    assert "onUpdateLog" in src, (
+        "preload.js does not expose 'onUpdateLog'. "
+        "The renderer cannot receive log lines and the log panel will stay empty."
+    )
+    assert "update-log" in src, (
+        "preload.js must listen on the 'update-log' IPC channel in onUpdateLog."
+    )
+
+
+def test_preload_exposes_required_updater_api():
+    """preload.js must expose the full updater API surface."""
+    src = _preload_src()
+    required = [
+        "onUpdateAvailable",
+        "onUpdateDownloaded",
+        "onUpdateNotAvailable",
+        "onDownloadProgress",
+        "onUpdateLog",
+        "checkForUpdates",
+        "installUpdate",
+    ]
+    for name in required:
+        assert name in src, (
+            f"preload.js is missing '{name}'. "
+            f"The renderer will throw when it tries to call window.celerp.{name}()."
+        )
+
+
+# ---------------------------------------------------------------------------
+# shell.py: update card HTML structure
+# ---------------------------------------------------------------------------
+
+def _shell_src() -> str:
+    shell = Path(__file__).parent.parent / "ui" / "components" / "shell.py"
+    return shell.read_text()
+
+
+def test_shell_has_progress_bar_element():
+    """shell.py must render a progress bar element inside the update card."""
+    src = _shell_src()
+    assert "update-card__progress-bar" in src, (
+        "shell.py is missing the '.update-card__progress-bar' element. "
+        "The progress bar will not appear during downloads."
+    )
+    assert "update-card__progress-fill" in src, (
+        "shell.py is missing the '.update-card__progress-fill' element. "
+        "The JS cannot animate the progress bar width."
+    )
+
+
+def test_shell_has_log_element():
+    """shell.py must render a log <pre> element inside the update card."""
+    src = _shell_src()
+    assert "update-card__log" in src, (
+        "shell.py is missing the '.update-card__log' element. "
+        "Updater log lines have nowhere to go."
+    )
+
+
+def test_shell_check_btn_hides_on_click():
+    """The JS in shell.py must call setCheckBtn(false) when the check button is clicked."""
+    src = _shell_src()
+    # setCheckBtn(false) hides the button; must appear in the checkBtn click handler
+    assert "setCheckBtn(false)" in src, (
+        "shell.py JS does not call setCheckBtn(false) anywhere. "
+        "The check button will remain visible while checking/downloading."
+    )
+
+
+def test_shell_check_btn_hidden_on_update_available():
+    """When an update is found, the check button must be hidden (not just disabled)."""
+    src = _shell_src()
+    # onUpdateAvailable callback must hide the check button
+    # Find the onUpdateAvailable block - look for setCheckBtn(false) near it
+    oa_idx = src.find("onUpdateAvailable")
+    assert oa_idx != -1, "onUpdateAvailable not found in shell.py"
+    # Within 300 chars of the onUpdateAvailable callback, setCheckBtn(false) must appear
+    nearby = src[oa_idx: oa_idx + 400]
+    assert "setCheckBtn(false)" in nearby, (
+        "onUpdateAvailable handler does not call setCheckBtn(false). "
+        "The check button will remain visible while a download is in progress."
+    )
+
+
+def test_shell_check_btn_shown_on_not_available():
+    """When no update is found, the check button must be shown again."""
+    src = _shell_src()
+    na_idx = src.find("onUpdateNotAvailable")
+    assert na_idx != -1, "onUpdateNotAvailable not found in shell.py"
+    nearby = src[na_idx: na_idx + 300]
+    assert "setCheckBtn(true)" in nearby or "resetToIdle" in nearby, (
+        "onUpdateNotAvailable handler does not restore the check button. "
+        "The button will stay hidden after a successful 'already up to date' check."
+    )
+
+
+def test_shell_restart_btn_disables_on_click():
+    """The restart button must disable itself when clicked to prevent double-clicks."""
+    src = _shell_src()
+    rb_idx = src.find("restartBtn.addEventListener")
+    assert rb_idx != -1, "restartBtn click listener not found in shell.py"
+    nearby = src[rb_idx: rb_idx + 300]
+    assert "disabled = true" in nearby or ".disabled" in nearby, (
+        "restartBtn click handler does not disable the button. "
+        "Users could click it multiple times and trigger multiple install calls."
+    )
+
+
+def test_css_has_progress_bar_styles():
+    """app.css must define styles for the progress bar elements."""
+    css = (Path(__file__).parent.parent / "ui" / "static" / "app.css").read_text()
+    assert ".update-card__progress-bar" in css, (
+        "app.css is missing .update-card__progress-bar styles. "
+        "The progress bar will be invisible."
+    )
+    assert ".update-card__progress-fill" in css, (
+        "app.css is missing .update-card__progress-fill styles. "
+        "The fill animation will not work."
+    )
+    assert ".update-card__log" in css, (
+        "app.css is missing .update-card__log styles. "
+        "The log panel will have no styling."
+    )
+

--- a/ui/components/shell.py
+++ b/ui/components/shell.py
@@ -427,7 +427,14 @@ document.addEventListener('DOMContentLoaded', function() {
     function appendLog(msg) {
       if (!logEl) return;
       logEl.style.display = '';
-      logEl.textContent += (logEl.textContent ? '\n' : '') + msg;
+      // Append via text node (avoids re-reading/rewriting the full textContent string).
+      // Cap at 200 lines to prevent unbounded DOM growth during long downloads.
+      var lines = logEl.querySelectorAll('.log-line');
+      if (lines.length >= 200) lines[0].remove();
+      var line = document.createElement('span');
+      line.className = 'log-line';
+      line.textContent = (logEl.childNodes.length ? '\n' : '') + msg;
+      logEl.appendChild(line);
       logEl.scrollTop = logEl.scrollHeight;
     }
 

--- a/ui/components/shell.py
+++ b/ui/components/shell.py
@@ -411,10 +411,35 @@ document.addEventListener('DOMContentLoaded', function() {
     var stateEl = card.querySelector('.update-card__state');
     var checkBtn = card.querySelector('.update-card__check-btn');
     var restartBtn = card.querySelector('.update-card__restart-btn');
+    var progressBar = card.querySelector('.update-card__progress-bar');
+    var progressFill = card.querySelector('.update-card__progress-fill');
+    var logEl = card.querySelector('.update-card__log');
 
     function setState(text, showRestart) {
       if (stateEl) stateEl.textContent = text;
       if (restartBtn) restartBtn.style.display = showRestart ? '' : 'none';
+    }
+
+    function setCheckBtn(visible) {
+      if (checkBtn) checkBtn.style.display = visible ? '' : 'none';
+    }
+
+    function appendLog(msg) {
+      if (!logEl) return;
+      logEl.style.display = '';
+      logEl.textContent += (logEl.textContent ? '\n' : '') + msg;
+      logEl.scrollTop = logEl.scrollHeight;
+    }
+
+    function setProgress(pct) {
+      if (!progressBar || !progressFill) return;
+      progressBar.style.display = pct >= 0 ? '' : 'none';
+      progressFill.style.width = Math.min(100, Math.max(0, pct)) + '%';
+    }
+
+    function resetToIdle() {
+      setCheckBtn(true);
+      setProgress(-1);
     }
 
     if (window.celerp) {
@@ -425,43 +450,47 @@ document.addEventListener('DOMContentLoaded', function() {
 
       setState('Up to date', false);
 
-      function resetCheckBtn() {
-        if (checkBtn) {
-          checkBtn.disabled = false;
-          checkBtn.textContent = 'Check for updates';
-        }
-      }
+      window.celerp.onUpdateLog(function(msg) {
+        appendLog(msg);
+      });
 
-      window.celerp.onUpdateAvailable(function() {
-        setState('Update available - downloading...', false);
-        resetCheckBtn();
+      window.celerp.onUpdateAvailable(function(info) {
+        setState('Downloading v' + (info && info.version ? info.version : 'update') + '...', false);
+        setCheckBtn(false);
+        setProgress(0);
+      });
+
+      window.celerp.onDownloadProgress(function(progress) {
+        setProgress(progress.percent || 0);
       });
 
       window.celerp.onUpdateNotAvailable(function() {
         setState('Up to date', false);
-        resetCheckBtn();
+        resetToIdle();
       });
 
       window.celerp.onUpdateDownloaded(function(info) {
-        setState('Restart to install v' + info.version, true);
-        resetCheckBtn();
+        setState('Ready to install v' + info.version, true);
+        setProgress(100);
+        setCheckBtn(false);
       });
 
       if (checkBtn) {
         checkBtn.addEventListener('click', function() {
-          checkBtn.disabled = true;
-          checkBtn.textContent = '...';
+          setCheckBtn(false);
           setState('Checking...', false);
-          // Button re-enabled by onUpdateAvailable / onUpdateNotAvailable / error path
+          if (logEl) { logEl.textContent = ''; logEl.style.display = 'none'; }
           window.celerp.checkForUpdates().catch(function() {
             setState('Up to date', false);
-            resetCheckBtn();
+            resetToIdle();
           });
         });
       }
 
       if (restartBtn) {
         restartBtn.addEventListener('click', function() {
+          restartBtn.disabled = true;
+          restartBtn.textContent = 'Restarting...';
           window.celerp.installUpdate();
         });
       }
@@ -615,6 +644,14 @@ def _topbar(companies: list[dict], lang: str = "en", user_email: str | None = No
                         cls="update-card__info",
                     ),
                     Div(
+                        # Progress bar (hidden until download starts)
+                        Div(
+                            Div(cls="update-card__progress-fill"),
+                            cls="update-card__progress-bar",
+                            style="display:none;",
+                        ),
+                        # Scrolling log (hidden until first log line)
+                        Pre(cls="update-card__log", style="display:none;"),
                         Button(t("btn.check_for_updates"), cls="update-card__check-btn", type="button"),
                         Button(t("btn.restart_to_install"), cls="update-card__restart-btn", type="button",
                                style="display:none;"),

--- a/ui/static/app.css
+++ b/ui/static/app.css
@@ -2032,6 +2032,37 @@ a:hover { text-decoration: underline; }
   border-color: var(--c-primary);
 }
 .update-card__restart-btn:hover { opacity: 0.9; }
+.update-card__progress-bar {
+  width: 100%;
+  height: 6px;
+  background: var(--c-border);
+  border-radius: 3px;
+  overflow: hidden;
+  margin-bottom: 6px;
+}
+.update-card__progress-fill {
+  height: 100%;
+  width: 0%;
+  background: var(--c-primary);
+  border-radius: 3px;
+  transition: width 0.3s ease;
+}
+.update-card__log {
+  width: 100%;
+  max-height: 100px;
+  overflow-y: auto;
+  background: #fff;
+  border: 1px solid var(--c-border);
+  border-radius: 4px;
+  padding: 6px 8px;
+  font-size: 11px;
+  font-family: monospace;
+  color: var(--c-text2);
+  white-space: pre-wrap;
+  word-break: break-all;
+  margin-bottom: 6px;
+  box-sizing: border-box;
+}
 
 /* ── Report KPI/summary bar ─────────────────────────────────────────── */
 .report-summary-bar { display: flex; gap: 1.5rem; flex-wrap: wrap; padding: 10px 14px; background: var(--c-bg3); border: 1px solid var(--c-border); border-radius: 6px; margin-bottom: 12px; }


### PR DESCRIPTION
## Summary

All Electron auto-updater fixes since main:

**Runtime fixes**
- `fix(updater): kill subprocesses before quitAndInstall` - ShipIt was aborting with "App Still Running Error" because Electron was still alive when ShipIt tried to replace the bundle. Now kills uiProcess/apiProcess first with 500ms grace period.

**Update card UI**
- `feat(updater): progress bar, log stream, check button visibility` - progress bar during download, scrollable log panel showing updater events, check button hides while busy