### PR TITLE
Require explicit opt-in to split items; imported items default to no-split

### DIFF
--- a/default_modules/celerp-docs/celerp_docs/routes.py
+++ b/default_modules/celerp-docs/celerp_docs/routes.py
@@ -3089,7 +3089,9 @@ async def fulfill_lines(
                 f"{sku}: insufficient stock — invoiced {line_qty:g}, available {available:g}"
             )
             continue
-        if line_qty + 1e-9 < available and not item_proj.state.get("allow_splitting", True):
+        # Split-on-fulfill is allowed only when splitting is explicitly enabled.
+        # A missing/None allow_splitting (e.g. older imports) must NOT bypass this.
+        if line_qty + 1e-9 < available and item_proj.state.get("allow_splitting") is not True:
             blocked.append(
                 f"{sku}: invoiced {line_qty:g} of {available:g} but 'Allow Splitting' is off — "
                 f"enable splitting or invoice the full quantity"

--- a/default_modules/celerp-docs/tests/test_fulfill_no_split.py
+++ b/default_modules/celerp-docs/tests/test_fulfill_no_split.py
@@ -1,0 +1,60 @@
+# Copyright (c) 2026 Noah Severs
+# SPDX-License-Identifier: MIT
+"""Fulfillment must respect 'no split' even when allow_splitting was never set.
+
+A partial draw on an invoice line splits the parcel (split-on-fulfill). The
+fulfillment guard must block that split for a parcel that isn't explicitly
+splittable — a missing/None allow_splitting (e.g. older imports) must not bypass
+the gate, the same as a manual split."""
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from sqlalchemy import select
+
+from celerp.models.projections import Projection
+
+
+async def _register(client) -> str:
+    addr = f"admin-{uuid.uuid4().hex[:8]}@nosplit.test"
+    r = await client.post("/auth/register", json={"company_name": "NoSplit Co", "email": addr, "name": "A", "password": "pw"})
+    assert r.status_code == 200
+    return r.json()["access_token"]
+
+
+def _h(t):
+    return {"Authorization": f"Bearer {t}"}
+
+
+@pytest.mark.asyncio
+async def test_partial_fulfillment_blocked_when_allow_splitting_missing(client, session):
+    token = await _register(client)
+    h = _h(token)
+
+    # Parcel with 10 in stock.
+    item = (await client.post("/items", headers=h, json={
+        "sku": "PARCEL-NS", "name": "Parcel", "quantity": 10, "sell_by": "piece"})).json()["id"]
+
+    # Remove allow_splitting from the parcel's projection state (as older imports left it).
+    row = (await session.execute(select(Projection).where(Projection.entity_id == item))).scalar_one()
+    new_state = dict(row.state)
+    new_state.pop("allow_splitting", None)
+    row.state = new_state
+    await session.commit()
+
+    # Invoice drawing a PARTIAL 3 of the 10 → fulfillment would split off a child.
+    doc = (await client.post("/docs", headers=h, json={"doc_type": "invoice", "line_items": [
+        {"entity_id": item, "sku": "PARCEL-NS", "name": "Parcel", "quantity": 3, "unit_price": 5, "sell_by": "piece"}],
+    })).json()["id"]
+    assert (await client.post(f"/docs/{doc}/finalize", headers=h)).status_code == 200
+
+    r = await client.post(f"/docs/{doc}/fulfill-lines", headers=h, json={"line_entity_ids": [item]})
+    assert r.status_code == 409, (
+        f"partial fulfillment of a no-split parcel must be blocked, got {r.status_code}: {r.text}"
+    )
+    assert "Allow Splitting" in str(r.json().get("detail", ""))
+
+    # And the parcel must be untouched (not split).
+    parcel = (await client.get(f"/items/{item}", headers=h)).json()
+    assert float(parcel.get("quantity") or 0) == 10.0, f"parcel was split: qty={parcel.get('quantity')}"

--- a/default_modules/celerp-inventory/celerp_inventory/routes.py
+++ b/default_modules/celerp-inventory/celerp_inventory/routes.py
@@ -2200,6 +2200,12 @@ async def batch_import_items(
         # Strip any client-supplied timestamps: created_at is set by ProjectionEngine on INSERT.
         rec.data.pop("created_at", None)
         rec.data.pop("updated_at", None)
+        # Normalize allow_splitting to a real bool if the import provided one (CSV
+        # gives strings like "Yes"/"No", and None means "unset"). Imports that omit
+        # it default to no-split in the create branch below; the split guard
+        # requires an explicit True, so a string/None must never read as splittable.
+        if "allow_splitting" in rec.data and not isinstance(rec.data["allow_splitting"], bool):
+            rec.data["allow_splitting"] = str(rec.data["allow_splitting"]).strip().lower() in ("true", "yes", "1", "y", "t")
 
         # Validate sell_by against company units before attempting any DB work.
         sell_by = str(rec.data.get("sell_by") or "").strip()
@@ -2258,6 +2264,10 @@ async def batch_import_items(
                 skipped += 1
             continue
         try:
+            # Imported items default to no-split until splitting is explicitly
+            # enabled per item (matches how they display; the split guard requires
+            # an explicit True).
+            rec.data.setdefault("allow_splitting", False)
             loc_id: uuid.UUID | None = None
             raw_loc = rec.data.get("location_id")
             if raw_loc:

--- a/default_modules/celerp-inventory/celerp_inventory/routes.py
+++ b/default_modules/celerp-inventory/celerp_inventory/routes.py
@@ -1203,7 +1203,9 @@ async def split_item(entity_id: str, payload: SplitBody, company_id=Depends(get_
     if parent is None or not is_item_available(parent.state):
         raise HTTPException(status_code=404, detail="Item not found or unavailable")
 
-    if not parent.state.get("allow_splitting", True):
+    # Allow splitting ONLY when explicitly enabled (== True). A missing/None value
+    # (e.g. older imports that never set the field) must NOT bypass this gate.
+    if parent.state.get("allow_splitting") is not True:
         raise HTTPException(
             status_code=422,
             detail="Allow splitting is set to No for this item. Change Allow Splitting to Yes in the item details to enable splitting.",

--- a/tests/test_routers/test_items.py
+++ b/tests/test_routers/test_items.py
@@ -556,6 +556,38 @@ async def test_split_blocked_when_allow_splitting_false(client):
 
 
 @pytest.mark.asyncio
+async def test_split_blocked_when_allow_splitting_field_missing(client, session):
+    """A missing/None allow_splitting must NOT bypass the split guard — only an
+    explicit True allows splitting. Simulate an item whose projection state lacks
+    the field (as older imports produced) by removing it before splitting.
+    """
+    from celerp.models.projections import Projection
+    from sqlalchemy import select
+
+    token = await _token(client)
+    h = {"Authorization": f"Bearer {token}"}
+    r = await client.post("/items", json={"sku": "MISSING-SPLIT", "name": "Item", "quantity": 10, "sell_by": "piece"}, headers=h)
+    assert r.status_code == 200
+    item_id = r.json()["id"]
+
+    # Remove allow_splitting from the item's projection state (manual edit).
+    row = (await session.execute(select(Projection).where(Projection.entity_id == item_id))).scalar_one()
+    new_state = dict(row.state)
+    new_state.pop("allow_splitting", None)
+    row.state = new_state
+    await session.commit()
+
+    item = (await client.get(f"/items/{item_id}", headers=h)).json()
+    assert item.get("allow_splitting") is None, f"field should be gone, got {item.get('allow_splitting')!r}"
+
+    rs = await client.post(f"/items/{item_id}/split", json={
+        "children": [{"sku": "MISSING-SPLIT-1", "quantity": 3}]
+    }, headers=h)
+    assert rs.status_code == 422, f"missing allow_splitting must block split, got {rs.status_code}: {rs.text}"
+    assert "Allow Splitting" in rs.json()["detail"]
+
+
+@pytest.mark.asyncio
 async def test_split_allowed_when_allow_splitting_true(client):
     """Split must succeed when allow_splitting is explicitly True."""
     token = await _token(client)

--- a/tests/test_routers/test_items.py
+++ b/tests/test_routers/test_items.py
@@ -588,6 +588,42 @@ async def test_split_blocked_when_allow_splitting_field_missing(client, session)
 
 
 @pytest.mark.asyncio
+async def test_import_defaults_no_split_and_coerces_present_value(client):
+    """Imported items default to no-split (allow_splitting=False) when the field is
+    absent, and a present CSV value ("Yes"/"No") is coerced to a real bool."""
+    token = await _token(client)
+    h = {"Authorization": f"Bearer {token}"}
+
+    # (1) Import WITHOUT allow_splitting → defaults to False → split blocked.
+    eid1 = "item:imp-nofield"
+    r = await client.post("/items/import/batch", json={"records": [{
+        "entity_id": eid1, "event_type": "item.created", "source": "csv",
+        "idempotency_key": "imp-nofield",
+        "data": {"sku": "IMP-NF-001", "name": "Imported NoField", "sell_by": "piece", "quantity": 10},
+    }]}, headers=h)
+    assert r.status_code == 200, r.text
+    assert r.json()["created"] == 1, r.json()
+    item1 = (await client.get(f"/items/{eid1}", headers=h)).json()
+    assert item1.get("allow_splitting") is False, item1.get("allow_splitting")
+    rs1 = await client.post(f"/items/{eid1}/split", json={"children": [{"sku": "IMP-NF-001-1", "quantity": 3}]}, headers=h)
+    assert rs1.status_code == 422, rs1.text
+
+    # (2) Import WITH allow_splitting="Yes" → coerced to True → splittable.
+    eid2 = "item:imp-yes"
+    r = await client.post("/items/import/batch", json={"records": [{
+        "entity_id": eid2, "event_type": "item.created", "source": "csv",
+        "idempotency_key": "imp-yes",
+        "data": {"sku": "IMP-Y-001", "name": "Imported Yes", "sell_by": "piece",
+                 "quantity": 10, "allow_splitting": "Yes"},
+    }]}, headers=h)
+    assert r.status_code == 200, r.text
+    item2 = (await client.get(f"/items/{eid2}", headers=h)).json()
+    assert item2.get("allow_splitting") is True, item2.get("allow_splitting")
+    rs2 = await client.post(f"/items/{eid2}/split", json={"children": [{"sku": "IMP-Y-001-1", "quantity": 3}]}, headers=h)
+    assert rs2.status_code == 200, rs2.text
+
+
+@pytest.mark.asyncio
 async def test_split_allowed_when_allow_splitting_true(client):
     """Split must succeed when allow_splitting is explicitly True."""
     token = await _token(client)


### PR DESCRIPTION
<!--
  Thanks for contributing to Celerp. Please complete the sections below.
  Submissions require Contributor License Agreement acceptance before they can be merged
  (see CONTRIBUTING.md and CLA.md). Opening this pull request does not by itself complete the CLA.
-->

## What this changes

Items could be **split even when they were marked (or displayed as) "No split"**,
because the split guard treated a missing/None `allow_splitting` as "allowed". This
PR makes splitting require an explicit opt-in and fixes the import path that left the
field unset.

**Splitting now requires `allow_splitting == True`**
- The guard was `if not state.get("allow_splitting", True)`, so an item whose state
  was missing the field (or had `None`) defaulted to `True` and could be split —
  even though it displayed as "No split". It now allows splitting **only when
  `allow_splitting` is explicitly `True`**; missing / None / False all block.
- Applied to **both** split paths:
  - **Manual split** (`POST /items/{id}/split`) — the bulk and batch split UIs route
    through it too.
  - **Split-on-fulfill** (document `fulfill-lines`) — a partial draw of a parcel that
    isn't explicitly splittable is now rejected (409) instead of silently splitting.

**Imported items default to no-split**
- The item import passed CSV data through verbatim and **never set
  `allow_splitting`**, so imported items came in without it (and were silently
  splittable). The import now sets it explicitly: **default `False` (no-split)** when
  the import omits it, and **coerces a present value** (`yes/true/1/y/t` → True, else
  False) to a real bool. Upserts only touch the field when the import includes it, so
  an existing value isn't clobbered.

**Net effect:** imported items stay no-split until splitting is enabled per item, and
no item can be split (manually or via fulfillment) unless it's explicitly allowed.

**Tests**
- Manual split is blocked (422) when `allow_splitting` is removed from an item's
  state.
- Partial invoice fulfillment of a no-split parcel is blocked (409).
- Import without the field → `allow_splitting` is False and the split is blocked;
  import with `"Yes"` → True and the split succeeds.
- Full unit suite passes locally; browser suite unchanged from baseline.


## Contributor License Agreement

By submitting this pull request you acknowledge that it cannot be merged into an official Celerp
repository until the required **CLA acceptance** has been completed. If you have not already accepted the
current version of [`CLA.md`](https://github.com/celerp/celerp/blob/main/CLA.md), the CLA bot will comment
with the exact acceptance phrase. Posting that phrase from your authenticated GitHub account records your
acceptance of the current version of `CLA.md`.

- [X] I have read [`CONTRIBUTING.md`](https://github.com/celerp/celerp/blob/main/CONTRIBUTING.md) and
      [`CLA.md`](https://github.com/celerp/celerp/blob/main/CLA.md), and I will complete CLA acceptance
      through the CLA workflow when prompted.

## Checklist

- [X] Tests added or updated, and the relevant suites pass locally
- [X] License headers are correct for the paths touched (see `LICENSING.md`; enforced by `scripts/licenses.py`)
- [X] No new self-attribution or tool watermarks in code, commits, or docs
