### PR TITLE
fix(shell): notification bell broken on HTMX navigation

### DIFF
--- a/ui/components/shell.py
+++ b/ui/components/shell.py
@@ -307,10 +307,66 @@ _GLOBAL_UI_ERROR_HTML = Div(
 )
 
 _NOTIFICATION_JS = """
+window.toggleNotifPanel = function() {
+  var p = document.getElementById('notif-panel');
+  if (!p) return;
+  var visible = p.style.display !== 'none';
+  p.style.display = visible ? 'none' : '';
+  if (!visible) {
+    fetch('/notifications')
+      .then(function(r) { return r.json(); })
+      .then(function(data) {
+        var badge = document.getElementById('notif-badge');
+        var list = document.getElementById('notif-list');
+        if (badge) {
+          if (data.unread_count > 0) {
+            badge.textContent = data.unread_count > 99 ? '99+' : data.unread_count;
+            badge.style.display = '';
+          } else {
+            badge.style.display = 'none';
+          }
+        }
+        if (list) {
+          if (data.items.length === 0) {
+            list.innerHTML = '<div class="notif-panel__empty">No notifications</div>';
+          } else {
+            list.innerHTML = data.items.slice(0, 10).map(function(n) {
+              return '<div class="notif-item' + (n.read ? '' : ' notif-item--unread') + '">'
+                + '<div class="notif-item__title">' + n.title + '</div>'
+                + '<div class="notif-item__body">' + n.body + '</div>'
+                + '</div>';
+            }).join('');
+          }
+        }
+      })
+      .catch(function() {});
+  }
+};
+
+window.markAllNotifRead = function() {
+  fetch('/notifications/read-all', { method: 'POST' })
+    .then(function() {
+      var p = document.getElementById('notif-panel');
+      if (p && p.style.display !== 'none') {
+        fetch('/notifications')
+          .then(function(r) { return r.json(); })
+          .then(function(data) {
+            var badge = document.getElementById('notif-badge');
+            var list = document.getElementById('notif-list');
+            if (badge) badge.style.display = 'none';
+            if (list) list.innerHTML = '<div class="notif-panel__empty">No notifications</div>';
+          })
+          .catch(function() {});
+      }
+    })
+    .catch(function() {});
+};
+
 document.addEventListener('DOMContentLoaded', function() {
   var badge = document.getElementById('notif-badge');
   var panel = document.getElementById('notif-panel');
   var list = document.getElementById('notif-list');
+  if (!badge || !panel) return;
 
   function updateBadge(count) {
     if (count > 0) {
@@ -341,22 +397,6 @@ document.addEventListener('DOMContentLoaded', function() {
       })
       .catch(function() {});
   }
-
-  window.toggleNotifPanel = function() {
-    var p = document.getElementById('notif-panel');
-    if (!p) return;
-    var visible = p.style.display !== 'none';
-    p.style.display = visible ? 'none' : '';
-    if (!visible) loadNotifications();
-  };
-
-  window.markAllNotifRead = function() {
-    fetch('/notifications/read-all', { method: 'POST' })
-      .then(function() { loadNotifications(); })
-      .catch(function() {});
-  };
-
-  if (!badge || !panel) return;
 
   // Close panel on outside click
   document.addEventListener('click', function(e) {


### PR DESCRIPTION
## What

Fixes notification bell silently doing nothing after navigating between pages in the Electron app.

## Root cause

`window.toggleNotifPanel` was defined inside a `DOMContentLoaded` listener. HTMX navigation does not re-fire `DOMContentLoaded`, so on subsequent page loads the function either pointed to a stale DOM reference or was never re-registered.

## Fix

Moved `toggleNotifPanel` and `markAllNotifRead` to top-level script scope (outside any event listener). Both functions now do a fresh `getElementById` on every call. The `DOMContentLoaded` block retains the SSE stream, badge polling, and outside-click handler which legitimately need the DOM ready.

## Testing

- Install v1.1.4, navigate to any page, click bell - should open panel
- Tag v1.1.5 from this PR to test auto-updater flow end-to-end