### PR TITLE
feat: add UTM parameters to subscribe URLs

### DIFF
--- a/celerp/gateway/state.py
+++ b/celerp/gateway/state.py
@@ -98,6 +98,10 @@ def relay_subscribe_url(anchor: str = "") -> str:
     from celerp.config import settings
     iid = _instance_id or settings.gateway_instance_id
     base = "https://celerp.com/subscribe"
-    url = f"{base}?instance_id={iid}" if iid else base
+    params = "utm_source=app&utm_medium=inapp"
+    if iid:
+        url = f"{base}?instance_id={iid}&{params}"
+    else:
+        url = f"{base}?{params}"
     return f"{url}#{anchor}" if anchor else url
 

--- a/default_modules/celerp-ai/celerp_ai/routes.py
+++ b/default_modules/celerp-ai/celerp_ai/routes.py
@@ -57,9 +57,9 @@ from celerp.session_gate import require_session_token
 def _upgrade_url() -> str:
     from celerp.config import settings
     iid = settings.gateway_instance_id
-    base = "https://celerp.com/subscribe"
+    base = "https://celerp.com/subscribe?utm_source=app&utm_medium=inapp"
     if iid:
-        return f"{base}?instance_id={iid}#ai"
+        return f"{base}&instance_id={iid}#ai"
     return f"{base}#ai"
 _CLOUD_FILE_LIMIT = 1
 

--- a/default_modules/celerp-ai/celerp_ai/ui_routes.py
+++ b/default_modules/celerp-ai/celerp_ai/ui_routes.py
@@ -162,7 +162,7 @@ def setup_ui_routes(app) -> None:
                 limit = 0
 
             if code == "quota_exceeded":
-                topup_url = f"https://celerp.com/subscribe/topup?instance_id={detail.get('instance_id', '')}"
+                topup_url = f"https://celerp.com/subscribe/topup?utm_source=app&utm_medium=inapp&instance_id={detail.get('instance_id', '')}"
                 upgrade_url = detail.get("upgrade_url", _subscribe_url("ai"))
                 is_ai_tier = "ai" in str(detail.get("tier", "")) or "team" in str(detail.get("tier", ""))
                 if is_ai_tier:
@@ -980,7 +980,7 @@ function _celerpAiUploadFormData(formData, fileNames) {
             badge.classList.add('ai-quota--low');
         }
         if (remaining < 20 && (data.tier === 'ai' || data.tier === 'team')) {
-            link.href = 'https://celerp.com/subscribe/topup?instance_id=' + encodeURIComponent(data.instance_id || '');
+            link.href = 'https://celerp.com/subscribe/topup?utm_source=app&utm_medium=inapp&instance_id=' + encodeURIComponent(data.instance_id || '');
             link.style.display = 'inline';
         }
     })

--- a/ui/components/cloud_gate.py
+++ b/ui/components/cloud_gate.py
@@ -22,7 +22,8 @@ def _subscribe_url(anchor: str = "") -> str:
     from celerp.config import ensure_instance_id
     base = _SUBSCRIBE_BASE
     iid = ensure_instance_id()
-    base += "?" + urlencode({"instance_id": iid})
+    params = {"instance_id": iid, "utm_source": "app", "utm_medium": "inapp"}
+    base += "?" + urlencode(params)
     if anchor:
         base += f"#{anchor}"
     return base

--- a/ui/routes/auth.py
+++ b/ui/routes/auth.py
@@ -660,10 +660,10 @@ def _onboarding_view() -> FT:
 
 def _direct_connection_gate(email: str, password: str) -> FT:
     """Shown when a second user tries to log in without relay connected."""
-    subscribe_url = "https://celerp.com/subscribe"
+    subscribe_url = "https://celerp.com/subscribe?utm_source=app&utm_medium=inapp"
     try:
         from celerp.config import ensure_instance_id
-        subscribe_url += f"?instance_id={ensure_instance_id()}#cloud"
+        subscribe_url += f"&instance_id={ensure_instance_id()}#cloud"
     except Exception:
         pass
 
@@ -780,7 +780,7 @@ def _forgot_password_cli() -> FT:
     """Forgot-password page for self-hosted installs without email transport."""
     from celerp.config import ensure_instance_id
     iid = ensure_instance_id()
-    subscribe_url = f"https://celerp.com/subscribe?instance_id={iid}#cloud"
+    subscribe_url = f"https://celerp.com/subscribe?utm_source=app&utm_medium=inapp&instance_id={iid}#cloud"
     return Div(
         Div(
             Img(src="/static/logo.png", alt="Celerp", cls="auth-logo"),

--- a/ui/routes/settings.py
+++ b/ui/routes/settings.py
@@ -1634,8 +1634,8 @@ def setup_routes(app):
         connected = data.get("connected", False)
 
         iid = ensure_instance_id()
-        subscribe_url = "https://celerp.com/subscribe"
-        subscribe_url += f"?instance_id={iid}"
+        subscribe_url = "https://celerp.com/subscribe?utm_source=app&utm_medium=inapp"
+        subscribe_url += f"&instance_id={iid}"
         # Include local app URL so Stripe success page can offer a direct return link
         local_url = str(request.base_url).rstrip("/")
         subscribe_url += f"&local_url={local_url}"
@@ -3631,7 +3631,7 @@ def _cloud_relay_unconnected(
             Used when embedding inside the Web Access value-prop page which already
             has its own plan cards and CTAs.
     """
-    subscribe_url = f"https://celerp.com/subscribe?instance_id={iid}"
+    subscribe_url = f"https://celerp.com/subscribe?utm_source=app&utm_medium=inapp&instance_id={iid}"
     children: list = []
     if show_header:
         children += [

--- a/ui/routes/settings_cloud.py
+++ b/ui/routes/settings_cloud.py
@@ -65,7 +65,7 @@ def _plan_card(name: str, price: str, desc: str, bullets: list[str], subscribe_u
 
 def _value_prop_page(iid: str, lang: str = "en") -> FT:
     """Full value-proposition landing page shown when not connected to cloud."""
-    subscribe_base = f"https://celerp.com/subscribe?instance_id={iid}"
+    subscribe_base = f"https://celerp.com/subscribe?utm_source=app&utm_medium=inapp&instance_id={iid}"
 
     return Div(
         # Hero - explain the relay concept simply

--- a/ui/routes/setup.py
+++ b/ui/routes/setup.py
@@ -595,9 +595,9 @@ def _activating_form(lang: str = "en") -> FT:
 def _cloud_form() -> FT:
     from celerp.config import settings
     iid = settings.gateway_instance_id
-    subscribe_url = "https://celerp.com/subscribe"
+    subscribe_url = "https://celerp.com/subscribe?utm_source=app&utm_medium=inapp"
     if iid:
-        subscribe_url += f"?instance_id={iid}"
+        subscribe_url += f"&instance_id={iid}"
     subscribe_url += "#cloud"
 
     pricing_url = "https://celerp.com/pricing"


### PR DESCRIPTION
Adds utm_source=app&utm_medium=inapp to all subscribe page links for conversion funnel tracking.

**What changed:**
- 8 files modified, 20 insertions, 15 deletions
- All subscribe URLs now include UTM parameters
- Two central URL builders updated (covers most links)
- Six inline URLs updated individually

**Why:**
Track which users come from the desktop app vs external sources on the subscribe page. Enables GA4 to attribute plan selections and checkouts to in-app clicks.

**Testing:**
- All existing tests use substring matching (e.g., `'celerp.com/subscribe' in url`) and continue to pass
- Manual verification: both central URL builders produce correct URLs with UTM params
- No functional changes to checkout flow, Stripe integration, or existing behavior