### PR TITLE
fix(electron): hide window on Mac close; DRY PyPI update card + updater fixes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,53 @@ env:
   PBS_PYTHON: "3.12.13"
 
 jobs:
+  # ── Prepare release (tag builds only) ────────────────────────────────────
+  # Runs once before all three platform builds. Creates the GitHub release and
+  # clears any stale assets from a previous attempt at the same tag. This
+  # eliminates the race condition where Mac's electron-builder uploads its first
+  # asset before Windows/Linux reach the asset-clearing step.
+  prepare-release:
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clear existing release assets (retag support)
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${GITHUB_REF_NAME}"
+          RELEASE_ID=$(curl -s -H "Authorization: token $GH_TOKEN" \
+            "https://api.github.com/repos/celerp/celerp/releases/tags/$TAG" \
+            | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('id',''))" 2>/dev/null || true)
+          if [ -z "$RELEASE_ID" ]; then
+            echo "No existing release for $TAG - nothing to clear"
+            exit 0
+          fi
+          echo "Release $RELEASE_ID found for $TAG - clearing assets"
+          ASSET_IDS=$(curl -s -H "Authorization: token $GH_TOKEN" \
+            "https://api.github.com/repos/celerp/celerp/releases/$RELEASE_ID/assets" \
+            | python3 -c "import sys,json; [print(a['id']) for a in json.load(sys.stdin)]" 2>/dev/null || true)
+          if [ -z "$ASSET_IDS" ]; then
+            echo "No assets to delete"
+            exit 0
+          fi
+          for ASSET_ID in $ASSET_IDS; do
+            echo "Deleting asset $ASSET_ID"
+            STATUS=$(curl -s -o /dev/null -w "%{http_code}" -X DELETE \
+              -H "Authorization: token $GH_TOKEN" \
+              "https://api.github.com/repos/celerp/celerp/releases/assets/$ASSET_ID" | tr -d '\r')
+            if [ "$STATUS" -ge 500 ]; then
+              echo "ERROR: DELETE asset $ASSET_ID returned HTTP $STATUS - aborting"
+              exit 1
+            fi
+            echo "Deleted asset $ASSET_ID (HTTP $STATUS)"
+          done
+          echo "Assets cleared"
+
   build:
+    needs: [prepare-release]
+    # prepare-release is skipped on non-tag builds; treat skipped as success.
+    if: always() && (needs.prepare-release.result == 'success' || needs.prepare-release.result == 'skipped')
     strategy:
       fail-fast: false
       matrix:
@@ -88,41 +134,6 @@ jobs:
           fi
           "$PY" -m pip install --upgrade pip
           "$PY" -m pip install .
-
-      - name: Clear existing release assets (retag support)
-        if: startsWith(github.ref, 'refs/tags/v')
-        shell: bash
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          TAG="${GITHUB_REF_NAME}"
-          RELEASE_ID=$(curl -s -H "Authorization: token $GH_TOKEN" \
-            "https://api.github.com/repos/celerp/celerp/releases/tags/$TAG" \
-            | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('id',''))" 2>/dev/null || true)
-          if [ -z "$RELEASE_ID" ]; then
-            echo "No existing release for $TAG - nothing to clear"
-            exit 0
-          fi
-          echo "Release $RELEASE_ID found for $TAG - clearing assets"
-          ASSET_IDS=$(curl -s -H "Authorization: token $GH_TOKEN" \
-            "https://api.github.com/repos/celerp/celerp/releases/$RELEASE_ID/assets" \
-            | python3 -c "import sys,json; [print(a['id']) for a in json.load(sys.stdin)]" 2>/dev/null || true)
-          if [ -z "$ASSET_IDS" ]; then
-            echo "No assets to delete"
-            exit 0
-          fi
-          for ASSET_ID in $ASSET_IDS; do
-            echo "Deleting asset $ASSET_ID"
-            STATUS=$(curl -s -o /dev/null -w "%{http_code}" -X DELETE \
-              -H "Authorization: token $GH_TOKEN" \
-              "https://api.github.com/repos/celerp/celerp/releases/assets/$ASSET_ID")
-            if [ "$STATUS" -ge 500 ]; then
-              echo "ERROR: DELETE asset $ASSET_ID returned HTTP $STATUS - aborting"
-              exit 1
-            fi
-            echo "Deleted asset $ASSET_ID (HTTP $STATUS)"
-          done
-          echo "Assets cleared"
 
       - name: Build macOS (production - signed + notarized)
         if: matrix.os == 'macos-latest' && startsWith(github.ref, 'refs/tags/v')

--- a/electron/main.js
+++ b/electron/main.js
@@ -600,6 +600,17 @@ function createWindow() {
     return { action: "allow" };
   });
 
+  // On macOS, hide the window instead of destroying it when the user clicks
+  // the red X. This matches Telegram's behaviour: app stays alive in the
+  // background and re-opens instantly when the user clicks the dock icon.
+  // The `before-quit` handler (Cmd+Q) still kills all processes and fully exits.
+  mainWindow.on("close", (event) => {
+    if (process.platform === "darwin") {
+      event.preventDefault();
+      mainWindow.hide();
+    }
+  });
+
   mainWindow.on("closed", () => { mainWindow = null; });
 }
 
@@ -735,7 +746,10 @@ app.on("window-all-closed", () => {
 });
 
 app.on("activate", () => {
-  if (mainWindow === null && uiPort) createWindow();
+  // Dock icon clicked: show the hidden window (Mac hide-on-close) or create
+  // a new one if it was genuinely destroyed (shouldn't normally happen).
+  if (mainWindow) mainWindow.show();
+  else if (uiPort) createWindow();
 });
 
 app.on("before-quit", async () => {

--- a/tests/test_electron_build_config.py
+++ b/tests/test_electron_build_config.py
@@ -485,3 +485,69 @@ def test_shell_has_on_update_error_handler():
         "onUpdateError handler does not set an error state. "
         "The UI will show 'Up to date' even when the check failed."
     )
+
+
+def test_main_js_mac_hide_on_close():
+    """main.js must intercept the 'close' event on darwin and hide instead of destroy.
+
+    Without this, clicking the red X on macOS destroys the BrowserWindow and the
+    next dock-icon click shows an endless "Starting..." loader (startup not re-run).
+    """
+    src = _main_src()
+    assert 'process.platform === "darwin"' in src, (
+        'main.js does not check process.platform === "darwin" in a close handler. '
+        "Mac users will get the endless Starting... bug when reopening from dock."
+    )
+    # Verify the hide() call exists and event.preventDefault() suppresses destroy
+    assert "mainWindow.hide()" in src, (
+        "main.js does not call mainWindow.hide(). "
+        "Red-X click will destroy the window instead of hiding it on macOS."
+    )
+    assert "event.preventDefault()" in src, (
+        "main.js does not call event.preventDefault() in the close handler. "
+        "The BrowserWindow will still be destroyed despite hide() call."
+    )
+
+
+def test_main_js_activate_shows_hidden_window():
+    """The 'activate' handler must call mainWindow.show() for the hide-on-close path."""
+    src = _main_src()
+    act_idx = src.find('app.on("activate"')
+    assert act_idx != -1, "activate handler not found in main.js"
+    block = src[act_idx: act_idx + 300]
+    assert "mainWindow.show()" in block, (
+        "activate handler does not call mainWindow.show(). "
+        "Clicking the dock icon will not restore the hidden window."
+    )
+
+
+def test_shell_pypi_check_btn_visible():
+    """In the PyPI path, the check button must NOT be hidden.
+
+    The check button was previously hidden for PyPI installs, making the UI
+    inconsistent with Electron (WET: different behaviour, same widget).
+    PyPI path now wires the button to runPyPICheck() instead.
+    """
+    src = _shell_src()
+    # Confirm the PyPI branch no longer hides checkBtn
+    # Look for the tell-tale old pattern: checkBtn.style.display = 'none' outside Electron branch
+    # We require runPyPICheck to exist instead
+    assert "runPyPICheck" in src, (
+        "shell.py PyPI path is missing runPyPICheck(). "
+        "The check button has no click handler in PyPI mode."
+    )
+
+
+def test_shell_pypi_auto_check_on_load():
+    """PyPI path must call runPyPICheck() automatically on load (not just on button click)."""
+    src = _shell_src()
+    # The auto-call must appear after the button click handler wiring
+    pypi_idx = src.find("runPyPICheck")
+    assert pypi_idx != -1, "runPyPICheck not found in shell.py"
+    # The function definition ends, then there's a btn click wiring, then the auto-call
+    # Simply confirm runPyPICheck() appears at least twice (definition + auto-call)
+    count = src.count("runPyPICheck")
+    assert count >= 3, (  # definition + addEventListener + auto-call
+        f"runPyPICheck appears only {count} time(s) in shell.py. "
+        "Expect at least 3: function definition, click handler body, and auto-call on load."
+    )

--- a/tests/test_electron_build_config.py
+++ b/tests/test_electron_build_config.py
@@ -371,6 +371,32 @@ def test_build_yml_delete_checks_http_status():
         "build.yml DELETE step does not fail on 5xx responses. "
         "A server-side delete failure will silently allow a stale asset to remain."
     )
+    assert "tr -d" in step_block and r"\r" in step_block, (
+        "build.yml DELETE step does not strip \\r from curl output. "
+        "On Windows Git Bash, curl -w '%{http_code}' appends \\r, causing "
+        "[ \"204\\r\" -ge 500 ] to exit with code 3 (integer expression expected). "
+        "Pipe through | tr -d '\\r'."
+    )
+
+
+def test_build_yml_has_prepare_release_job():
+    """build.yml must have a prepare-release job that runs before the build matrix.
+
+    Without this, all three platform jobs run in parallel. Mac's electron-builder
+    uploads assets to the GitHub release within ~60s of starting. If Windows
+    reaches the asset-clearing step after Mac has uploaded, it tries to delete
+    Mac's assets mid-upload, causing a race condition. prepare-release serialises
+    the clear step before any platform build starts.
+    """
+    yml = (Path(__file__).parent.parent / ".github" / "workflows" / "build.yml").read_text()
+    assert "prepare-release:" in yml, (
+        "build.yml is missing a 'prepare-release' job. "
+        "Add it to run asset-clearing before the build matrix starts."
+    )
+    assert "needs: [prepare-release]" in yml or "needs: prepare-release" in yml, (
+        "The build matrix job does not declare 'needs: prepare-release'. "
+        "Without this, the build matrix runs in parallel with prepare-release."
+    )
 
 
 def test_main_auto_install_on_quit_disabled():

--- a/ui/components/shell.py
+++ b/ui/components/shell.py
@@ -493,8 +493,7 @@ document.addEventListener('DOMContentLoaded', function() {
     }
 
     if (window.celerp) {
-      // Electron path
-
+      // ── Electron path ────────────────────────────────────────────────
       window.celerp.getVersion().then(function(v) {
         if (versionEl) versionEl.textContent = 'v' + v;
       }).catch(function() {});
@@ -502,9 +501,7 @@ document.addEventListener('DOMContentLoaded', function() {
       setState('Up to date', false);
 
       // Log lines: always show — no isManualCheck gate.
-      window.celerp.onUpdateLog(function(msg) {
-        appendLog(msg);
-      });
+      window.celerp.onUpdateLog(function(msg) { appendLog(msg); });
 
       window.celerp.onUpdateAvailable(function(info) {
         setState('Downloading v' + (info && info.version ? info.version : 'update') + '...', false);
@@ -558,26 +555,41 @@ document.addEventListener('DOMContentLoaded', function() {
         });
       }
     } else {
-      // PyPI path - fetch current version from /health, compare to PyPI
-      fetch('/health').then(function(r) { return r.json(); }).then(function(health) {
-        var current = health.version || '';
-        var isDev = current.indexOf('.dev') !== -1 || current.indexOf('+dev') !== -1 || current === '0.0.0+dev';
-        if (versionEl) versionEl.textContent = isDev ? 'Development build' : (current ? 'v' + current : 'Unknown');
-        if (isDev) { setState('Running from source - no updates', false); return; }
-        return fetch('https://pypi.org/pypi/celerp/json').then(function(r) { return r.json(); }).then(function(pypi) {
-          var latest = pypi.info && pypi.info.version ? pypi.info.version : null;
-          if (!latest) { setState('Up to date', false); return; }
-          if (latest !== current) {
-            setState('Update available: v' + latest, false);
-            var upgrade = card.querySelector('.update-card__upgrade-cmd');
-            if (upgrade) upgrade.style.display = '';
-          } else {
-            setState('Up to date', false);
-          }
+      // ── PyPI / pip path ───────────────────────────────────────────────
+      // Electron-only controls are hidden; everything else (version label,
+      // state text, check button, pip upgrade command) works identically.
+      if (restartBtn) restartBtn.style.display = 'none';
+      if (progressBar) progressBar.style.display = 'none';
+
+      function runPyPICheck() {
+        setCheckBtn(false);
+        setState('Checking...', false);
+        fetch('/health').then(function(r) { return r.json(); }).then(function(health) {
+          var current = health.version || '';
+          var isDev = current.indexOf('.dev') !== -1 || current.indexOf('+dev') !== -1 || current === '0.0.0+dev';
+          if (versionEl) versionEl.textContent = isDev ? 'Development build' : (current ? 'v' + current : 'Unknown');
+          if (isDev) { setState('Running from source - no updates', false); resetToIdle(); return; }
+          return fetch('https://pypi.org/pypi/celerp/json').then(function(r) { return r.json(); }).then(function(pypi) {
+            var latest = pypi.info && pypi.info.version ? pypi.info.version : null;
+            if (!latest) { setState('Up to date', false); resetToIdle(); return; }
+            if (latest !== current) {
+              setState('Update available: v' + latest, false);
+              var upgrade = card.querySelector('.update-card__upgrade-cmd');
+              if (upgrade) upgrade.style.display = '';
+            } else {
+              setState('Up to date', false);
+            }
+            resetToIdle();
+          });
+        }).catch(function() {
+          setState('Check failed', false);
+          resetToIdle();
         });
-      }).catch(function() {
-        setState('', false);
-      });
+      }
+
+      if (checkBtn) {
+        checkBtn.addEventListener('click', function() { runPyPICheck(); });
+      }
 
       var copyBtn = card.querySelector('.update-card__copy-btn');
       if (copyBtn) {
@@ -588,9 +600,8 @@ document.addEventListener('DOMContentLoaded', function() {
         });
       }
 
-      // Hide electron-only buttons
-      if (checkBtn) checkBtn.style.display = 'none';
-      if (restartBtn) restartBtn.style.display = 'none';
+      // Auto-check on load so the card shows a version immediately.
+      runPyPICheck();
     }
   })();
 });


### PR DESCRIPTION
## Changes

### fix(electron): hide window on Mac close; DRY PyPI update card (`e61fac87`)
- **Mac**: intercept `close` event on darwin — `preventDefault` + `hide()`. Dock icon click restores via `mainWindow.show()`. Cmd+Q still kills processes and exits fully.
- **PyPI update card**: extracted `runPyPICheck()`, wired check button to it (same widget, different handler). Button now visible on PyPI installs. Only `restartBtn`/`progressBar` are Electron-only. 6 new regression tests (32 total).

### fix(ci): eliminate Windows/Mac race + fix curl \r on Windows (`462dd227`)
- Fixes curl exit code 3 (URL malformed) caused by `\r\n` line endings on Windows runner.
- Eliminates race condition between concurrent Mac/Windows builds on same tag.

### fix(updater): simplify state machine — remove stamp hack, fix error visibility (`c6e9423c`)
- `autoInstallOnAppQuit = false` (permanent — Squirrel must not install on normal quit)
- All stamp logic deleted (`PENDING_UPDATE_STAMP`, read/write/clear)
- Error handler sends `update-error` IPC; errors always visible
- Periodic re-check every 4 hours
- 27 regression tests passing

## Test status
- Full suite: 3677 passed, 0 failed
- Electron build config: 32/32 passed