### PR TITLE
fix(build): universal macOS DMG - bundle both darwin postgres arches

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -102,11 +102,7 @@ jobs:
         run: |
           # Force pnpm to install optional deps for BOTH darwin arches so the
           # universal DMG contains @embedded-postgres/darwin-x64 (not just arm64).
-          cat >> .npmrc <<'EOF'
-          supportedArchitectures[cpu][]=arm64
-          supportedArchitectures[cpu][]=x64
-          supportedArchitectures[os][]=darwin
-          EOF
+          printf 'supportedArchitectures[cpu][]=arm64\nsupportedArchitectures[cpu][]=x64\nsupportedArchitectures[os][]=darwin\n' >> .npmrc
 
       - name: Install Node deps
         working-directory: electron

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -103,7 +103,7 @@ jobs:
           # pnpm 9 reads supportedArchitectures from pnpm-workspace.yaml (NOT .npmrc).
           # Write it before pnpm install so both darwin-arm64 and darwin-x64
           # optional packages are fetched and bundled into the universal DMG.
-          printf 'supportedArchitectures:\n  cpu:\n    - arm64\n    - x64\n  os:\n    - darwin\n' > pnpm-workspace.yaml
+          printf 'packages:\n  - "."\nsupportedArchitectures:\n  cpu:\n    - arm64\n    - x64\n  os:\n    - darwin\n' > pnpm-workspace.yaml
           echo "pnpm-workspace.yaml written:"
           cat pnpm-workspace.yaml
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -95,6 +95,19 @@ jobs:
         with:
           version: 9
 
+      - name: Configure pnpm for universal macOS build
+        if: matrix.os == 'macos-latest'
+        working-directory: electron
+        shell: bash
+        run: |
+          # Force pnpm to install optional deps for BOTH darwin arches so the
+          # universal DMG contains @embedded-postgres/darwin-x64 (not just arm64).
+          cat >> .npmrc <<'EOF'
+          supportedArchitectures[cpu][]=arm64
+          supportedArchitectures[cpu][]=x64
+          supportedArchitectures[os][]=darwin
+          EOF
+
       - name: Install Node deps
         working-directory: electron
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -95,18 +95,6 @@ jobs:
         with:
           version: 9
 
-      - name: Configure pnpm for universal macOS build
-        if: matrix.os == 'macos-latest'
-        working-directory: electron
-        shell: bash
-        run: |
-          # pnpm 9 reads supportedArchitectures from pnpm-workspace.yaml (NOT .npmrc).
-          # Write it before pnpm install so both darwin-arm64 and darwin-x64
-          # optional packages are fetched and bundled into the universal DMG.
-          printf 'packages:\n  - "."\nsupportedArchitectures:\n  cpu:\n    - arm64\n    - x64\n  os:\n    - darwin\n' > pnpm-workspace.yaml
-          echo "pnpm-workspace.yaml written:"
-          cat pnpm-workspace.yaml
-
       - name: Install Node deps
         working-directory: electron
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -100,9 +100,12 @@ jobs:
         working-directory: electron
         shell: bash
         run: |
-          # Force pnpm to install optional deps for BOTH darwin arches so the
-          # universal DMG contains @embedded-postgres/darwin-x64 (not just arm64).
-          printf 'supportedArchitectures[cpu][]=arm64\nsupportedArchitectures[cpu][]=x64\nsupportedArchitectures[os][]=darwin\n' >> .npmrc
+          # pnpm 9 reads supportedArchitectures from pnpm-workspace.yaml (NOT .npmrc).
+          # Write it before pnpm install so both darwin-arm64 and darwin-x64
+          # optional packages are fetched and bundled into the universal DMG.
+          printf 'supportedArchitectures:\n  cpu:\n    - arm64\n    - x64\n  os:\n    - darwin\n' > pnpm-workspace.yaml
+          echo "pnpm-workspace.yaml written:"
+          cat pnpm-workspace.yaml
 
       - name: Install Node deps
         working-directory: electron

--- a/electron/package.json
+++ b/electron/package.json
@@ -97,13 +97,7 @@
         {
           "target": "dmg",
           "arch": [
-            "universal"
-          ]
-        },
-        {
-          "target": "zip",
-          "arch": [
-            "universal"
+            "x64"
           ]
         }
       ],

--- a/electron/package.json
+++ b/electron/package.json
@@ -99,7 +99,13 @@
         {
           "target": "dmg",
           "arch": [
-            "x64"
+            "universal"
+          ]
+        },
+        {
+          "target": "zip",
+          "arch": [
+            "universal"
           ]
         }
       ],

--- a/electron/package.json
+++ b/electron/package.json
@@ -16,7 +16,9 @@
   },
   "dependencies": {
     "electron-updater": "^6.3.0",
-    "embedded-postgres": "^17.9.0-beta.16"
+    "embedded-postgres": "^17.9.0-beta.16",
+    "@embedded-postgres/darwin-arm64": "17.9.0-beta.16",
+    "@embedded-postgres/darwin-x64": "17.9.0-beta.16"
   },
   "devDependencies": {
     "electron": "^30.0.0",

--- a/electron/pnpm-lock.yaml
+++ b/electron/pnpm-lock.yaml
@@ -13,6 +13,12 @@ importers:
 
   .:
     dependencies:
+      '@embedded-postgres/darwin-arm64':
+        specifier: 17.9.0-beta.16
+        version: 17.9.0-beta.16
+      '@embedded-postgres/darwin-x64':
+        specifier: 17.9.0-beta.16
+        version: 17.9.0-beta.16
       electron-updater:
         specifier: ^6.3.0
         version: 6.8.3
@@ -2705,11 +2711,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@embedded-postgres/darwin-arm64@17.9.0-beta.16':
-    optional: true
+  '@embedded-postgres/darwin-arm64@17.9.0-beta.16': {}
 
-  '@embedded-postgres/darwin-x64@17.9.0-beta.16':
-    optional: true
+  '@embedded-postgres/darwin-x64@17.9.0-beta.16': {}
 
   '@embedded-postgres/linux-arm64@17.9.0-beta.16':
     optional: true


### PR DESCRIPTION
## Summary

Fixes the `Cannot find package '@embedded-postgres/darwin-x64'` error on Intel Macs.

### Root cause
`pnpm install` on the arm64 CI runner only fetches optional platform packages matching the runner's architecture. `@embedded-postgres/darwin-x64` was never installed, so it wasn't bundled into the universal DMG, causing Intel Macs to fail at startup.

### Fix
Added `@embedded-postgres/darwin-arm64` and `@embedded-postgres/darwin-x64` as explicit **direct** dependencies in `electron/package.json`. pnpm never skips direct deps regardless of runner platform — both are always installed and bundled.

### Tested
- x64 DMG confirmed working on Apple Silicon Mac (Rosetta) by Nikolai
- Universal DMG target restored (arm64 + x64)

### Commits
- `1cb429d5` fix(build): initial attempt (incorrect - .npmrc approach)
- `a967ba26` fix(build): add @embedded-postgres darwin packages as direct deps ✅
- `fa8ff28d` revert(build): restore universal macOS DMG target