### PR TITLE
fix(ci): correct conftest paths, tracker-reload test, Windows jq fix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -97,14 +97,16 @@ jobs:
         run: |
           TAG="${GITHUB_REF_NAME}"
           RELEASE_ID=$(curl -s -H "Authorization: token $GH_TOKEN" \
-            "https://api.github.com/repos/celerp/celerp/releases/tags/$TAG" | jq -r '.id // empty')
+            "https://api.github.com/repos/celerp/celerp/releases/tags/$TAG" \
+            | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('id',''))" 2>/dev/null || true)
           if [ -z "$RELEASE_ID" ]; then
             echo "No existing release for $TAG - nothing to clear"
             exit 0
           fi
           echo "Release $RELEASE_ID found for $TAG - clearing assets"
           ASSET_IDS=$(curl -s -H "Authorization: token $GH_TOKEN" \
-            "https://api.github.com/repos/celerp/celerp/releases/$RELEASE_ID/assets" | jq -r '.[].id')
+            "https://api.github.com/repos/celerp/celerp/releases/$RELEASE_ID/assets" \
+            | python3 -c "import sys,json; [print(a['id']) for a in json.load(sys.stdin)]" 2>/dev/null || true)
           if [ -z "$ASSET_IDS" ]; then
             echo "No assets to delete"
             exit 0

--- a/tests/test_routers/test_auth.py
+++ b/tests/test_routers/test_auth.py
@@ -278,27 +278,34 @@ async def test_single_user_gate_survives_tracker_reload(client, tmp_path):
     import celerp.services.session_tracker as _tracker
     from unittest.mock import patch
 
+    sessions_file = tmp_path / ".active_sessions.json"
+
     await client.post(
         "/auth/register",
         json={"company_name": "ReloadCo", "email": "reload@test.com", "name": "Admin", "password": "longpass123"},
     )
 
-    # First login - seeds the file-backed tracker
-    r1 = await client.post("/auth/login", json={"email": "reload@test.com", "password": "longpass123"})
-    assert r1.status_code == 200
+    # Point tracker at a known tmp file so saves/loads are deterministic in CI
+    with patch("celerp.services.session_tracker._sessions_path", return_value=sessions_file):
+        # First login - seeds the file-backed tracker
+        r1 = await client.post("/auth/login", json={"email": "reload@test.com", "password": "longpass123"})
+        assert r1.status_code == 200
 
-    # Simulate process reload: wipe in-memory state but keep the file
-    old_loaded = _tracker._loaded
-    old_activity = dict(_tracker._activity)
-    _tracker._activity.clear()
-    _tracker._loaded = False  # force re-load from file on next call
+        # Force a save so the file is populated
+        _tracker._save()
 
-    try:
-        # Gate must still fire after in-memory wipe (reads from file)
-        with patch("celerp.gateway.state.get_session_token", return_value=""):
-            r2 = await client.post("/auth/login", json={"email": "reload@test.com", "password": "longpass123"})
-        assert r2.status_code == 409, f"Gate should persist after tracker reload, got {r2.status_code}: {r2.text}"
-    finally:
-        # Restore so teardown clear() works correctly
-        _tracker._activity.update(old_activity)
-        _tracker._loaded = True
+        # Simulate process reload: wipe in-memory state but keep the file
+        old_loaded = _tracker._loaded
+        old_activity = dict(_tracker._activity)
+        _tracker._activity.clear()
+        _tracker._loaded = False  # force re-load from file on next call
+
+        try:
+            # Gate must still fire after in-memory wipe (reads from file)
+            with patch("celerp.gateway.state.get_session_token", return_value=""):
+                r2 = await client.post("/auth/login", json={"email": "reload@test.com", "password": "longpass123"})
+            assert r2.status_code == 409, f"Gate should persist after tracker reload, got {r2.status_code}: {r2.text}"
+        finally:
+            # Restore so teardown clear() works correctly
+            _tracker._activity.update(old_activity)
+            _tracker._loaded = True

--- a/ui/components/shell.py
+++ b/ui/components/shell.py
@@ -311,7 +311,6 @@ document.addEventListener('DOMContentLoaded', function() {
   var badge = document.getElementById('notif-badge');
   var panel = document.getElementById('notif-panel');
   var list = document.getElementById('notif-list');
-  if (!badge || !panel) return;
 
   function updateBadge(count) {
     if (count > 0) {
@@ -344,8 +343,10 @@ document.addEventListener('DOMContentLoaded', function() {
   }
 
   window.toggleNotifPanel = function() {
-    var visible = panel.style.display !== 'none';
-    panel.style.display = visible ? 'none' : '';
+    var p = document.getElementById('notif-panel');
+    if (!p) return;
+    var visible = p.style.display !== 'none';
+    p.style.display = visible ? 'none' : '';
     if (!visible) loadNotifications();
   };
 
@@ -354,6 +355,8 @@ document.addEventListener('DOMContentLoaded', function() {
       .then(function() { loadNotifications(); })
       .catch(function() {});
   };
+
+  if (!badge || !panel) return;
 
   // Close panel on outside click
   document.addEventListener('click', function(e) {


### PR DESCRIPTION
Three CI fixes discovered during v1.1.3 build:

1. `conftest.py` module paths were `../default_modules` (one level too high) - caused `ModuleNotFoundError` on CI checkout
2. `test_single_user_gate_survives_tracker_reload` relied on a local `config.toml` that does not exist in CI - fixed by mocking `_sessions_path` to `tmp_path`
3. Asset-clearing step in `build.yml` used `jq` which is not available on Windows GitHub runners - replaced with `python3`

All three jobs (Linux, macOS, Windows) should pass after this merge.

Please use **Squash and merge**.