### PR TITLE
fix: Mac Cmd+Q quit, progress bar, PyPI check button, 409 login loop

### DIFF
--- a/celerp/routers/auth.py
+++ b/celerp/routers/auth.py
@@ -142,8 +142,10 @@ async def login(request: Request, payload: LoginRequest, session: AsyncSession =
 
     from celerp.gateway.state import get_session_token as _get_session_token
     from celerp.services.session_tracker import active_user_ids as _active_ids, record as _record
-    if not _get_session_token() and _active_ids():
-        raise HTTPException(status_code=409, detail="direct_connection_limit")
+    if not _get_session_token():
+        others = _active_ids() - {str(user.id)}
+        if others:
+            raise HTTPException(status_code=409, detail="direct_connection_limit")
 
     _record(str(user.id), str(user.company_id))
     return {

--- a/electron/main.js
+++ b/electron/main.js
@@ -104,6 +104,7 @@ const DEFAULT_MODULES_SRC = IS_DEV
 // ── Globals ──────────────────────────────────────────────────────────────────
 
 let mainWindow = null;
+let isQuitting = false; // set true in before-quit so the close handler doesn't intercept Cmd+Q
 let pgInstance = null;
 let apiProcess = null;
 let uiProcess = null;
@@ -605,7 +606,7 @@ function createWindow() {
   // background and re-opens instantly when the user clicks the dock icon.
   // The `before-quit` handler (Cmd+Q) still kills all processes and fully exits.
   mainWindow.on("close", (event) => {
-    if (process.platform === "darwin") {
+    if (process.platform === "darwin" && !isQuitting) {
       event.preventDefault();
       mainWindow.hide();
     }
@@ -753,6 +754,7 @@ app.on("activate", () => {
 });
 
 app.on("before-quit", async () => {
+  isQuitting = true;
   if (uiProcess) uiProcess.kill();
   if (apiProcess) apiProcess.kill();
   if (pgInstance) await pgInstance.stop();

--- a/tests/test_electron_build_config.py
+++ b/tests/test_electron_build_config.py
@@ -551,3 +551,28 @@ def test_shell_pypi_auto_check_on_load():
         f"runPyPICheck appears only {count} time(s) in shell.py. "
         "Expect at least 3: function definition, click handler body, and auto-call on load."
     )
+
+
+def test_main_js_cmd_q_quits_fully():
+    """Cmd+Q (before-quit) must set isQuitting=true so the close handler lets it through.
+
+    Without this, event.preventDefault() in the 'close' handler intercepts the
+    quit-triggered close event too, making Cmd+Q appear to do nothing on macOS.
+    """
+    src = _main_src()
+    assert "isQuitting" in src, (
+        "main.js does not use an isQuitting flag. "
+        "Cmd+Q will be intercepted by the close handler and appear to do nothing on macOS."
+    )
+    assert "isQuitting = true" in src, (
+        "main.js never sets isQuitting = true. "
+        "The before-quit handler must set it so the close handler stops hiding the window."
+    )
+    # The close handler must check the flag before hiding
+    close_idx = src.find("mainWindow.on(\"close\"")
+    assert close_idx != -1, "close handler not found"
+    close_block = src[close_idx: close_idx + 300]
+    assert "isQuitting" in close_block, (
+        "The close handler does not check isQuitting. "
+        "Cmd+Q will still be intercepted and the app will not quit."
+    )

--- a/tests/test_routers/test_auth.py
+++ b/tests/test_routers/test_auth.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import time
 import pytest
 
 
@@ -218,8 +219,13 @@ async def test_single_user_gate_empty_tracker_allows_login(client):
 
 
 @pytest.mark.asyncio
-async def test_single_user_gate_blocks_same_user_relogin(client):
-    """Gate: same user attempting re-login while already active is blocked (no exclude=self)."""
+async def test_single_user_gate_allows_same_user_relogin(client):
+    """Gate: same user re-logging in while their own session is still tracked is allowed.
+
+    Scenario: user's token expired (or they logged out without the tracker being cleared),
+    and they try to log in again. They should not be blocked by their own stale session.
+    Only *other* users count as a conflict.
+    """
     from unittest.mock import patch
     from celerp.services.session_tracker import clear as _clear_tracker, record as _record
     import base64, json as _json
@@ -237,13 +243,13 @@ async def test_single_user_gate_blocks_same_user_relogin(client):
     payload_b64 = token.split(".")[1] + "=="
     user_id = _json.loads(base64.b64decode(payload_b64))["sub"]
 
-    # Seed tracker with THIS user (simulates their own existing session)
+    # Seed tracker with THIS user (simulates their own existing/stale session)
     _record(user_id, company_id="")
 
-    # Same user re-login -> blocked (universal gate, no self-exclusion) when relay not connected
+    # Same user re-login -> allowed (only OTHER users block access)
     with patch("celerp.gateway.state.get_session_token", return_value=""):
         r2 = await client.post("/auth/login", json={"email": "gate3@test.com", "password": "longpass123"})
-    assert r2.status_code == 409, f"Same-user re-login should be blocked, got {r2.status_code}: {r2.text}"
+    assert r2.status_code == 200, f"Same-user re-login should be allowed, got {r2.status_code}: {r2.text}"
 
 
 @pytest.mark.asyncio
@@ -291,7 +297,12 @@ async def test_single_user_gate_survives_tracker_reload(client, tmp_path):
         r1 = await client.post("/auth/login", json={"email": "reload@test.com", "password": "longpass123"})
         assert r1.status_code == 200
 
-        # Force a save so the file is populated
+        # Inject a *different* user into the tracker to represent a foreign active session
+        import uuid as _uuid
+        foreign_id = str(_uuid.uuid4())
+        _tracker._activity[("", foreign_id)] = time.time()
+
+        # Force a save so the file is populated with the foreign session
         _tracker._save()
 
         # Simulate process reload: wipe in-memory state but keep the file
@@ -301,7 +312,7 @@ async def test_single_user_gate_survives_tracker_reload(client, tmp_path):
         _tracker._loaded = False  # force re-load from file on next call
 
         try:
-            # Gate must still fire after in-memory wipe (reads from file)
+            # Gate must still fire after in-memory wipe (foreign session read from file)
             with patch("celerp.gateway.state.get_session_token", return_value=""):
                 r2 = await client.post("/auth/login", json={"email": "reload@test.com", "password": "longpass123"})
             assert r2.status_code == 409, f"Gate should persist after tracker reload, got {r2.status_code}: {r2.text}"

--- a/ui/components/shell.py
+++ b/ui/components/shell.py
@@ -510,11 +510,15 @@ document.addEventListener('DOMContentLoaded', function() {
       });
 
       window.celerp.onDownloadProgress(function(progress) {
-        setProgress(progress.percent || 0);
+        var pct = progress && typeof progress.percent === 'number' ? progress.percent : 0;
+        setProgress(pct);
+        // Also update state text so user sees live percentage
+        setState('Downloading... ' + Math.round(pct) + '%', false);
       });
 
       window.celerp.onUpdateNotAvailable(function() {
         setState('Up to date', false);
+        appendLog('Already on the latest version.');
         resetToIdle();
       });
 

--- a/ui/routes/auth.py
+++ b/ui/routes/auth.py
@@ -240,6 +240,17 @@ def setup_routes(app):
 
     @app.post("/logout")
     async def logout(request: Request):
+        token = request.cookies.get(COOKIE_NAME)
+        if token:
+            try:
+                from celerp.services.auth import _decode_token
+                claims = _decode_token(token)
+                user_id = claims.get("sub")
+                if user_id:
+                    from celerp.services.session_tracker import evict as _evict
+                    _evict(user_id)
+            except Exception:
+                pass
         resp = RedirectResponse("/login", status_code=302)
         _clear_tokens(resp)
         return resp
@@ -247,6 +258,17 @@ def setup_routes(app):
     @app.get("/logout")
     async def logout_get(request: Request):
         """GET fallback for no-JS clients. Clears tokens and redirects."""
+        token = request.cookies.get(COOKIE_NAME)
+        if token:
+            try:
+                from celerp.services.auth import _decode_token
+                claims = _decode_token(token)
+                user_id = claims.get("sub")
+                if user_id:
+                    from celerp.services.session_tracker import evict as _evict
+                    _evict(user_id)
+            except Exception:
+                pass
         resp = RedirectResponse("/login", status_code=302)
         _clear_tokens(resp)
         return resp


### PR DESCRIPTION
## Changes

### fix(electron): Cmd+Q fully quits on macOS
- Added `isQuitting` flag set in `before-quit`; close handler skips hide when quitting
- Previously Cmd+Q was intercepted by the hide-on-close handler and appeared to do nothing

### fix(updater): progress bar + "up to date" log message
- Download progress shows live percentage in state text ("Downloading... 42%")
- `onUpdateNotAvailable` now appends "Already on the latest version." to the log panel so user knows the check completed
- `progress.percent` guarded against null/undefined

### fix(auth): 409 direct_connection_limit login loop
- `/login` now excludes the requesting user from the active-session check — same user re-logging in after token expiry or logout is no longer blocked
- `logout` (both POST and GET) evicts the user from the session tracker immediately, so re-login works right away
- `login-force` ("Continue, sign out the other user") remains unchanged — still clears all sessions

## Test status
- Full suite: **2954 passed, 0 failed**
- Electron build config: 33/33 passed