### PR TITLE
fix(electron): restart-to-install button hides app instead of quitting on macOS

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -628,6 +628,7 @@ ipcMain.handle("check-for-updates", () => {
 // Electron's process lingers long enough for ShipIt to see it and cancel. We kill
 // subprocesses first, then give them 500ms to exit before handing off to ShipIt.
 ipcMain.on("install-update", async () => {
+  isQuitting = true;  // prevent the macOS hide-on-close handler from blocking quit
   if (uiProcess) uiProcess.kill();
   if (apiProcess) apiProcess.kill();
   if (pgInstance) {


### PR DESCRIPTION
## Problem
Clicking "Restart to Install" after an update downloads hides the app instead of quitting it. User has to manually quit via Cmd+Q.

## Root Cause
`isQuitting` flag was not set before calling `quitAndInstall()`. On macOS, Electron's `window.close` event fires during `app.quit()`, and the hide-on-close handler (`event.preventDefault() + mainWindow.hide()`) intercepts it because `isQuitting` is still `false`. Cmd+Q works because it triggers `before-quit` which sets `isQuitting = true` before the close event.

## Fix
One line: `isQuitting = true` at the top of the `install-update` IPC handler, before killing child processes. Matches the existing Cmd+Q code path.