### PR TITLE
fix(shell/updater): notification bell + Mac update loop

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -467,12 +467,71 @@ function resolveStorageEnv(cfg) {
  *   - Forwards update events to the renderer via IPC
  *   - Errors are logged only — never surfaced as crashes
  */
+// ── Pending-update stamp ─────────────────────────────────────────────────────
+// On Mac, autoInstallOnAppQuit hands off to Squirrel which replaces the bundle
+// in the background AFTER the app exits. Relaunching before Squirrel finishes
+// (typically 1-3 min) runs the old binary, which sees no update applied and
+// starts downloading again — creating an infinite loop.
+//
+// We break the loop with a stamp file:
+//   - Written to userData when download completes, recording the pending version.
+//   - On next launch, if the stamp exists and app.getVersion() == stamp.from,
+//     Squirrel hasn't finished yet — skip checkForUpdates and show a waiting UI.
+//   - If the stamp exists and app.getVersion() == stamp.to, install succeeded —
+//     delete the stamp and show a "Updated to vX" toast.
+const PENDING_UPDATE_STAMP = path.join(app.getPath("userData"), "pending-update.json");
+
+function readPendingUpdateStamp() {
+  try {
+    return JSON.parse(fs.readFileSync(PENDING_UPDATE_STAMP, "utf8"));
+  } catch (_) {
+    return null;
+  }
+}
+
+function writePendingUpdateStamp(fromVersion, toVersion) {
+  try {
+    fs.writeFileSync(PENDING_UPDATE_STAMP, JSON.stringify({ from: fromVersion, to: toVersion, ts: Date.now() }));
+  } catch (_) {}
+}
+
+function clearPendingUpdateStamp() {
+  try { fs.unlinkSync(PENDING_UPDATE_STAMP); } catch (_) {}
+}
+
 function setupAutoUpdater() {
   if (!app.isPackaged) return;
 
   autoUpdater.autoDownload = true;
   autoUpdater.autoInstallOnAppQuit = true;
   autoUpdater.allowPrerelease = false;
+
+  const currentVersion = app.getVersion();
+  const stamp = readPendingUpdateStamp();
+
+  // Check if we just successfully updated
+  if (stamp && stamp.to === currentVersion) {
+    clearPendingUpdateStamp();
+    // Notify renderer of successful update once the window loads
+    if (mainWindow) {
+      mainWindow.webContents.once("did-finish-load", () => {
+        mainWindow.webContents.send("update-just-applied", { version: currentVersion });
+      });
+    }
+  }
+
+  // If stamp exists and version hasn't changed, Squirrel is still working —
+  // skip checkForUpdates entirely to avoid the download loop.
+  const installPending = stamp && stamp.from === currentVersion;
+  if (installPending) {
+    console.log("[updater] install pending for v" + stamp.to + " — skipping update check");
+    if (mainWindow) {
+      mainWindow.webContents.once("did-finish-load", () => {
+        mainWindow.webContents.send("update-install-pending", { version: stamp.to });
+      });
+    }
+    return;
+  }
 
   function sendLog(msg) {
     if (mainWindow) mainWindow.webContents.send("update-log", String(msg));
@@ -510,7 +569,8 @@ function setupAutoUpdater() {
   });
 
   autoUpdater.on("update-downloaded", (info) => {
-    sendLog("Download complete — ready to install v" + info.version);
+    sendLog("Download complete — quit Celerp to install v" + info.version);
+    writePendingUpdateStamp(currentVersion, info.version);
     if (mainWindow) mainWindow.webContents.send("update-downloaded", info);
   });
 

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -38,6 +38,12 @@ contextBridge.exposeInMainWorld("celerp", {
   // Trigger a manual update check.
   checkForUpdates: () => ipcRenderer.invoke("check-for-updates"),
 
+  // Register a callback for when the app launches while a Squirrel install is still pending.
+  onUpdateInstallPending: (cb) => ipcRenderer.on("update-install-pending", (_event, info) => cb(info)),
+
+  // Register a callback for when the app launches after a successful update.
+  onUpdateJustApplied: (cb) => ipcRenderer.on("update-just-applied", (_event, info) => cb(info)),
+
   // Quit and install the downloaded update immediately.
   installUpdate: () => ipcRenderer.send("install-update"),
 });

--- a/ui/components/shell.py
+++ b/ui/components/shell.py
@@ -476,7 +476,7 @@ document.addEventListener('DOMContentLoaded', function() {
       if (lines.length >= 200) lines[0].remove();
       var line = document.createElement('span');
       line.className = 'log-line';
-      line.textContent = (logEl.childNodes.length ? '\n' : '') + msg;
+      line.textContent = (logEl.childNodes.length ? '\\n' : '') + msg;
       logEl.appendChild(line);
       logEl.scrollTop = logEl.scrollHeight;
     }

--- a/ui/components/shell.py
+++ b/ui/components/shell.py
@@ -520,9 +520,29 @@ document.addEventListener('DOMContentLoaded', function() {
       });
 
       window.celerp.onUpdateDownloaded(function(info) {
-        setState('Ready to install v' + info.version, true);
+        setState('Ready — quit Celerp to install v' + info.version, false);
         setProgress(100);
         setCheckBtn(false);
+        appendLog('Quit Celerp completely to finish installing v' + info.version + '. Reopen after ~1 minute.');
+      });
+
+      window.celerp.onUpdateInstallPending(function(info) {
+        var v = info && info.version ? info.version : 'update';
+        setState('Installing v' + v + ' in background...', false);
+        setCheckBtn(false);
+        appendLog('Update v' + v + ' is being installed by the system. Please wait 1-2 minutes, then reopen Celerp.');
+      });
+
+      window.celerp.onUpdateJustApplied(function(info) {
+        var v = info && info.version ? info.version : '';
+        setState('Updated to v' + v + ' \u2713', false);
+        resetToIdle();
+        // Open the notification panel briefly so the user sees the success
+        var panel = document.getElementById('notif-panel');
+        if (panel) panel.style.display = '';
+        setTimeout(function() {
+          setState('Up to date', false);
+        }, 8000);
       });
 
       if (checkBtn) {


### PR DESCRIPTION
## Changes

### fix(shell): escape literal newline in appendLog JS string (`d6bc103b`)
A `\n` in a Python triple-quoted string rendered as a real newline inside a JS single-quoted string literal — a syntax error that aborted the entire `_NOTIFICATION_JS` script block before `toggleNotifPanel` was ever defined. This broke the notification bell on every version since it was introduced with the updater progress log.

### fix(shell): make toggleNotifPanel top-level to survive HTMX navigation (`a1abaa3d`)
Hoisted `toggleNotifPanel` and `markAllNotifRead` to top-level script scope so they survive HTMX page navigation (DOMContentLoaded only fires once).

### fix(updater): break Mac Squirrel install loop with pending-update stamp (`aad98746`)
On Mac, `autoInstallOnAppQuit` hands off to Squirrel which replaces the bundle in the background after the app exits. Reopening too quickly ran the old binary, saw no update applied, and started downloading again — infinite loop.

Fix: write `pending-update.json` to userData on download complete. On next launch: if stamp exists and version unchanged, skip `checkForUpdates` and show "Installing in background...". When Squirrel finishes and user reopens, show "Updated to vX ✓" toast for 8 seconds.

Ready to tag v1.1.6.