### PR TITLE
Fix inventory file handling and cloud-relay reliability

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ name: Build Binaries
 on:
   push:
     tags: ["v*"]
-    branches: ["develop"]
+    branches: ["develop", "bugfix"]
   workflow_dispatch:
 
 permissions:
@@ -68,29 +68,32 @@ jobs:
           done
           echo "Assets cleared"
 
+  # Compute the build matrix: the bugfix branch builds macOS only (a fast unsigned
+  # test DMG); every other ref builds all three platforms.
+  setup-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.gen.outputs.matrix }}
+    steps:
+      - id: gen
+        shell: bash
+        run: |
+          mac='{"os":"macos-latest","build_cmd":"pnpm run build:mac","platform_flag":"--mac","standalone_dir":"mac-arm64","pbs_triple":"aarch64-apple-darwin"}'
+          win='{"os":"windows-latest","build_cmd":"pnpm run build:win","platform_flag":"--win","standalone_dir":"win-x64","pbs_triple":"x86_64-pc-windows-msvc"}'
+          lin='{"os":"ubuntu-latest","build_cmd":"pnpm run build:linux","platform_flag":"--linux","standalone_dir":"linux-x64","pbs_triple":"x86_64-unknown-linux-gnu"}'
+          if [ "${{ github.ref_name }}" = "bugfix" ]; then
+            echo "matrix={\"include\":[$mac]}" >> "$GITHUB_OUTPUT"
+          else
+            echo "matrix={\"include\":[$lin,$win,$mac]}" >> "$GITHUB_OUTPUT"
+          fi
+
   build:
-    needs: [prepare-release]
+    needs: [prepare-release, setup-matrix]
     # prepare-release is skipped on non-tag builds; treat skipped as success.
-    if: always() && (needs.prepare-release.result == 'success' || needs.prepare-release.result == 'skipped')
+    if: always() && (needs.prepare-release.result == 'success' || needs.prepare-release.result == 'skipped') && needs.setup-matrix.result == 'success'
     strategy:
       fail-fast: false
-      matrix:
-        include:
-          - os: ubuntu-latest
-            build_cmd: pnpm run build:linux
-            platform_flag: --linux
-            standalone_dir: linux-x64
-            pbs_triple: x86_64-unknown-linux-gnu
-          - os: windows-latest
-            build_cmd: pnpm run build:win
-            platform_flag: --win
-            standalone_dir: win-x64
-            pbs_triple: x86_64-pc-windows-msvc
-          - os: macos-latest
-            build_cmd: pnpm run build:mac
-            platform_flag: --mac
-            standalone_dir: mac-arm64
-            pbs_triple: aarch64-apple-darwin
+      matrix: ${{ fromJSON(needs.setup-matrix.outputs.matrix) }}
 
     runs-on: ${{ matrix.os }}
     timeout-minutes: 180
@@ -341,13 +344,26 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: pnpm run build:mac -- --publish always
 
-      - name: Build macOS (dev - signed only, no notarization)
-        if: matrix.os == 'macos-latest' && !startsWith(github.ref, 'refs/tags/v')
+      - name: Build macOS (develop dev - signed only, no notarization)
+        if: matrix.os == 'macos-latest' && !startsWith(github.ref, 'refs/tags/v') && github.ref_name != 'bugfix'
         timeout-minutes: 60
         working-directory: electron
         env:
           CSC_LINK: ${{ secrets.APPLE_CERTIFICATE }}
           CSC_KEY_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+        run: pnpm exec electron-builder ${{ matrix.platform_flag }} --publish never
+
+      - name: Build macOS (bugfix dev - UNSIGNED, fast)
+        # bugfix-branch dev builds skip macOS code signing (~20 min) entirely to
+        # speed up the test loop. The resulting .app/.dmg is unsigned and is for our
+        # own testing only — get it past Gatekeeper with
+        #   xattr -dr com.apple.quarantine /Applications/Celerp.app
+        # (or right-click -> Open). Not for distribution.
+        if: matrix.os == 'macos-latest' && github.ref_name == 'bugfix'
+        timeout-minutes: 60
+        working-directory: electron
+        env:
+          CSC_IDENTITY_AUTO_DISCOVERY: "false"
         run: pnpm exec electron-builder ${{ matrix.platform_flag }} --publish never
 
       - name: Build (Windows / Linux - release tag)
@@ -475,7 +491,9 @@ jobs:
           if-no-files-found: warn
 
       - name: Release (dev build)
-        if: "!startsWith(github.ref, 'refs/tags/v')"
+        # bugfix builds stay as downloadable workflow artifacts only (above) — don't
+        # publish them to the shared dev-latest release, which tracks develop.
+        if: ${{ !startsWith(github.ref, 'refs/tags/v') && github.ref_name != 'bugfix' }}
         uses: softprops/action-gh-release@v2
         with:
           tag_name: dev-latest

--- a/celerp/gateway/client.py
+++ b/celerp/gateway/client.py
@@ -126,7 +126,11 @@ class GatewayClient:
     async def _connect_and_serve(self) -> None:
         log.debug("Connecting to gateway at %s", self._url)
         self._relay_status = "connecting"
-        async with websockets.connect(self._url, ping_interval=None) as ws:
+        # Keepalive on: a silently-dead connection (e.g. the host sleeping) raises
+        # ConnectionClosed within ~ping_interval+ping_timeout, so _connect_and_serve
+        # exits and run()'s backoff loop reconnects — instead of blocking forever on
+        # a half-open socket while the relay returns 502.
+        async with websockets.connect(self._url, ping_interval=20, ping_timeout=20) as ws:
             self._ws = ws
             # Read current TOS version from config
             from celerp.config import read_config

--- a/celerp/gateway/client.py
+++ b/celerp/gateway/client.py
@@ -282,11 +282,14 @@ class GatewayClient:
             })
             return
 
-        # API-only paths go to the API server; everything else to the UI
-        if path.startswith("/api/") or path.startswith("/openapi"):
-            port = self._api_port
-        else:
-            port = self._ui_port
+        # Everything proxied through the relay goes to the UI server. The browser
+        # only ever talks to the UI server — including routes under /api/, which are
+        # UI-server endpoints (HTMX fragments, image/barcode previews, item & bulk
+        # actions), NOT the internal data API. The API server (self._api_port) is an
+        # internal backend the UI calls server-side via api_client and is never
+        # browser-facing, so routing /api/* there over the relay just 404s those UI
+        # routes (barcode preview, label-templates, bulk split/merge, etc.).
+        port = self._ui_port
 
         url = f"http://127.0.0.1:{port}{path}"
         if query:

--- a/celerp/routers/health.py
+++ b/celerp/routers/health.py
@@ -76,7 +76,10 @@ async def cloud_status() -> dict:
     from celerp.gateway.state import get_session_token
     gw = get_client()
     relay_status = gw.relay_status if gw else "inactive"
-    connected = relay_status in ("active", "tos_required", "connecting", "error")
+    # Only report "connected" (green dot) when the tunnel is really up. "connecting"
+    # and "error" are transient/failed states — reporting them as connected is the
+    # "green but still 502" the user sees while the relay has no live upstream.
+    connected = relay_status in ("active", "tos_required")
     if not connected:
         return {"connected": False, "relay_status": relay_status, "tier": None, "last_backup": None, "email_quota": 0, "email_used": 0, "public_url": settings.celerp_public_url, "gateway_token_set": bool(settings.gateway_token)}
 

--- a/default_modules/celerp-inventory/celerp_inventory/routes_attachments.py
+++ b/default_modules/celerp-inventory/celerp_inventory/routes_attachments.py
@@ -330,16 +330,11 @@ async def bulk_attach_files(
                     idempotency_key=str(uuid.uuid4()),
                     metadata_={},
                 )
-                # Keep in-memory projection current for subsequent files on same SKU
-                from celerp_inventory.projections import apply_item_event as _apply
-                row.state = _apply(dict(row.state), "item.file.attached", {
-                    "entity_id": row.entity_id, "entity_type": "item",
-                    "file_id": meta["id"], "filename": meta["filename"],
-                    "mime": meta["mime"], "size": meta["size"],
-                    "url": meta.get("url", ""), "document_tag": tag,
-                    "description": label, "uploaded_at": datetime.now(timezone.utc).isoformat(),
-                    "is_hero": is_hero,
-                })
+                # NOTE: do NOT re-apply the event here. emit_event() ->
+                # ProjectionEngine.apply_event already appended the file to this
+                # same projection row (session identity map), so row.state is
+                # current for the next file on this SKU. Re-applying double-counts
+                # the file (two entries with the same file_id) — see F1.
 
                 matched += 1
                 report.append({"sku": sku_part, "file": name, "status": "ok",

--- a/default_modules/celerp-inventory/celerp_inventory/routes_attachments.py
+++ b/default_modules/celerp-inventory/celerp_inventory/routes_attachments.py
@@ -256,7 +256,10 @@ async def bulk_attach_files(
 
     with zipfile.ZipFile(io.BytesIO(content)) as zf:
         for name in sorted(zf.namelist()):  # sorted for deterministic hero selection
-            if name.endswith("/") or name.startswith("__") or name.startswith("."):
+            # Check the BASENAME, not the full ZIP path, so nested junk like
+            # sub/.DS_Store is skipped too (the full name doesn't start with '.') — F5.
+            base = _Path(name).name
+            if name.endswith("/") or base.startswith("__") or base.startswith("."):
                 continue
 
             stem = _Path(name).stem

--- a/tests/test_electron_build_config.py
+++ b/tests/test_electron_build_config.py
@@ -393,7 +393,8 @@ def test_build_yml_has_prepare_release_job():
         "build.yml is missing a 'prepare-release' job. "
         "Add it to run asset-clearing before the build matrix starts."
     )
-    assert "needs: [prepare-release]" in yml or "needs: prepare-release" in yml, (
+    # Accept prepare-release alone or alongside other deps (e.g. setup-matrix).
+    assert "needs: [prepare-release" in yml or "needs: prepare-release" in yml, (
         "The build matrix job does not declare 'needs: prepare-release'. "
         "Without this, the build matrix runs in parallel with prepare-release."
     )

--- a/tests/test_gateway/test_client.py
+++ b/tests/test_gateway/test_client.py
@@ -270,3 +270,32 @@ async def test_tos_required_blocks_reconnect(client, monkeypatch):
     # Should have connected once, then looped in tos_required wait
     assert len(connect_calls) == 1
     assert len(wait_calls) >= 1
+
+
+@pytest.mark.asyncio
+async def test_connect_and_serve_uses_keepalive(client, monkeypatch):
+    """The relay WS must open with keepalive (ping_interval/ping_timeout) so a
+    silently-dead connection (e.g. the Mac sleeping) raises and the backoff loop
+    reconnects. With ping_interval=None a half-open socket never raises, so the
+    client never reconnects and the relay returns 502 until a manual restart.
+    """
+    import celerp.gateway.client as gwc
+    captured = {}
+
+    class _CM:
+        async def __aenter__(self):
+            raise ConnectionError("stop after capturing connect kwargs")
+        async def __aexit__(self, *a):
+            return False
+
+    def fake_connect(url, **kwargs):
+        captured["url"] = url
+        captured.update(kwargs)
+        return _CM()
+
+    monkeypatch.setattr(gwc.websockets, "connect", fake_connect)
+    with pytest.raises(ConnectionError):
+        await client._connect_and_serve()
+
+    assert captured.get("ping_interval") == 20, captured
+    assert captured.get("ping_timeout") == 20, captured

--- a/tests/test_gateway/test_client.py
+++ b/tests/test_gateway/test_client.py
@@ -299,3 +299,53 @@ async def test_connect_and_serve_uses_keepalive(client, monkeypatch):
 
     assert captured.get("ping_interval") == 20, captured
     assert captured.get("ping_timeout") == 20, captured
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("path", [
+    "/api/labels/preview/barcode",
+    "/api/items/bulk/split-preview",
+    "/inventory/x",
+])
+async def test_proxy_routes_everything_to_ui_server(client, monkeypatch, path):
+    """Relay-proxied requests (including /api/*) must go to the UI server (8080).
+
+    The browser only ever talks to the UI server; the /api/* routes it calls are
+    UI-server endpoints (HTMX fragments / previews), not the internal data API. The
+    API server (8000) is an internal backend the UI calls server-side, so sending
+    /api/* there over the relay 404s those UI routes.
+    """
+    client._ui_port = 8080
+    client._api_port = 8000
+
+    captured = {}
+
+    class FakeResp:
+        status_code = 200
+        content = b"ok"
+        headers = {}
+
+    class FakeClient:
+        def __init__(self, *a, **k):
+            pass
+        async def __aenter__(self):
+            return self
+        async def __aexit__(self, *a):
+            return False
+        async def request(self, method, url, headers=None, content=None):
+            captured["url"] = url
+            return FakeResp()
+
+    monkeypatch.setattr("httpx.AsyncClient", FakeClient)
+
+    async def fake_send(ws, msg):
+        pass
+    monkeypatch.setattr(client.__class__, "_send", staticmethod(fake_send))
+    client._ws = object()
+
+    await client._handle_proxy_request({
+        "id": "r1", "method": "GET", "path": path,
+        "query": "", "headers": {}, "body_b64": "",
+    })
+    assert "127.0.0.1:8080" in captured["url"], captured
+    assert "127.0.0.1:8000" not in captured["url"], captured

--- a/tests/test_routers/test_cloud_relay.py
+++ b/tests/test_routers/test_cloud_relay.py
@@ -642,3 +642,19 @@ async def test_connector_authorize_url_shopify_passes_shop(client):
     assert r.status_code == 200
     assert "authorize_url" in r.json()
     assert captured_params.get("shop") == "my-shop.myshopify.com"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("status", ["connecting", "error"])
+async def test_cloud_status_not_connected_while_connecting_or_error(client, status):
+    """The relay dot must NOT report connected (green) for transient/failed states
+    — only 'active'/'tos_required'. It was greening on 'connecting'/'error', i.e.
+    showing "connected" while the relay was actually returning 502."""
+    token = await _register(client, status)
+    gw = _mock_gw(status)
+    with patch("celerp.gateway.client.get_client", return_value=gw), \
+         patch("celerp.gateway.state.get_session_token", return_value="tok"):
+        r = await client.get("/settings/cloud-status", headers=_h(token))
+    assert r.status_code == 200
+    assert r.json()["connected"] is False, r.json()
+    assert r.json()["relay_status"] == status

--- a/tests/test_routers/test_items.py
+++ b/tests/test_routers/test_items.py
@@ -1719,6 +1719,30 @@ async def test_bulk_attach_does_not_duplicate_files(client):
 
 
 @pytest.mark.asyncio
+async def test_bulk_attach_skips_nested_dotfiles(client):
+    """F5: a nested dotfile (sub/.DS_Store) must be skipped, not processed as
+    unmatched. It slips the skip because its full ZIP path doesn't start with
+    '.'/'__' — the skip must look at the basename.
+    """
+    token = await _token(client)
+    h = {"Authorization": f"Bearer {token}"}
+    await client.post("/items", json={"sku": "F5-ITEM-001", "name": "F5", "quantity": 1, "sell_by": "piece"}, headers=h)
+
+    fake_jpg = b"\xff\xd8\xff" + b"\x00" * 10
+    zdata = _make_zip({
+        "F5-ITEM-001.jpg": fake_jpg,   # valid → should match
+        "sub/.DS_Store": b"x",         # nested junk → must be skipped
+    })
+    result = await client.post("/items/files/bulk", files={"file": ("attach.zip", zdata, "application/zip")}, headers=h)
+    assert result.status_code == 200, result.text
+    data = result.json()
+    assert data["matched"] == 1, data
+    assert data["unmatched"] == 0, f"nested dotfile should be skipped, not unmatched: {data}"
+    reported = " ".join(r.get("file", "") for r in data["report"])
+    assert ".DS_Store" not in reported, reported
+
+
+@pytest.mark.asyncio
 async def test_bulk_attach_multi_image_only_first_hero(client):
     """First alphabetical bare image gets hero; second does not."""
     token = await _token(client)

--- a/tests/test_routers/test_items.py
+++ b/tests/test_routers/test_items.py
@@ -1689,6 +1689,36 @@ async def test_bulk_attach_bare_image_is_hero(client):
 
 
 @pytest.mark.asyncio
+async def test_bulk_attach_does_not_duplicate_files(client):
+    """F1: bulk attach must add each file exactly ONCE.
+
+    Regression for the double-applied `item.file.attached` event (emit_event
+    already updates the projection, and the handler re-applied it manually), which
+    left each bulk-attached file twice in state.files with the same file_id.
+    """
+    token = await _token(client)
+    h = {"Authorization": f"Bearer {token}"}
+    r = await client.post("/items", json={"sku": "BULK-DUP-001", "name": "Dup", "quantity": 1, "sell_by": "piece"}, headers=h)
+    assert r.status_code == 200
+    item_id = r.json()["id"]
+
+    fake_jpg = b"\xff\xd8\xff" + b"\x00" * 10
+    zdata = _make_zip({
+        "BULK-DUP-001.jpg": fake_jpg,
+        "BULK-DUP-001-cert-grs.pdf": b"%PDF-1.4",
+    })
+    result = await client.post("/items/files/bulk", files={"file": ("dup.zip", zdata, "application/zip")}, headers=h)
+    assert result.status_code == 200, result.text
+    assert result.json()["matched"] == 2
+
+    item = (await client.get(f"/items/{item_id}", headers=h)).json()
+    files = item.get("files") or (item.get("attributes") or {}).get("files") or []
+    ids = [f.get("id") for f in files]
+    assert len(ids) == len(set(ids)), f"duplicate file_ids after bulk attach: {ids}"
+    assert len(files) == 2, f"expected 2 distinct files, got {len(files)}: {ids}"
+
+
+@pytest.mark.asyncio
 async def test_bulk_attach_multi_image_only_first_hero(client):
     """First alphabetical bare image gets hero; second does not."""
     token = await _token(client)

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -13685,3 +13685,25 @@ class TestDangerZoneUI:
             r = await ui_client.get("/settings/general?tab=company", cookies=_authed(role="admin"))
         assert r.status_code == 200
         assert "Reset All Data" not in r.text
+
+
+@pytest.mark.asyncio
+async def test_item_files_section_applies_tag_filter(ui_client):
+    """F3: GET /items/{id}/files/_section?tag_filter=X must apply the tag filter
+    (show only that tag's files), not silently reset to "All tags"."""
+    item = {
+        "entity_id": "item:f3", "id": "item:f3", "sku": "F3", "name": "F3 Item",
+        "files": [
+            {"id": "a", "filename": "front-photo.jpg", "mime": "image/jpeg",
+             "size": 1, "url": "/x/a", "document_tag": "product_images"},
+            {"id": "b", "filename": "gia-report.pdf", "mime": "application/pdf",
+             "size": 1, "url": "/x/b", "document_tag": "certificates"},
+        ],
+    }
+    with patch("ui.api_client.get_item", new=AsyncMock(return_value=item)):
+        r = await ui_client.get(
+            "/items/item:f3/files/_section?tag_filter=certificates", cookies=_authed())
+    assert r.status_code == 200, r.text
+    body = r.text
+    assert "gia-report" in body, "the certificates file should be shown"
+    assert "front-photo" not in body, "the product_images file must be filtered out"

--- a/ui/routes/inventory.py
+++ b/ui/routes/inventory.py
@@ -3894,7 +3894,13 @@ function celerpPrintLabel(entityId, templateId) {
             item = await api.get_item(token, entity_id)
         except APIError as e:
             return P(str(e.detail), cls="cell-error")
-        return _item_files_section(entity_id, item, show_preview=_item_files_preview(request))
+        qp = request.query_params
+        return _item_files_section(
+            entity_id, item, show_preview=_item_files_preview(request),
+            tag_filter=qp.get("tag_filter", ""), search=qp.get("search", ""),
+            sort_dir=qp.get("sort_dir", "desc"), page=int(qp.get("page") or 1),
+            date_from=qp.get("date_from", ""), date_to=qp.get("date_to", ""),
+        )
 
     @app.get("/items/{entity_id}/files/{file_id}/download")
     async def item_download_file(request: Request, entity_id: str, file_id: str):
@@ -5072,7 +5078,7 @@ def _item_files_preview(request: Request) -> bool:
     return "tab=manufacturing" not in request.headers.get("HX-Current-URL", "")
 
 
-def _item_files_section(entity_id: str, item: dict, *, title: str = "Production documents & images", show_preview: bool = False) -> FT:
+def _item_files_section(entity_id: str, item: dict, *, title: str = "Production documents & images", show_preview: bool = False, tag_filter: str = "", search: str = "", sort_dir: str = "desc", page: int = 1, date_from: str = "", date_to: str = "") -> FT:
     """Render the shared files section for an item, with hero toggle enabled.
 
     Titled "Production documents & images" everywhere it appears (Details +
@@ -5112,7 +5118,9 @@ def _item_files_section(entity_id: str, item: dict, *, title: str = "Production 
     # show_preview=True to put thumbnails back next to filenames. No hero column either way (set
     # the hero by clicking a gallery thumbnail); compact filters keep the bar on one row.
     return _shared_files_section("item", entity_id, files, can_set_hero=False, show_linked=False,
-                                 title=title, show_preview=show_preview, compact=True)
+                                 title=title, show_preview=show_preview, compact=True,
+                                 tag_filter=tag_filter, search=search, sort_dir=sort_dir,
+                                 page=page, date_from=date_from, date_to=date_to)
 
 
 def _recipe_money(v, currency: str | None) -> str:


### PR DESCRIPTION
## What this changes

Bug fixes across inventory file handling and the cloud relay, plus a CI tweak.

**Inventory / files**
- **Bulk attach no longer duplicates files.** The attach handler applied each
  file-attached event twice — once via the event engine (which already updates the
  projection) and once manually — so every bulk-attached file showed up twice.
  Removed the redundant re-apply.
- **The item "Documents & Images" tag filter and search now apply.** The section
  refresh endpoint dropped the filter query params, so the tag control snapped back
  to "All tags" and the list never filtered. It now reads and forwards them.
- **Nested OS junk files are skipped on bulk attach.** The skip checked the full
  ZIP path, so a nested dotfile (e.g. `sub/.DS_Store`) slipped through as
  "unmatched". It now checks the basename.

**Cloud relay**
- **The relay recovers automatically after the host sleeps, and the status
  indicator is honest.** Enabled WebSocket keepalive (ping interval/timeout) so a
  silently-dead connection (host asleep) raises and the existing reconnect loop
  fires — instead of the host staying unreachable (502) until a manual restart. The
  indicator now reports "connected" only when the tunnel is actually active (it
  previously turned green on transient/failed states).
- **Relay-proxied requests now route to the UI server.** The browser only talks to
  the UI server, and the routes it calls under `/api/*` are UI-server endpoints
  (HTMX fragments, image/barcode previews, item & bulk actions), not the internal
  data API. Sending them to the API server over the relay returned 404 — so barcode
  previews, label-template pickers, and bulk split/merge were unusable remotely
  while working locally. All proxied requests now go to the UI server.

**CI**
- Pushes to this branch build an **unsigned, macOS-only dev DMG** (skips ~20 min of
  code signing) for a faster test loop. It's uploaded as a workflow artifact only,
  not published to the shared dev release.

**Tests**
- Unit tests added/updated for each fix; the full unit suite passes locally. The
  browser suite is unchanged from baseline (only pre-existing failures remain).

## Contributor License Agreement

By submitting this pull request you acknowledge that it cannot be merged into an official Celerp
repository until the required **CLA acceptance** has been completed. If you have not already accepted the
current version of [`CLA.md`](https://github.com/celerp/celerp/blob/main/CLA.md), the CLA bot will comment
with the exact acceptance phrase. Posting that phrase from your authenticated GitHub account records your
acceptance of the current version of `CLA.md`.

- [X] I have read [`CONTRIBUTING.md`](https://github.com/celerp/celerp/blob/main/CONTRIBUTING.md) and
      [`CLA.md`](https://github.com/celerp/celerp/blob/main/CLA.md), and I will complete CLA acceptance
      through the CLA workflow when prompted.

## Checklist

- [x] Tests added or updated, and the relevant suites pass locally
- [x] License headers are correct for the paths touched (see `LICENSING.md`; enforced by `scripts/licenses.py`)
- [x] No new self-attribution or tool watermarks in code, commits, or docs