### PR TITLE
fix(electron): update progress bar fill invisible due to undefined --c-primary

### DIFF
--- a/ui/static/app.css
+++ b/ui/static/app.css
@@ -2045,7 +2045,7 @@ a:hover { text-decoration: underline; }
 .update-card__progress-fill {
   height: 100%;
   width: 0%;
-  background: var(--c-primary);
+  background: var(--c-accent);
   border-radius: 3px;
   transition: width 0.3s ease;
 }


### PR DESCRIPTION
## Problem
On Mac, the download progress bar appeared frozen during updates while the text label correctly showed the percentage (e.g. "Downloading... 85%").

## Root Cause
`update-card__progress-fill` used `background: var(--c-primary)` but `--c-primary` is not defined in `:root`. The fill was transparent/invisible - the bar was mechanically updating its width but nothing was visible.

## Fix
One-line CSS change: `var(--c-primary)` → `var(--c-accent)` (`#0ea57a`), consistent with every other progress fill in the codebase (`import-progress-fill`, `recon-progress-fill`, `ai-settings__progress-fill`).