### PR TITLE
fix(updater): simplify update state machine for v1.1.8

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -461,77 +461,23 @@ function resolveStorageEnv(cfg) {
  * Guard: only active in packaged builds. Dev mode skips the updater so
  * a missing GitHub release file doesn't throw noise at the developer.
  *
- * When active:
- *   - Checks for updates silently on launch
- *   - Downloads in background
- *   - Forwards update events to the renderer via IPC
- *   - Errors are logged only — never surfaced as crashes
+ * State machine (matches doc section 10):
+ *   IDLE -> CHECKING -> DOWNLOADING -> READY -> [admin clicks] -> INSTALLING
+ *   Any state -> ERROR on failure (always surfaced to renderer)
+ *
+ * autoInstallOnAppQuit = false: Squirrel/NSIS never install on normal quit.
+ * The ONLY install trigger is an explicit admin action (installUpdate IPC).
+ * This eliminates background race conditions entirely.
+ *
+ * Periodic re-check: every 4 hours while the app is running, in case a new
+ * version is released while the user has the app open.
  */
-// ── Pending-update stamp ─────────────────────────────────────────────────────
-// On Mac, autoInstallOnAppQuit hands off to Squirrel which replaces the bundle
-// in the background AFTER the app exits. Relaunching before Squirrel finishes
-// (typically 1-3 min) runs the old binary, which sees no update applied and
-// starts downloading again — creating an infinite loop.
-//
-// We break the loop with a stamp file:
-//   - Written to userData when download completes, recording the pending version.
-//   - On next launch, if the stamp exists and app.getVersion() == stamp.from,
-//     Squirrel hasn't finished yet — skip checkForUpdates and show a waiting UI.
-//   - If the stamp exists and app.getVersion() == stamp.to, install succeeded —
-//     delete the stamp and show a "Updated to vX" toast.
-const PENDING_UPDATE_STAMP = path.join(app.getPath("userData"), "pending-update.json");
-
-function readPendingUpdateStamp() {
-  try {
-    return JSON.parse(fs.readFileSync(PENDING_UPDATE_STAMP, "utf8"));
-  } catch (_) {
-    return null;
-  }
-}
-
-function writePendingUpdateStamp(fromVersion, toVersion) {
-  try {
-    fs.writeFileSync(PENDING_UPDATE_STAMP, JSON.stringify({ from: fromVersion, to: toVersion, ts: Date.now() }));
-  } catch (_) {}
-}
-
-function clearPendingUpdateStamp() {
-  try { fs.unlinkSync(PENDING_UPDATE_STAMP); } catch (_) {}
-}
-
 function setupAutoUpdater() {
   if (!app.isPackaged) return;
 
   autoUpdater.autoDownload = true;
-  autoUpdater.autoInstallOnAppQuit = true;
+  autoUpdater.autoInstallOnAppQuit = false;
   autoUpdater.allowPrerelease = false;
-
-  const currentVersion = app.getVersion();
-  const stamp = readPendingUpdateStamp();
-
-  // Check if we just successfully updated
-  if (stamp && stamp.to === currentVersion) {
-    clearPendingUpdateStamp();
-    // Notify renderer of successful update once the window loads
-    if (mainWindow) {
-      mainWindow.webContents.once("did-finish-load", () => {
-        mainWindow.webContents.send("update-just-applied", { version: currentVersion });
-      });
-    }
-  }
-
-  // If stamp exists and version hasn't changed, Squirrel is still working —
-  // skip checkForUpdates entirely to avoid the download loop.
-  const installPending = stamp && stamp.from === currentVersion;
-  if (installPending) {
-    console.log("[updater] install pending for v" + stamp.to + " — skipping update check");
-    if (mainWindow) {
-      mainWindow.webContents.once("did-finish-load", () => {
-        mainWindow.webContents.send("update-install-pending", { version: stamp.to });
-      });
-    }
-    return;
-  }
 
   function sendLog(msg) {
     if (mainWindow) mainWindow.webContents.send("update-log", String(msg));
@@ -542,12 +488,11 @@ function setupAutoUpdater() {
   });
 
   autoUpdater.on("update-available", (info) => {
-    sendLog("Found version " + info.version + " — downloading...");
+    sendLog("Found v" + info.version + " — downloading...");
     if (mainWindow) mainWindow.webContents.send("update-available", info);
   });
 
   autoUpdater.on("update-not-available", () => {
-    sendLog("Already up to date.");
     if (mainWindow) mainWindow.webContents.send("update-not-available");
   });
 
@@ -569,18 +514,17 @@ function setupAutoUpdater() {
   });
 
   autoUpdater.on("update-downloaded", (info) => {
-    sendLog("Download complete — quit Celerp to install v" + info.version);
-    writePendingUpdateStamp(currentVersion, info.version);
+    sendLog("v" + info.version + " ready — click 'Restart to Install'");
     if (mainWindow) mainWindow.webContents.send("update-downloaded", info);
   });
 
   autoUpdater.on("error", (err) => {
-    // Log only — update failures must never interrupt the user's work.
-    // Also notify renderer so the UI can reset from "Checking..." state.
+    // Always surface errors to the renderer — never silently swallow them.
+    // Update failures must never interrupt work, but must be visible.
     const msg = err?.message ?? String(err);
     console.error("[updater] error:", msg);
-    sendLog("Error: " + msg);
-    if (mainWindow) mainWindow.webContents.send("update-not-available");
+    sendLog("Update error: " + msg);
+    if (mainWindow) mainWindow.webContents.send("update-error", { message: msg });
   });
 
   // Delay initial check until the renderer has loaded and registered its IPC handlers.
@@ -594,6 +538,11 @@ function setupAutoUpdater() {
     // Fallback: mainWindow not yet created (shouldn't happen in normal flow)
     autoUpdater.checkForUpdates().catch(() => {});
   }
+
+  // Periodic re-check every 4 hours in case a new release ships while app is open.
+  setInterval(() => {
+    autoUpdater.checkForUpdates().catch(() => {});
+  }, 4 * 60 * 60 * 1000);
 }
 
 function setLoadingStatus(msg) {

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -38,11 +38,9 @@ contextBridge.exposeInMainWorld("celerp", {
   // Trigger a manual update check.
   checkForUpdates: () => ipcRenderer.invoke("check-for-updates"),
 
-  // Register a callback for when the app launches while a Squirrel install is still pending.
-  onUpdateInstallPending: (cb) => ipcRenderer.on("update-install-pending", (_event, info) => cb(info)),
-
-  // Register a callback for when the app launches after a successful update.
-  onUpdateJustApplied: (cb) => ipcRenderer.on("update-just-applied", (_event, info) => cb(info)),
+  // Register a callback for update errors ({ message }).
+  // Always fired on any update error — never silently dropped.
+  onUpdateError: (cb) => ipcRenderer.on("update-error", (_event, info) => cb(info)),
 
   // Quit and install the downloaded update immediately.
   installUpdate: () => ipcRenderer.send("install-update"),

--- a/tests/test_electron_build_config.py
+++ b/tests/test_electron_build_config.py
@@ -156,6 +156,7 @@ def test_preload_exposes_required_updater_api():
         "onDownloadProgress",
         "onUpdateLog",
         "checkForUpdates",
+        "onUpdateError",
         "installUpdate",
     ]
     for name in required:
@@ -369,4 +370,92 @@ def test_build_yml_delete_checks_http_status():
     assert ">= 500" in step_block or "-ge 500" in step_block, (
         "build.yml DELETE step does not fail on 5xx responses. "
         "A server-side delete failure will silently allow a stale asset to remain."
+    )
+
+
+def test_main_auto_install_on_quit_disabled():
+    """autoInstallOnAppQuit must be false.
+
+    With true, Squirrel installs on any normal quit without admin confirmation.
+    This creates an uncontrolled background install that cannot be monitored or
+    tested. The only install trigger must be an explicit admin action.
+    """
+    src = _main_src()
+    assert "autoInstallOnAppQuit = false" in src, (
+        "main.js sets autoInstallOnAppQuit = true. "
+        "This allows Squirrel to install silently on normal quit, creating a "
+        "background race condition. Set it to false."
+    )
+    assert "autoInstallOnAppQuit = true" not in src, (
+        "main.js still has autoInstallOnAppQuit = true. Remove it."
+    )
+
+
+def test_main_error_sends_update_error_not_not_available():
+    """The updater error handler must send 'update-error', not 'update-not-available'.
+
+    Sending update-not-available on error is misleading — it resets state to
+    'Up to date' even when the check failed. Errors must be visible.
+    """
+    src = _main_src()
+    err_idx = src.find('autoUpdater.on("error"')
+    assert err_idx != -1, "autoUpdater error handler not found in main.js"
+    handler_block = src[err_idx: err_idx + 400]
+    assert '"update-error"' in handler_block, (
+        "autoUpdater error handler does not send 'update-error' IPC. "
+        "Errors will be silently swallowed in the renderer."
+    )
+    assert '"update-not-available"' not in handler_block, (
+        "autoUpdater error handler sends 'update-not-available' on error. "
+        "This misleadingly shows 'Up to date' when the check actually failed."
+    )
+
+
+def test_main_periodic_check_interval():
+    """main.js must schedule a periodic update check (every 4 hours).
+
+    Without a periodic check, users who keep the app open for days will miss
+    newly released versions until they manually restart.
+    """
+    src = _main_src()
+    assert "setInterval" in src, (
+        "main.js does not schedule a periodic update check via setInterval. "
+        "Long-running sessions will never see new releases."
+    )
+    # 4 hours in ms = 14400000; also accept the expression form
+    assert "14400000" in src or "4 * 60 * 60 * 1000" in src, (
+        "main.js periodic check interval is not 4 hours (14400000 ms). "
+        "Use setInterval(..., 4 * 60 * 60 * 1000)."
+    )
+
+
+def test_shell_no_is_manual_check_gate():
+    """shell.py must not gate log output behind isManualCheck.
+
+    All update log lines — including from background checks — must be shown.
+    Errors in particular must always be visible regardless of who triggered the check.
+    """
+    src = _shell_src()
+    # Check for the variable declaration/assignment, not just the word in comments
+    assert "var isManualCheck" not in src, (
+        "shell.py still declares var isManualCheck. Remove it. "
+        "All update log lines must be shown unconditionally."
+    )
+    assert "isManualCheck = true" not in src, (
+        "shell.py still sets isManualCheck = true. Remove it."
+    )
+
+
+def test_shell_has_on_update_error_handler():
+    """shell.py must handle the onUpdateError event from the IPC bridge."""
+    src = _shell_src()
+    assert "onUpdateError" in src, (
+        "shell.py does not register an onUpdateError handler. "
+        "Update errors will be silently ignored in the UI."
+    )
+    err_idx = src.find("onUpdateError")
+    handler_block = src[err_idx: err_idx + 300]
+    assert "Update check failed" in handler_block or "failed" in handler_block.lower(), (
+        "onUpdateError handler does not set an error state. "
+        "The UI will show 'Up to date' even when the check failed."
     )

--- a/ui/components/shell.py
+++ b/ui/components/shell.py
@@ -494,7 +494,6 @@ document.addEventListener('DOMContentLoaded', function() {
 
     if (window.celerp) {
       // Electron path
-      var isManualCheck = false;
 
       window.celerp.getVersion().then(function(v) {
         if (versionEl) versionEl.textContent = 'v' + v;
@@ -502,8 +501,9 @@ document.addEventListener('DOMContentLoaded', function() {
 
       setState('Up to date', false);
 
+      // Log lines: always show — no isManualCheck gate.
       window.celerp.onUpdateLog(function(msg) {
-        if (isManualCheck) appendLog(msg);
+        appendLog(msg);
       });
 
       window.celerp.onUpdateAvailable(function(info) {
@@ -519,45 +519,33 @@ document.addEventListener('DOMContentLoaded', function() {
       window.celerp.onUpdateNotAvailable(function() {
         setState('Up to date', false);
         resetToIdle();
-        isManualCheck = false;
       });
 
       window.celerp.onUpdateDownloaded(function(info) {
-        setState('Ready — quit Celerp to install v' + info.version, false);
+        var v = info && info.version ? info.version : 'update';
+        setState('v' + v + ' ready to install', false);
         setProgress(100);
         setCheckBtn(false);
-        appendLog('Quit Celerp completely to finish installing v' + info.version + '. Reopen after ~1 minute.');
+        if (restartBtn) restartBtn.style.display = '';
+        appendLog('v' + v + ' downloaded. Click "Restart to Install" when ready.');
       });
 
-      window.celerp.onUpdateInstallPending(function(info) {
-        var v = info && info.version ? info.version : 'update';
-        setState('Installing v' + v + ' in background...', false);
-        setCheckBtn(false);
-        appendLog('Update v' + v + ' is being installed by the system. Please wait 1-2 minutes, then reopen Celerp.');
-      });
-
-      window.celerp.onUpdateJustApplied(function(info) {
-        var v = info && info.version ? info.version : '';
-        setState('Updated to v' + v + ' \u2713', false);
+      // Errors are always visible — never silently swallowed.
+      window.celerp.onUpdateError(function(info) {
+        var msg = info && info.message ? info.message : 'Unknown error';
+        setState('Update check failed', false);
+        appendLog('Error: ' + msg);
         resetToIdle();
-        // Open the notification panel briefly so the user sees the success
-        var panel = document.getElementById('notif-panel');
-        if (panel) panel.style.display = '';
-        setTimeout(function() {
-          setState('Up to date', false);
-        }, 8000);
       });
 
       if (checkBtn) {
         checkBtn.addEventListener('click', function() {
-          isManualCheck = true;
           setCheckBtn(false);
           setState('Checking...', false);
           if (logEl) { logEl.textContent = ''; logEl.style.display = 'none'; }
           window.celerp.checkForUpdates().catch(function() {
-            setState('Up to date', false);
+            setState('Update check failed', false);
             resetToIdle();
-            isManualCheck = false;
           });
         });
       }


### PR DESCRIPTION
## Summary

Simplifies the Electron auto-updater to match the clean state machine designed in the update design doc (section 10).

### What changed

**Removed:**
- All pending-update stamp logic (`PENDING_UPDATE_STAMP`, read/write/clear functions)
- `update-install-pending` and `update-just-applied` IPC events
- `isManualCheck` gate in `shell.py` (was silently suppressing all background check logs + errors)
- `autoInstallOnAppQuit = true`

**Added/Fixed:**
- `autoInstallOnAppQuit = false` — Squirrel/NSIS never install on normal quit. The only install trigger is the explicit admin "Restart to Install" button. Eliminates the background race condition entirely.
- `update-error` IPC event — errors are always surfaced to the UI. The old code sent `update-not-available` on error, which showed "Up to date" when the check actually failed.
- `onUpdateError` handler in `shell.py` — sets state to "Update check failed", shows error in log panel.
- Periodic re-check every 4 hours while app is open.
- 6 new regression tests.

### Test

857 UI tests passed. 27/27 electron build config tests passed.