### PR TITLE
fix(test): isolate cloud settings + config.toml to kill cloud-relay shard flake

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -8,6 +8,17 @@ import os
 # Must be set before celerp.config is imported (JWT guard fires at module load).
 os.environ.setdefault("ALLOW_INSECURE_JWT", "true")
 
+# Point config.toml at a per-worker temp file. Otherwise every xdist worker
+# shares ~/.config/celerp/config.toml, which ensure_instance_id() reads+writes
+# on the cloud-relay endpoints — concurrent access across workers (and leakage
+# of one test's instance_id/token into the next) made those tests flaky.
+import tempfile as _tempfile
+_worker = os.environ.get("PYTEST_XDIST_WORKER", "main")
+os.environ.setdefault(
+    "CELERP_CONFIG",
+    os.path.join(_tempfile.gettempdir(), f"celerp-test-config-{_worker}.toml"),
+)
+
 # ── Postgres for the whole test suite ──────────────────────────────────────────
 # Both production targets (the server and the Electron embedded-postgres build)
 # run Postgres, so the tests run on Postgres too. A pre-set DATABASE_URL (e.g. a
@@ -407,6 +418,37 @@ def _reset_gateway_state():
     yield
     _gw.set_instance_id(_iid)
     _gw.set_session_token(_tok)
+
+
+# Process-global settings fields that the cloud-activation endpoints mutate
+# in place (gateway_token etc. via _apply_gateway_token_api, instance_id via
+# ensure_instance_id). Snapshot+restore so a test that activates/claims/applies
+# a token cannot leak the values into a later test on the same xdist worker.
+_CLOUD_SETTINGS_FIELDS = (
+    "gateway_token", "gateway_instance_id", "gateway_http_url",
+    "celerp_public_url", "backup_encryption_key", "backup_enabled",
+    "cookie_secure",
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_cloud_settings():
+    """Restore the mutable cloud/backup `settings` fields around each test.
+
+    The cloud-relay endpoints write straight onto the process-global
+    `celerp.config.settings` object (e.g. _apply_gateway_token_api sets
+    gateway_token / celerp_public_url and auto-generates backup_encryption_key;
+    ensure_instance_id sets gateway_instance_id). Nothing else reset these, so a
+    successful activate/claim/apply-token test leaked a non-empty gateway_token
+    into later tests on the same worker — order-dependent flakiness that
+    surfaced as cloud-claim timeouts in one shard and passed on rerun. This is
+    the settings-side counterpart to _reset_gateway_state above.
+    """
+    from celerp.config import settings as _s
+    snapshot = {f: getattr(_s, f) for f in _CLOUD_SETTINGS_FIELDS}
+    yield
+    for f, v in snapshot.items():
+        setattr(_s, f, v)
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
## Problem

`tests/test_routers/test_cloud_relay.py::test_cloud_claim_success_activates_immediately` and `::test_cloud_claim_otp_invalid` are flaky: they timed out (>30s) in a parallel shard, then passed on rerun. Classic "passes alone, fails in shard, passes on rerun" state-leak signature.

## Root cause

The cloud-activation endpoints mutate **process-global** state that nothing resets between tests:

- `_apply_gateway_token_api` writes straight onto `celerp.config.settings` (`gateway_token`, `gateway_instance_id`, `celerp_public_url`, auto-generated `backup_encryption_key`).
- `ensure_instance_id()` reads+writes `~/.config/celerp/config.toml`. `CELERP_CONFIG` is unset in CI, so **every xdist worker shares the same file** and reads/writes it concurrently.

A successful activate/claim/apply-token test therefore leaked a non-empty `gateway_token`/`instance_id` into later tests on the same worker, and the shared config file was touched concurrently across workers. That order-dependent state is what made the cloud-claim requests hang until the 30s timeout in one shard and pass on rerun.

The repo already guards the sibling case for the `gateway.state` module (`_reset_gateway_state` fixture); the `settings` object and `config.toml` were simply missed.

## Fix

In `conftest.py`, mirroring `_reset_gateway_state`:

- **`_reset_cloud_settings`** (autouse): snapshot + restore the mutable cloud/backup `settings` fields around each test.
- **Per-worker `CELERP_CONFIG`**: point `config.toml` at a temp file keyed by `PYTEST_XDIST_WORKER`, so each worker's config IO is isolated.

No production code changed — this is purely test isolation.

## Verification

- Full unit suite under `-n auto`: **3679 passed, 1 skipped**.
- `test_cloud_relay.py` + `test_config.py` + `test_cli.py` + `test_bootstrap_flow.py` + `test_setup_wizard.py` + all routers: green.
- Confirmed the config-touching tests already override `CELERP_CONFIG` via `monkeypatch`/`patch`, so the new default never interferes.