### PR TITLE
chore(verticals): hide property_rental + saas presets pending their builds

### DIFF
--- a/default_modules/celerp-verticals/celerp_verticals/presets/property_rental.json
+++ b/default_modules/celerp-verticals/celerp_verticals/presets/property_rental.json
@@ -2,7 +2,7 @@
   "name": "property_rental",
   "display_name": "Property Rental",
   "hidden": true,
-  "hidden_reason": "A lease is a recurring billing agreement over a term, which today's recurring-invoice schedule almost models but lacks (no term end-date, asset link, or deposit), and occupancy/rent-roll reporting doesn't exist yet. Not a new module - a small shared 'Agreement' extension + derived occupancy reports. See context/2026-0621-saas-property-verticals-market-readiness.md. Re-enable when that v1 lands.",
+  "hidden_reason": "Disabled pending the property rental v1 (leases, occupancy, deposits, rent-roll). Remove this flag to re-enable.",
   "license": "MIT",
   "categories": [
     "residential_unit",

--- a/default_modules/celerp-verticals/celerp_verticals/presets/property_rental.json
+++ b/default_modules/celerp-verticals/celerp_verticals/presets/property_rental.json
@@ -2,7 +2,7 @@
   "name": "property_rental",
   "display_name": "Property Rental",
   "hidden": true,
-  "hidden_reason": "Rental units are persistent assets with leases and occupancy over time, not goods-inventory items sold to zero. Honestly supporting this needs a dedicated rental module (Unit/Lease entities on the shared event store), not the inventory model. See context/2026-0621-property-rental-vertical-analysis.md. Re-enable when that module exists.",
+  "hidden_reason": "A lease is a recurring billing agreement over a term, which today's recurring-invoice schedule almost models but lacks (no term end-date, asset link, or deposit), and occupancy/rent-roll reporting doesn't exist yet. Not a new module - a small shared 'Agreement' extension + derived occupancy reports. See context/2026-0621-saas-property-verticals-market-readiness.md. Re-enable when that v1 lands.",
   "license": "MIT",
   "categories": [
     "residential_unit",

--- a/default_modules/celerp-verticals/celerp_verticals/presets/property_rental.json
+++ b/default_modules/celerp-verticals/celerp_verticals/presets/property_rental.json
@@ -1,6 +1,8 @@
 {
   "name": "property_rental",
   "display_name": "Property Rental",
+  "hidden": true,
+  "hidden_reason": "Rental units are persistent assets with leases and occupancy over time, not goods-inventory items sold to zero. Honestly supporting this needs a dedicated rental module (Unit/Lease entities on the shared event store), not the inventory model. See context/2026-0621-property-rental-vertical-analysis.md. Re-enable when that module exists.",
   "license": "MIT",
   "categories": [
     "residential_unit",

--- a/default_modules/celerp-verticals/celerp_verticals/presets/saas.json
+++ b/default_modules/celerp-verticals/celerp_verticals/presets/saas.json
@@ -1,6 +1,8 @@
 {
   "name": "saas",
   "display_name": "SaaS / Software",
+  "hidden": true,
+  "hidden_reason": "Disabled pending payment collection (Stripe). Remove this flag to re-enable.",
   "license": "MIT",
   "categories": [
     "saas_plan",

--- a/tests/test_setup_wizard.py
+++ b/tests/test_setup_wizard.py
@@ -540,6 +540,20 @@ class TestLoadVerticals:
             result = setup_mod._load_verticals()
         assert result[-1][0] == "blank", "blank must be last"
 
+    def test_hidden_preset_excluded(self, tmp_path):
+        """A preset flagged 'hidden': true is not offered in the picker."""
+        presets_dir = self._make_presets_dir(tmp_path, [
+            {"name": "gemstones", "display_name": "Gems & Jewelry"},
+            {"name": "property_rental", "display_name": "Property Rental", "hidden": True},
+            {"name": "blank", "display_name": "Blank"},
+        ])
+        import ui.routes.setup as setup_mod
+        with patch.object(setup_mod, "_PRESETS_DIR", presets_dir):
+            result = setup_mod._load_verticals()
+        names = [n for n, _ in result]
+        assert "property_rental" not in names, "hidden preset must be excluded"
+        assert "gemstones" in names
+
     def test_non_blank_alphabetically_sorted(self, tmp_path):
         presets_dir = self._make_presets_dir(tmp_path, [
             {"name": "watches", "display_name": "Watches"},

--- a/ui/routes/setup.py
+++ b/ui/routes/setup.py
@@ -71,6 +71,8 @@ def _load_verticals() -> list[tuple[str, str]]:
     """Load vertical options from preset files. Returns [(value, label), ...].
 
     'blank' preset sorts last. All others sort alphabetically by display_name.
+    Presets flagged "hidden": true are skipped — used to stage a vertical that the
+    product can't yet honestly support (see the preset's "hidden_reason").
     """
     pinned_last: list[tuple[str, str]] = []
     options: list[tuple[str, str]] = []
@@ -78,6 +80,8 @@ def _load_verticals() -> list[tuple[str, str]]:
         for p in sorted(_PRESETS_DIR.glob("*.json")):
             try:
                 data = json.loads(p.read_text())
+                if data.get("hidden"):
+                    continue
                 entry = (data["name"], data["display_name"])
                 if data["name"] == "blank":
                     pinned_last.append(entry)


### PR DESCRIPTION
Hides the `property_rental` and `saas` vertical presets from the setup picker, via a `hidden` flag on presets that `_load_verticals` skips.

- **property_rental** — disabled pending the property rental v1 (leases, occupancy, deposits, rent-roll).
- **saas** — disabled pending payment collection (Stripe).

Soft and reversible: the presets, their categories, and demo data are unchanged — removing the `hidden` flag re-enables them. Includes a unit test for the skip behaviour.