### PR TITLE
fix(inventory): item-page split sends a SplitBody object, not a bare list

### DIFF
--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -3764,8 +3764,8 @@ class TestSprint5ItemActions:
     @pytest.mark.asyncio
     async def test_split_item_route_accepts_single_child(self, ui_client):
         captured = {}
-        async def _mock(token, entity_id, children):
-            captured['children'] = children
+        async def _mock(token, entity_id, payload):
+            captured['payload'] = payload
             return {"event_id": "e1"}
         with (
             patch("ui.api_client.get_item", new=AsyncMock(return_value={"sku": "PARENT-001", "quantity": 10})),
@@ -3774,8 +3774,36 @@ class TestSprint5ItemActions:
         ):
             r = await ui_client.post("/api/items/gc:123/split", data={"parts": "3"}, cookies=_authed())
         assert r.status_code == 204
-        assert len(captured['children']) == 1
-        assert captured['children'][0]["quantity"] == 3.0
+        children = captured['payload']["children"]
+        assert len(children) == 1
+        assert children[0]["quantity"] == 3.0
+
+    @pytest.mark.asyncio
+    async def test_split_item_route_sends_splitbody_object(self, ui_client):
+        """The item-page split window must send the API a SplitBody OBJECT
+        ({"children": [...]}), not a bare list — a list is rejected by the split
+        endpoint with a model_attributes_type error ("Input should be a valid
+        dictionary or object")."""
+        captured = {}
+        async def _mock(token, entity_id, payload):
+            captured['payload'] = payload
+            return {"event_id": "e1"}
+        with (
+            patch("ui.api_client.get_item", new=AsyncMock(return_value={"sku": "PARENT-001", "quantity": 10})),
+            patch("ui.api_client.list_items", new=AsyncMock(return_value={"items": [], "total": 0})),
+            patch("ui.api_client.split_item", new=_mock),
+        ):
+            r = await ui_client.post(
+                "/api/items/gc:123/split",
+                json={"children": [{"sku": "SKU", "quantity": 3.0, "pieces": 3}]},
+                cookies=_authed(),
+            )
+        assert r.status_code == 204, r.text
+        payload = captured['payload']
+        assert isinstance(payload, dict), (
+            f"split_item must receive a SplitBody object, got {type(payload).__name__}: {payload!r}"
+        )
+        assert isinstance(payload.get("children"), list) and len(payload["children"]) == 1
 
     @pytest.mark.asyncio
     async def test_split_item_route_invalid_quantities(self, ui_client):
@@ -4300,8 +4328,8 @@ class TestItemActionRouteCompleteness:
     @pytest.mark.asyncio
     async def test_split_passes_correct_quantity_count(self, ui_client):
         captured = {}
-        async def _mock(token, entity_id, children):
-            captured.update({"children": children})
+        async def _mock(token, entity_id, payload):
+            captured.update({"payload": payload})
             return {"event_id": "e1"}
         with (
             patch("ui.api_client.get_item", new=AsyncMock(return_value={"sku": "P-001", "quantity": 20})),
@@ -4309,8 +4337,9 @@ class TestItemActionRouteCompleteness:
             patch("ui.api_client.split_item", new=_mock),
         ):
             await ui_client.post("/api/items/gc:123/split", data={"parts": "5,3,2"}, cookies=_authed())
-        assert len(captured["children"]) == 3
-        assert sorted(c["quantity"] for c in captured["children"]) == [2.0, 3.0, 5.0]
+        children = captured["payload"]["children"]
+        assert len(children) == 3
+        assert sorted(c["quantity"] for c in children) == [2.0, 3.0, 5.0]
 
     # ── merge (additional coverage) ──────────────────────────────────────────
 
@@ -4369,8 +4398,8 @@ class TestBatchSplit:
         """Valid batch split (qty=1, count=5, total=5 ≤ 10) must redirect to filtered inventory."""
         split_calls = []
 
-        async def mock_split(token, entity_id, children):
-            split_calls.append(children)
+        async def mock_split(token, entity_id, payload):
+            split_calls.append(payload)
             return {}
 
         with (
@@ -4388,9 +4417,10 @@ class TestBatchSplit:
         assert r.status_code == 204
         assert "HX-Redirect" in r.headers
         assert "skus=" in r.headers["HX-Redirect"]
-        # Must have generated 5 children
+        # Must have generated 5 children, sent as a SplitBody object.
         assert len(split_calls) == 1
-        assert len(split_calls[0]) == 5
+        assert isinstance(split_calls[0], dict)
+        assert len(split_calls[0]["children"]) == 5
 
     @pytest.mark.asyncio
     async def test_batch_split_total_exceeds_available_rejected(self, ui_client):

--- a/ui/routes/inventory.py
+++ b/ui/routes/inventory.py
@@ -3577,7 +3577,7 @@ function celerpPrintLabel(entityId, templateId) {
         if len(children) < 1:
             return Div(Span(t("inv.enter_at_least_one_split_quantity"), cls="flash flash--error"), id="item-action-error")
         try:
-            await api.split_item(token, entity_id, children)
+            await api.split_item(token, entity_id, {"children": children})
         except APIError as e:
             return Div(Span(str(e.detail), cls="flash flash--error"), id="item-action-error")
         redirect = f"/inventory?q={quote(orig_sku)}" if orig_sku else f"/inventory/{entity_id}"
@@ -3637,7 +3637,7 @@ function celerpPrintLabel(entityId, templateId) {
                         pass
             children.append(child)
         try:
-            await api.split_item(token, entity_id, children)
+            await api.split_item(token, entity_id, {"children": children})
         except APIError as e:
             return Span(str(e.detail), cls="flash flash--error", id="item-action-error")
         child_skus = [c["sku"] for c in children]
@@ -3714,7 +3714,7 @@ function celerpPrintLabel(entityId, templateId) {
                 _apply_complement(child, sell_by, complement, _default_umap)
             children.append(child)
         try:
-            await api.split_item(token, entity_id, children)
+            await api.split_item(token, entity_id, {"children": children})
         except APIError as e:
             return Span(str(e.detail), cls="flash flash--error", id="item-action-error")
         return _split_redirect(orig_sku, [c["sku"] for c in children])


### PR DESCRIPTION
## What this changes

The item-page split window (/api/items/{id}/split), /split-inline, and /batch-split unwrapped `children` from the request and passed the bare list to api.split_item. The split endpoint expects a SplitBody object ({"children": [...]}), so it rejected the list with a model_attributes_type error ("Input should be a valid dictionary or object to extract fields from"). All three now send {"children": children}, matching the already-correct bulk-split path.

Tests: new regression asserting the route sends a dict (not a list); updated the existing split/batch-split tests that had baked in the old list shape.

## Contributor License Agreement

By submitting this pull request you acknowledge that it cannot be merged into an official Celerp
repository until the required **CLA acceptance** has been completed. If you have not already accepted the
current version of [`CLA.md`](https://github.com/celerp/celerp/blob/main/CLA.md), the CLA bot will comment
with the exact acceptance phrase. Posting that phrase from your authenticated GitHub account records your
acceptance of the current version of `CLA.md`.

- [X] I have read [`CONTRIBUTING.md`](https://github.com/celerp/celerp/blob/main/CONTRIBUTING.md) and
      [`CLA.md`](https://github.com/celerp/celerp/blob/main/CLA.md), and I will complete CLA acceptance
      through the CLA workflow when prompted.

## Checklist

- [X] Tests added or updated, and the relevant suites pass locally
- [X] License headers are correct for the paths touched (see `LICENSING.md`; enforced by `scripts/licenses.py`)
- [X] No new self-attribution or tool watermarks in code, commits, or docs
