### PR TITLE
develop: relay version + Mac sleep-prevention (C2/C4), file idempotency (F9), import-crash test (I1)

### DIFF
--- a/celerp/gateway/client.py
+++ b/celerp/gateway/client.py
@@ -121,11 +121,27 @@ class GatewayClient:
     def required_tos_version(self) -> str:
         return self._required_tos_version
 
+    def _set_status(self, status: str) -> None:
+        """Set the relay status and, on a *change*, emit a one-line sentinel on stdout.
+
+        The Electron host reads the spawned API process's stdout and holds a power-save
+        assertion while the relay is serving (keeps the Mac awake so an idle sleep can't drop
+        the connection - C4). Routing every status transition through here is the single
+        producer of that signal; outside Electron the line is just harmless log noise.
+        """
+        if status == self._relay_status:
+            return
+        self._relay_status = status
+        try:
+            print(f"CELERP_RELAY_STATE={status}", flush=True)
+        except Exception:
+            pass
+
     # ── Internal ───────────────────────────────────────────────────────
 
     async def _connect_and_serve(self) -> None:
         log.debug("Connecting to gateway at %s", self._url)
-        self._relay_status = "connecting"
+        self._set_status("connecting")
         # Keepalive on: a silently-dead connection (e.g. the host sleeping) raises
         # ConnectionClosed within ~ping_interval+ping_timeout, so _connect_and_serve
         # exits and run()'s backoff loop reconnects — instead of blocking forever on
@@ -161,14 +177,14 @@ class GatewayClient:
                     continue
                 await self._dispatch(msg)
         self._ws = None
-        self._relay_status = "inactive"
+        self._set_status("inactive")
 
     async def _dispatch(self, msg: dict) -> None:
         msg_type = msg.get("type", "")
         payload = msg.get("payload", {})
 
         if msg_type == "hello_ack":
-            self._relay_status = "active"
+            self._set_status("active")
             # Relay returns the canonical instance_id - store it for quota calls
             from celerp.gateway.state import set_session_token, set_instance_id
             canonical_id = payload.get("instance_id", "")
@@ -199,7 +215,7 @@ class GatewayClient:
         elif msg_type == "error":
             code = payload.get("code", "")
             if code == "tos_required":
-                self._relay_status = "tos_required"
+                self._set_status("tos_required")
                 self._required_tos_version = payload.get("required_version", "")
                 log.warning("Gateway: TOS acceptance required (version=%s)", self._required_tos_version)
             else:

--- a/celerp/routers/health.py
+++ b/celerp/routers/health.py
@@ -18,9 +18,15 @@ router = APIRouter()
 
 @router.get("/health")
 async def health() -> dict:
+    # C2: the version must read the same everywhere - desktop, cloud relay, and pip.
+    # The desktop app (Electron) is the authoritative source of the user-facing version,
+    # so it passes its app version to the spawned API via CELERP_APP_VERSION; /health
+    # reports that when present, else the Python package version (pip installs / dev).
+    # This is the version the relay/PC-browser path reads (it has no window.celerp), so it
+    # no longer disagrees with the desktop.
     return {
         "status": "ok",
-        "version": __version__,
+        "version": os.environ.get("CELERP_APP_VERSION") or __version__,
         "install_channel": os.environ.get("CELERP_INSTALL_CHANNEL", "pypi"),
     }
 

--- a/default_modules/celerp-inventory/celerp_inventory/projections.py
+++ b/default_modules/celerp-inventory/celerp_inventory/projections.py
@@ -298,7 +298,15 @@ def apply_item_event(state: dict, event_type: str, data: dict) -> dict:
             for f in current["files"]:
                 f["is_hero"] = False
             current["preview_image_id"] = entry["id"]
-        current["files"].append(entry)
+        # F9 (idempotency): keep file_id unique in the projection. Re-applying the same
+        # item.file.attached - a replayed event, or two call sites each emitting it (the
+        # F1 class) - must not create a duplicate list entry. Update in place if the
+        # file_id is already present; otherwise append.
+        _existing = next((f for f in current["files"] if f.get("id") == entry["id"]), None)
+        if _existing is not None:
+            _existing.update(entry)
+        else:
+            current["files"].append(entry)
     elif event_type == "item.file.tagged":
         for f in current.get("files", []):
             if f.get("id") == data["file_id"]:

--- a/electron/main.js
+++ b/electron/main.js
@@ -13,7 +13,7 @@
 
 "use strict";
 
-const { app, BrowserWindow, shell, dialog, ipcMain, Menu } = require("electron");
+const { app, BrowserWindow, shell, dialog, ipcMain, Menu, powerSaveBlocker } = require("electron");
 const { autoUpdater } = require("electron-updater");
 const path = require("path");
 const fs = require("fs");
@@ -105,6 +105,27 @@ const DEFAULT_MODULES_SRC = IS_DEV
 
 let mainWindow = null;
 let isQuitting = false; // set true in before-quit so the close handler doesn't intercept Cmd+Q
+
+// C4: hold a power-save assertion (prevent idle system sleep) ONLY while the relay is actually
+// serving, so an idle Mac can't drop the connection. The relay state is owned by the Python
+// gateway client, which prints `CELERP_RELAY_STATE=<status>` on every transition; we read that
+// off the API process stdout below. `prevent-app-suspension` keeps the SYSTEM awake (the display
+// may still sleep) and is auto-released when the app exits. It does NOT override lid-close,
+// explicit sleep, or low battery - C3's auto-reconnect remains the safety net for those.
+let relaySleepBlockerId = null;
+function applyRelaySleepState(active) {
+  if (active && relaySleepBlockerId === null) {
+    relaySleepBlockerId = powerSaveBlocker.start("prevent-app-suspension");
+  } else if (!active && relaySleepBlockerId !== null) {
+    powerSaveBlocker.stop(relaySleepBlockerId);
+    relaySleepBlockerId = null;
+  }
+}
+function consumeRelayStateFromLog(text) {
+  // A chunk may carry several transitions; act on the last one only.
+  const matches = [...text.matchAll(/CELERP_RELAY_STATE=(\w+)/g)];
+  if (matches.length) applyRelaySleepState(matches[matches.length - 1][1] === "active");
+}
 let pgInstance = null;
 let apiProcess = null;
 let uiProcess = null;
@@ -332,6 +353,11 @@ function startApi(dbUrl, cfg) {
       CELERP_DATA_DIR: DATA_DIR,
       CELERP_CONFIG: PYTHON_CONFIG_PATH,
       CELERP_INSTALL_CHANNEL: "electron",
+      // C2: make the desktop app version authoritative everywhere. The PC-browser/relay
+      // path reads the version from /health (it has no window.celerp), so pass the Electron
+      // app version through to the API; /health reports it instead of the Python package
+      // version, keeping desktop and relay in agreement.
+      CELERP_APP_VERSION: app.getVersion(),
       CELERP_API_PORT: String(apiPort),
       CELERP_UI_PORT: String(uiPort),
       CELERP_PG_BIN_DIR: pgBinDir(),
@@ -346,7 +372,11 @@ function startApi(dbUrl, cfg) {
     const logFile = path.join(LOG_DIR, "api.log");
     let stderr = "";
     apiProcess.stderr.on("data", (d) => { stderr += d.toString(); apiLog?.write(d); });
-    apiProcess.stdout.on("data", (d) => { stderr += d.toString(); apiLog?.write(d); });
+    apiProcess.stdout.on("data", (d) => {
+      const s = d.toString();
+      stderr += s; apiLog?.write(d);
+      consumeRelayStateFromLog(s);  // C4: hold/release the sleep blocker on relay state changes
+    });
     apiProcess.on("error", reject);
     apiProcess.on("exit", (code) => {
       if (code !== 0 && code !== null) reject(new Error(`API process exited (code ${code}). Full log: ${logFile}\n${stderr.slice(-3000)}`));
@@ -1013,6 +1043,7 @@ app.on("activate", () => {
 
 app.on("before-quit", async () => {
   isQuitting = true;
+  applyRelaySleepState(false);  // C4: release the power-save assertion (also auto-released on exit)
   if (uiProcess) uiProcess.kill();
   if (apiProcess) apiProcess.kill();
   if (pgInstance) await pgInstance.stop();

--- a/tests/test_events/test_item_file_events.py
+++ b/tests/test_events/test_item_file_events.py
@@ -58,6 +58,25 @@ class TestItemFileAttached:
         state = _file_attached(state, "f2", is_hero=False)
         assert state["preview_image_id"] == "f1"
 
+    def test_reapplying_same_file_id_does_not_duplicate(self):
+        """F9: item.file.attached is idempotent on file_id. Re-applying the same event
+        (a replay, or two call sites each emitting it - the F1 class) must leave exactly
+        one entry, not two with the same id."""
+        state = _base_state()
+        state = _file_attached(state, "f1", is_hero=True)
+        state = _file_attached(state, "f1", is_hero=True)  # same file_id again
+        ids = [f["id"] for f in state["files"]]
+        assert ids == ["f1"], f"duplicate file entry created: {ids}"
+
+    def test_reapplying_same_file_id_updates_in_place(self):
+        """A second attach of the same file_id updates the existing entry's metadata
+        rather than appending a new row."""
+        state = _base_state()
+        state = _file_attached(state, "f1", tag="product_images")
+        state = _file_attached(state, "f1", tag="certificates")
+        assert len(state["files"]) == 1
+        assert state["files"][0]["document_tag"] == "certificates"
+
     def test_pdf_file_stored_correctly(self):
         state = _base_state()
         state = apply_item_event(state, "item.file.attached", {

--- a/tests/test_gateway/test_client.py
+++ b/tests/test_gateway/test_client.py
@@ -36,6 +36,46 @@ def reset_session_token():
     gw_state.set_session_token(original)
 
 
+# ── C4: relay-state sentinel on stdout (consumed by the Electron host) ─────────
+
+def test_set_status_emits_sentinel_on_change(client, capsys):
+    """_set_status prints one CELERP_RELAY_STATE line per transition and updates status."""
+    client._set_status("active")
+    out = capsys.readouterr().out
+    assert "CELERP_RELAY_STATE=active" in out
+    assert client.relay_status == "active"
+
+
+def test_set_status_is_idempotent_no_repeat_emit(client, capsys):
+    """Re-setting the same status emits nothing (Electron must not flap the blocker)."""
+    client._set_status("active")
+    capsys.readouterr()  # drain the first emit
+    client._set_status("active")
+    assert capsys.readouterr().out == ""
+    assert client.relay_status == "active"
+
+
+def test_set_status_emits_each_distinct_transition(client, capsys):
+    """Distinct transitions each emit their own sentinel, in order."""
+    for s in ("connecting", "active", "inactive"):
+        client._set_status(s)
+    lines = [ln for ln in capsys.readouterr().out.splitlines() if ln.startswith("CELERP_RELAY_STATE=")]
+    assert lines == [
+        "CELERP_RELAY_STATE=connecting",
+        "CELERP_RELAY_STATE=active",
+        "CELERP_RELAY_STATE=inactive",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_hello_ack_emits_active_sentinel(client, capsys):
+    """The real active transition (hello_ack dispatch) emits the active sentinel - the signal
+    Electron holds the power-save assertion on (C4)."""
+    await client._dispatch({"type": "hello_ack", "payload": {"instance_id": "test-instance-id"}})
+    assert "CELERP_RELAY_STATE=active" in capsys.readouterr().out
+    assert client.relay_status == "active"
+
+
 # ── hello_ack ─────────────────────────────────────────────────────────────────
 
 @pytest.mark.asyncio

--- a/tests/test_import_relay_i1.py
+++ b/tests/test_import_relay_i1.py
@@ -1,0 +1,145 @@
+# Copyright (c) 2026 Noah Severs
+# SPDX-License-Identifier: LicenseRef-Proprietary
+
+"""I1 - importing items via the cloud relay dropped the server.
+
+Root cause: the relay forwards each proxied HTTP request as ONE base64'd WebSocket
+message. The host client used the `websockets` default `max_size` of 1 MiB, so a
+large item-import body overflowed the frame -> the WS connection dropped -> the
+host became unreachable through the relay ("dropped the server"). Fixed by raising
+the host client's `max_size` to 160 MiB (celerp/gateway/client.py) and chunking the
+import to <=500 records per call.
+
+These tests verify the merged fix:
+  1. the host client is actually configured with the raised frame size;
+  2. a realistic large item import fits the new frame but would have overflowed the
+     old 1 MiB default (i.e. the fix is what closes the I1 scenario);
+  3. the import endpoint processes a full 500-record batch and isolates bad rows
+     without erroring - the server stays up and responsive.
+"""
+from __future__ import annotations
+
+import base64
+import json
+import re
+import uuid
+from pathlib import Path
+
+import pytest
+
+from celerp.events.types import EventType
+
+_OLD_DEFAULT_MAX = 1 * 1024 * 1024          # websockets library default that caused I1
+_RAISED_MAX = 160 * 1024 * 1024             # the merged fix in celerp/gateway/client.py
+_CLIENT_SRC = Path(__file__).resolve().parents[1] / "celerp" / "gateway" / "client.py"
+
+
+async def _register(client) -> str:
+    email = f"i1-{uuid.uuid4().hex[:10]}@test.test"
+    r = await client.post(
+        "/auth/register",
+        json={"company_name": "I1 Co", "email": email, "name": "Admin", "password": "pw"},
+    )
+    assert r.status_code == 200, r.text
+    return r.json()["access_token"]
+
+
+def _h(token: str) -> dict:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _item_record(i: int) -> dict:
+    return {
+        "entity_id": f"item:i1-{uuid.uuid4()}",
+        "entity_type": "item",
+        "event_type": EventType.ITEM_CREATED,
+        "data": {
+            "sku": f"I1-{i:05d}",
+            "name": f"Bulk Imported Item number {i} with a realistically long descriptive name",
+            "category": "Imported",
+            "sell_by": "piece",
+            "quantity": 1,
+            "cost_price": 1.23,
+            "wholesale_price": 2.34,
+            "retail_price": 3.45,
+        },
+        "idempotency_key": f"i1:{uuid.uuid4()}",
+        "source": "csv_import",
+        "source_ts": None,
+    }
+
+
+# ── 1. The merged transport fix is present ────────────────────────────────────
+
+def test_host_client_ws_max_size_is_raised():
+    """The host relay client must connect with the raised WS frame size; the library
+    default (1 MiB) is what dropped the connection on a large import (I1)."""
+    src = _CLIENT_SRC.read_text()
+    assert "max_size=160 * 1024 * 1024" in src, (
+        "celerp/gateway/client.py must raise the WS max_size to 160 MiB so large import "
+        "bodies traverse the relay instead of overflowing the frame and dropping the host"
+    )
+    # And it must not silently fall back to the library default on the live connect call.
+    connect = re.search(r"websockets\.connect\((.*?)\)", src, re.S)
+    assert connect and "max_size=" in connect.group(1), "websockets.connect must set max_size explicitly"
+
+
+# ── 2. A realistic large import fits the new frame, not the old ───────────────
+
+def test_large_item_import_fits_new_frame_but_overflowed_old():
+    """A ~4,000-item import (the I1 scenario) framed as one base64'd WS message
+    exceeds the old 1 MiB default (would drop -> I1) but fits the raised 160 MiB."""
+    records = [_item_record(i) for i in range(4000)]
+    body = json.dumps({"records": records, "filename": "big_import.csv"}).encode()
+    framed = len(base64.b64encode(body))  # the relay sends the body base64-encoded
+    assert framed > _OLD_DEFAULT_MAX, (
+        f"test payload ({framed} B framed) should exceed the old 1 MiB cap to model I1"
+    )
+    assert framed <= _RAISED_MAX, (
+        f"a 4k-item import ({framed} B framed) must fit the raised 160 MiB WS frame"
+    )
+
+
+# ── 3. The endpoint stays up under a full batch and bad rows ──────────────────
+
+@pytest.mark.asyncio
+async def test_max_batch_import_succeeds_and_server_stays_responsive(client):
+    """A full 500-record batch (the per-call max) imports cleanly and the server is
+    still responsive afterwards - it does not drop."""
+    token = await _register(client)
+    records = [_item_record(i) for i in range(500)]
+    r = await client.post(
+        "/items/import/batch",
+        headers=_h(token),
+        json={"records": records, "filename": "max_batch.csv"},
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["created"] == 500, body
+    # Server is still alive and serving after the large import.
+    health = await client.get("/items/import/batches", headers=_h(token))
+    assert health.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_import_isolates_bad_rows_without_crashing(client):
+    """A batch mixing valid and invalid rows must not 500; bad rows are skipped and
+    reported while the valid ones import - one malformed row can't drop the import."""
+    token = await _register(client)
+    good = [_item_record(i) for i in range(5)]
+    bad = []
+    for i in range(3):
+        rec = _item_record(1000 + i)
+        rec["data"].pop("sell_by")  # missing required unit -> per-row error, not a crash
+        bad.append(rec)
+    records = good + bad
+    r = await client.post(
+        "/items/import/batch",
+        headers=_h(token),
+        json={"records": records, "filename": "mixed.csv"},
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["created"] == 5, body
+    assert body["skipped"] == 3, body
+    assert len(body["errors"]) == 3, body

--- a/tests/test_prod_hardening.py
+++ b/tests/test_prod_hardening.py
@@ -24,6 +24,20 @@ async def test_health_returns_200(client: AsyncClient) -> None:
 
 
 @pytest.mark.asyncio
+async def test_health_version_prefers_app_version_env(monkeypatch) -> None:
+    """C2: /health reports the desktop app version (CELERP_APP_VERSION, set by Electron)
+    when present, else the Python package version - so the cloud-relay / PC-browser path
+    (which reads /health) shows the same version as the desktop, not the pip version."""
+    from celerp.routers import health as health_mod
+
+    monkeypatch.setenv("CELERP_APP_VERSION", "9.9.9-desktop")
+    assert (await health_mod.health())["version"] == "9.9.9-desktop"
+
+    monkeypatch.delenv("CELERP_APP_VERSION", raising=False)
+    assert (await health_mod.health())["version"] == health_mod.__version__
+
+
+@pytest.mark.asyncio
 async def test_rate_limit_on_login(client: AsyncClient) -> None:
     # /auth/login is gated by celerp.routers.auth.limiter ("10/minute") - NOT app.state.limiter, so
     # the old version re-enabled the wrong limiter and never actually exercised the limit. Enable the


### PR DESCRIPTION
Three small, independent triage fixes carried on `develop`. All sit cleanly on top of `main` (no overlap with already-merged work).

## C2 + C4 — desktop/relay integration (`cc1990b`)
- **C2:** Electron passes its app version to the spawned API via `CELERP_APP_VERSION`; `/health` reports that (else `celerp.__version__`), so the cloud-relay / PC-browser path shows the same version as the desktop instead of the Python package version.
- **C4:** the gateway client emits `CELERP_RELAY_STATE=<status>` on each relay-status transition; the Electron host reads it off the API stdout and holds a single `powerSaveBlocker('prevent-app-suspension')` while the relay is active, releasing it otherwise and on quit. Keeps the system awake so an idle Mac can't drop the relay; scoped to relay-active so a non-serving app sleeps normally.

## F9 — projection idempotency (`92816cd`)
`item.file.attached` now updates the existing entry in place when the `file_id` is already present, instead of appending a duplicate — duplicate file rows are structurally impossible at the projection layer.

## I1 — import-crash verification (`eddfd16`)
Tests confirming the merged relay fix resolves "cloud import drops the server": the host WS frame is 160 MiB, a 4k-item import fits it (but exceeds the old 1 MiB cap), and `/items/import/batch` handles a full 500-record batch and isolates bad rows without crashing.

## Tests
53 passing locally across the four touched suites (health, gateway, item-file events, import).

## Note
The C4 Electron half (powerSaveBlocker lifecycle) needs a desktop build to verify over a real idle-sleep cycle; the Python sentinel half is unit-tested. A 24/7 relay host still needs AC + lid open (C3 remains the reconnect safety net).