### PR TITLE
feat(electron): loading screen + fix update UX on Mac

### DIFF
--- a/electron/assets/loading.html
+++ b/electron/assets/loading.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Celerp</title>
+<style>
+  *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+  html, body {
+    height: 100%;
+    background: #111827;
+    color: #f9fafb;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 24px;
+    user-select: none;
+    -webkit-app-region: drag;
+  }
+  .logo {
+    font-size: 2rem;
+    font-weight: 700;
+    letter-spacing: -0.5px;
+    color: #fff;
+  }
+  .logo span { color: #6366f1; }
+  .spinner {
+    width: 36px;
+    height: 36px;
+    border: 3px solid rgba(255,255,255,0.15);
+    border-top-color: #6366f1;
+    border-radius: 50%;
+    animation: spin 0.8s linear infinite;
+  }
+  @keyframes spin { to { transform: rotate(360deg); } }
+  .status {
+    font-size: 0.85rem;
+    color: #9ca3af;
+    min-height: 1.2em;
+    text-align: center;
+  }
+</style>
+</head>
+<body>
+  <div class="logo">Celer<span>p</span></div>
+  <div class="spinner"></div>
+  <div class="status" id="status">Starting…</div>
+  <script>
+    // Listen for status updates from main process via localStorage polling
+    // (simple cross-context comms without needing a preload on this page)
+    function setStatus(msg) {
+      var el = document.getElementById('status');
+      if (el) el.textContent = msg;
+    }
+    // Expose globally so executeJavaScript from main process can call it
+    window.setLoadingStatus = setStatus;
+  </script>
+</body>
+</html>

--- a/electron/main.js
+++ b/electron/main.js
@@ -596,6 +596,14 @@ function setupAutoUpdater() {
   }
 }
 
+function setLoadingStatus(msg) {
+  if (mainWindow && !mainWindow.isDestroyed()) {
+    mainWindow.webContents.executeJavaScript(
+      `window.setLoadingStatus && window.setLoadingStatus(${JSON.stringify(msg)})`
+    ).catch(() => {});
+  }
+}
+
 function createWindow() {
   mainWindow = new BrowserWindow({
     width: 1280,
@@ -612,8 +620,10 @@ function createWindow() {
     show: false,
   });
 
-  mainWindow.loadURL(`http://127.0.0.1:${uiPort}`);
-
+  // Show loading page immediately so there is never a white frame.
+  // Main process calls setLoadingStatus() to update the status line
+  // while services boot. Once ready, loadURL() switches to the real UI.
+  mainWindow.loadFile(path.join(__dirname, "assets", "loading.html"));
   mainWindow.once("ready-to-show", () => mainWindow.show());
 
   // In Electron (contextIsolation=true), window.confirm() is silently stubbed
@@ -702,6 +712,7 @@ app.whenReady().then(async () => {
         throw new Error(`DEV_MODE: UI not found on port ${uiPort}. Start it first with:\n  uvicorn ui.app:app --port ${uiPort}`);
       });
       createWindow();
+      mainWindow.loadURL(`http://127.0.0.1:${uiPort}`);
       return;
     }
 
@@ -709,30 +720,31 @@ app.whenReady().then(async () => {
     const cfg = readConfig();
     const dbConfig = resolveDatabaseConfig(dbPort, cfg);
 
-    // Show a loading state while services boot. A splash window can replace this later.
-    const loadingWin = new BrowserWindow({
-      width: 400, height: 200, frame: false, alwaysOnTop: true, resizable: false,
-      webPreferences: { nodeIntegration: false },
-    });
+    // Create the main window immediately so user sees the loading page (no white frame).
+    createWindow();
 
     // Show grace period warning if applicable
-    const graceBanner = dbConfig.gracePeriod
-      ? " Your Celerp Team subscription has lapsed. External database remains active for up to 15 days. Please renew at celerp.com/subscribe."
-      : "";
-    loadingWin.loadURL(`data:text/html,<body style="font-family:sans-serif;display:flex;align-items:center;justify-content:center;height:100vh;margin:0;background:#111827;color:#fff"><p>Starting Celerp…${graceBanner}</p></body>`);
+    if (dbConfig.gracePeriod) {
+      setLoadingStatus("Your Celerp Team subscription has lapsed. External database remains active for up to 15 days. Please renew at celerp.com/subscribe.");
+    }
 
     if (dbConfig.useBundledPg) {
+      setLoadingStatus("Starting database…");
       await startPostgres(dbPort);
     }
+    setLoadingStatus("Loading modules…");
     seedDefaultModules();
     runModuleSetup();
+    setLoadingStatus("Running migrations…");
     runMigrations(dbConfig.url);
     // Pre-allocate both ports so each process env carries both values.
     // GatewayClient runs inside the API process and needs to know the UI port
     // for its reverse-proxy routing; allocating upfront avoids a null race.
     apiPort = await getFreePort();
     uiPort = await getFreePort();
+    setLoadingStatus("Starting API server…");
     await startApi(dbConfig.url, cfg);
+    setLoadingStatus("Starting UI server…");
     await startUi(dbConfig.url, cfg);
 
     watchForRestart(dbConfig.url, {
@@ -757,8 +769,8 @@ app.whenReady().then(async () => {
       },
     });
 
-    loadingWin.close();
-    createWindow();
+    // Switch from loading page to the real UI
+    mainWindow.loadURL(`http://127.0.0.1:${uiPort}`);
 
     if (!IS_DEV) {
       setupAutoUpdater();

--- a/ui/components/shell.py
+++ b/ui/components/shell.py
@@ -494,6 +494,8 @@ document.addEventListener('DOMContentLoaded', function() {
 
     if (window.celerp) {
       // Electron path
+      var isManualCheck = false;
+
       window.celerp.getVersion().then(function(v) {
         if (versionEl) versionEl.textContent = 'v' + v;
       }).catch(function() {});
@@ -501,7 +503,7 @@ document.addEventListener('DOMContentLoaded', function() {
       setState('Up to date', false);
 
       window.celerp.onUpdateLog(function(msg) {
-        appendLog(msg);
+        if (isManualCheck) appendLog(msg);
       });
 
       window.celerp.onUpdateAvailable(function(info) {
@@ -517,6 +519,7 @@ document.addEventListener('DOMContentLoaded', function() {
       window.celerp.onUpdateNotAvailable(function() {
         setState('Up to date', false);
         resetToIdle();
+        isManualCheck = false;
       });
 
       window.celerp.onUpdateDownloaded(function(info) {
@@ -547,12 +550,14 @@ document.addEventListener('DOMContentLoaded', function() {
 
       if (checkBtn) {
         checkBtn.addEventListener('click', function() {
+          isManualCheck = true;
           setCheckBtn(false);
           setState('Checking...', false);
           if (logEl) { logEl.textContent = ''; logEl.style.display = 'none'; }
           window.celerp.checkForUpdates().catch(function() {
             setState('Up to date', false);
             resetToIdle();
+            isManualCheck = false;
           });
         });
       }


### PR DESCRIPTION
## Changes

### Loading screen instead of white window
- New `assets/loading.html`: dark branded page with Celerp logo, CSS spinner, and live status line
- `createWindow()` loads `loading.html` immediately — no white frame ever shown
- Status line updates at each boot step: Starting database / Loading modules / Running migrations / Starting API server / Starting UI server
- Removed separate `loadingWin` BrowserWindow (was a tiny frameless overlay)
- `mainWindow.loadURL(uiPort)` called explicitly after all services ready

### Suppress auto-check log noise in notification panel
- Added `isManualCheck` flag: auto-check on startup suppresses log output
- Manual "Check for updates" click enables the log for that cycle only
- Prevents "Checking for update... Already up to date." always appearing in the panel

### Mac update loop fix (from previous commit)
- `pending-update.json` stamp prevents re-download loop while Squirrel installs
- "Updated to vX ✓" toast on successful update detection

Ready to tag v1.1.7.