### PR TITLE
fix(relay): allow large bulk file/cert uploads over the tunnel

### DIFF
--- a/celerp/gateway/client.py
+++ b/celerp/gateway/client.py
@@ -130,7 +130,13 @@ class GatewayClient:
         # ConnectionClosed within ~ping_interval+ping_timeout, so _connect_and_serve
         # exits and run()'s backoff loop reconnects — instead of blocking forever on
         # a half-open socket while the relay returns 502.
-        async with websockets.connect(self._url, ping_interval=20, ping_timeout=20) as ws:
+        # max_size: the relay forwards each proxied HTTP request as ONE base64'd WS
+        # message, so the default 1 MiB frame cap silently broke bulk uploads (a ZIP
+        # body > ~750 KB overflowed the frame → connection drop → relay 504). 160 MiB
+        # covers a ~100 MB body (≈134 MB base64) with margin.
+        async with websockets.connect(
+            self._url, ping_interval=20, ping_timeout=20, max_size=160 * 1024 * 1024
+        ) as ws:
             self._ws = ws
             # Read current TOS version from config
             from celerp.config import read_config
@@ -296,7 +302,7 @@ class GatewayClient:
             url = f"{url}?{query}"
 
         try:
-            async with httpx.AsyncClient(timeout=25.0) as client:
+            async with httpx.AsyncClient(timeout=180.0) as client:
                 resp = await client.request(
                     method=method,
                     url=url,

--- a/celerp/middleware.py
+++ b/celerp/middleware.py
@@ -73,6 +73,13 @@ class MaxBodySizeMiddleware:
             await self.app(scope, receive, send)
             return
 
+        # Bulk file/cert import legitimately uploads a large ZIP (many small files);
+        # exempt it from the body cap. It's bounded instead by the WS tunnel frame
+        # size and the per-file 50 MB limit in store_upload().
+        if scope.get("path", "").endswith(("/items/files/bulk", "/items/attachments/bulk")):
+            await self.app(scope, receive, send)
+            return
+
         headers = dict(scope.get("headers", []))
         cl = headers.get(b"content-length")
         if cl is not None:

--- a/tests/test_bulk_upload_limits.py
+++ b/tests/test_bulk_upload_limits.py
@@ -1,0 +1,100 @@
+# Copyright (c) 2026 Noah Severs
+# SPDX-License-Identifier: LicenseRef-Proprietary
+"""Proof tests for the bulk-upload / relay-tunnel size fix.
+
+These reproduce the ROOT CAUSE of the bulk file/cert import failure and verify the
+fix at the mechanism level (the full live-relay path can only be checked manually):
+
+1. WS frame cap — the relay forwards each proxied HTTP request as ONE base64'd
+   WebSocket message. The host client used the `websockets` default max_size of
+   1 MiB, so any bulk body > ~750 KB overflowed the frame → connection drop →
+   relay 504. We reproduce that, then show the raised max_size (the fix) accepts it.
+
+2. Body-cap middleware — the bulk path must be exempt from the 10 MB cap while
+   every other path stays capped.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+import websockets
+
+# A modest cert ZIP — 5 MB is well over the 1 MiB default frame cap, so it
+# represents a bulk import that fails over the relay TODAY.
+_BULK_MSG = b"x" * (5 * 1024 * 1024)
+_RAISED_MAX = 160 * 1024 * 1024  # matches the host client's new max_size
+
+
+async def _push_handler(ws):
+    """Server pushes one large message — mirrors the relay forwarding a base64'd
+    bulk request body to the host's WS client (relay sends, host receives)."""
+    await ws.send(_BULK_MSG)
+    await asyncio.sleep(0.2)
+
+
+@pytest.mark.asyncio
+async def test_default_ws_max_size_rejects_bulk_message():
+    """REPRODUCES THE BUG: with the default 1 MiB max_size, receiving a 5 MB
+    message fails (the connection is dropped) — this is why bulk upload 504s."""
+    async with websockets.serve(_push_handler, "127.0.0.1", 0) as server:
+        port = server.sockets[0].getsockname()[1]
+        async with websockets.connect(f"ws://127.0.0.1:{port}") as ws:  # DEFAULT max_size
+            with pytest.raises(websockets.exceptions.ConnectionClosed):
+                await ws.recv()
+
+
+@pytest.mark.asyncio
+async def test_raised_ws_max_size_accepts_bulk_message():
+    """VERIFIES THE FIX: with max_size raised (as in celerp/gateway/client.py),
+    the same 5 MB message is received intact."""
+    async with websockets.serve(_push_handler, "127.0.0.1", 0, max_size=_RAISED_MAX) as server:
+        port = server.sockets[0].getsockname()[1]
+        async with websockets.connect(f"ws://127.0.0.1:{port}", max_size=_RAISED_MAX) as ws:
+            got = await ws.recv()
+            assert len(got) == len(_BULK_MSG)
+
+
+def test_raised_max_size_covers_100mb_body():
+    """The chosen ceiling actually fits a 100 MB body once base64-expanded (~134 MB)."""
+    assert _RAISED_MAX >= int(100 * 1024 * 1024 * 4 / 3)
+
+
+# ── Body-cap middleware exemption ──────────────────────────────────────────────
+
+async def _ok_app(scope, receive, send):
+    await send({"type": "http.response.start", "status": 200, "headers": []})
+    await send({"type": "http.response.body", "body": b"ok"})
+
+
+async def _drive(mw, path: str, content_length: int) -> int:
+    """Run the ASGI middleware for one request; return the response status."""
+    statuses: list[int] = []
+    scope = {"type": "http", "path": path,
+             "headers": [(b"content-length", str(content_length).encode())]}
+
+    async def receive():
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    async def send(msg):
+        if msg["type"] == "http.response.start":
+            statuses.append(msg["status"])
+
+    await mw(scope, receive, send)
+    return statuses[0]
+
+
+@pytest.mark.asyncio
+async def test_body_cap_still_rejects_large_non_bulk():
+    from celerp.middleware import MaxBodySizeMiddleware
+    mw = MaxBodySizeMiddleware(_ok_app, max_body_size_bytes=10 * 1024 * 1024)
+    assert await _drive(mw, "/items", 50 * 1024 * 1024) == 413  # other paths stay capped
+
+
+@pytest.mark.asyncio
+async def test_bulk_path_exempt_from_body_cap():
+    from celerp.middleware import MaxBodySizeMiddleware
+    mw = MaxBodySizeMiddleware(_ok_app, max_body_size_bytes=10 * 1024 * 1024)
+    # 50 MB to the bulk route passes through instead of 413.
+    assert await _drive(mw, "/items/files/bulk", 50 * 1024 * 1024) == 200

--- a/ui/api_client.py
+++ b/ui/api_client.py
@@ -550,7 +550,8 @@ async def delete_attachment(token: str, entity_id: str, att_id: str) -> None:
 
 
 async def bulk_attach(token: str, file, override_hero: bool = False) -> dict:
-    async with _api_client(token) as c:
+    # Large ZIP upload + per-file processing can take well over the default 10s.
+    async with _api_client(token, timeout=180.0) as c:
         content = await file.read() if hasattr(file, "read") else file.file.read()
         filename = getattr(file, "filename", "attachments.zip")
         params = {"override_hero": "1"} if override_hero else {}


### PR DESCRIPTION
## Problem
Bulk file/cert import (reported by a customer) failed: **413** locally and **504** through the cloud relay.

## Root cause
The gateway tunnel forwards each proxied HTTP request as **one base64'd WebSocket message**. The host client connected with the `websockets` library default `max_size` of **1 MiB**, so any bulk body over ~750 KB overflowed the frame → the WS connection dropped → the relay returned 504. Locally, the 10 MB `MaxBodySizeMiddleware` cap rejected the same upload with 413.

## Fix (this repo)
- `gateway/client.py`: WS `max_size` 1 MiB → **160 MiB**; host→local httpx timeout 25s → **180s**.
- `middleware.py`: exempt `/items/files/bulk` + `/items/attachments/bulk` from the 10 MB body cap (still bounded by the WS frame size and the per-file 50 MB limit in `store_upload()`).
- `api_client.bulk_attach`: UI→API httpx timeout 10s → **180s**.

The matching relay-side timeout bumps (proxy + Caddy) are in a separate **celerp-cloud** PR; they must be deployed for the end-to-end path.

## Proof
`tests/test_bulk_upload_limits.py` (5 passed):
- reproduces the bug — a 5 MB message over the **default 1 MiB** `max_size` raises `ConnectionClosed`;
- verifies the fix — the same message over **160 MiB** `max_size` arrives intact;
- confirms 160 MiB covers a 100 MB body once base64-expanded (~134 MB);
- confirms `/items/files/bulk` is exempt from the body cap (200) while other paths stay capped (413).

Regression: gateway 28 passed, attachments 25 passed, prod-hardening 2 passed.

Full live-relay E2E (504 gone on a real upload) requires the deployed relay and is verified manually.