### PR TITLE
AI: route inference through the gateway service

### DIFF
--- a/celerp/ai/intent.py
+++ b/celerp/ai/intent.py
@@ -4,11 +4,9 @@
 """Intent classification - detect file-through routing tasks.
 
 Determines whether a query with files needs AI comprehension (read the file)
-or is a routing/filing task (skip file content, zero credits).
-
-Two-tier approach:
-  1. Keyword match (free, instant) - catches "file this", "save this", etc.
-  2. LLM fallback (GPT-5-nano, ~$0.0003) - for ambiguous cases
+or is a routing/filing task (skip file content). Keyword-based and instant, so
+classifying intent never costs a metered model call. Ambiguous cases default to
+COMPREHENSION.
 
 If no files are attached, always returns COMPREHENSION.
 """
@@ -16,9 +14,6 @@ If no files are attached, always returns COMPREHENSION.
 from __future__ import annotations
 
 import logging
-
-from celerp.ai.llm import call_llm
-from celerp.ai.models import CLASSIFY
 
 log = logging.getLogger(__name__)
 
@@ -40,18 +35,6 @@ _ROUTING_PATTERNS = (
     "archive this",
 )
 
-_CLASSIFY_PROMPT = """\
-Classify the user's intent for this query that includes file attachments.
-
-COMPREHENSION: The user wants the AI to READ and ANALYZE the file content.
-ROUTING: The user wants to FILE, SAVE, or MOVE the file without reading its content.
-
-Reply with exactly one word: COMPREHENSION or ROUTING
-
-Query: "{query}"
-"""
-
-
 def _keyword_match(query: str) -> str | None:
     """Check for routing keywords. Returns Intent or None if ambiguous."""
     lowered = query.lower()
@@ -65,28 +48,9 @@ async def classify_intent(query: str, has_files: bool) -> str:
     """Classify query intent. Returns Intent.COMPREHENSION or Intent.ROUTING.
 
     Without files, always returns COMPREHENSION (text queries always need AI).
-    With files, checks keywords first, then falls back to cheap LLM classification.
+    With files, a routing keyword marks a file-only task; otherwise COMPREHENSION.
     """
     if not has_files:
         return Intent.COMPREHENSION
-
-    # Tier 1: keyword match
     result = _keyword_match(query)
-    if result is not None:
-        return result
-
-    # Tier 2: LLM classification
-    try:
-        response = await call_llm(
-            CLASSIFY,
-            "You are an intent classifier. Reply with exactly one word.",
-            _CLASSIFY_PROMPT.format(query=query),
-            max_tokens=10,
-        )
-        cleaned = response.strip().upper()
-        if "ROUTING" in cleaned:
-            return Intent.ROUTING
-        return Intent.COMPREHENSION
-    except Exception:
-        log.warning("Intent classification LLM failed, defaulting to COMPREHENSION", exc_info=True)
-        return Intent.COMPREHENSION
+    return result if result is not None else Intent.COMPREHENSION

--- a/celerp/ai/llm.py
+++ b/celerp/ai/llm.py
@@ -1,11 +1,10 @@
 # Copyright (c) 2026 Noah Severs
 # SPDX-License-Identifier: LicenseRef-Proprietary
 
-"""OpenRouter LLM client - single entry point for all model calls.
+"""LLM client - single entry point for all model calls.
 
-Uses the OpenAI-compatible chat completions API at openrouter.ai.
-Supports text-only and multimodal (image/PDF) messages.
-Handles retry with exponential backoff on 429s.
+Calls are served through the cloud gateway, which selects the model and meters
+usage. Supports text-only and multimodal (image/PDF) messages.
 Concurrency-limited via a module-level semaphore.
 """
 
@@ -14,23 +13,15 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
-import random
 
 import httpx
 
+from celerp.gateway.state import relay_http_url, relay_session_headers
+
 log = logging.getLogger(__name__)
 
-_BASE_URL = "https://openrouter.ai/api/v1/chat/completions"
-_MAX_RETRIES = 3
 _MAX_CONCURRENT = int(os.getenv("AI_MAX_CONCURRENT", "3"))
 _semaphore = asyncio.Semaphore(_MAX_CONCURRENT)
-
-
-def _api_key() -> str:
-    key = os.getenv("OPENROUTER_API_KEY", "")
-    if not key:
-        raise RuntimeError("OPENROUTER_API_KEY is not configured.")
-    return key
 
 
 def _build_user_content(
@@ -61,18 +52,17 @@ async def call_llm(
     files: list[dict] | None = None,
     max_tokens: int = 2048,
     history: list[dict[str, str]] | None = None,
-    timeout: float = 45.0,
+    timeout: float = 60.0,
 ) -> str:
-    """Call OpenRouter and return the assistant's text response.
+    """Run a completion through the gateway and return the assistant's text.
 
     Args:
-        history: Optional prior conversation messages [{"role": "user"|"assistant", "content": "..."}].
-                 Inserted between system and the current user message.
+        model: advisory only — the gateway selects the served model.
+        history: Optional prior conversation messages [{"role": ..., "content": ...}].
 
-    Raises RuntimeError on permanent failures (missing key, non-retryable errors,
-    exhausted retries). Retries on 429 with exponential backoff + jitter.
+    Raises HTTPException(402) when the plan's quota is exhausted.
+    Raises RuntimeError on other failures (no session, gateway error).
     """
-    api_key = _api_key()
     user_content = _build_user_content(user_text, files)
 
     messages: list[dict] = [{"role": "system", "content": system}]
@@ -80,47 +70,41 @@ async def call_llm(
         messages.extend(history)
     messages.append({"role": "user", "content": user_content})
 
-    payload = {
-        "model": model,
-        "max_tokens": max_tokens,
+    file_count = len(files) if files else 0
+    body = {
         "messages": messages,
+        "hints": {
+            "query": user_text[:500],
+            "file_count": file_count,
+            "is_batch": file_count > 1,
+        },
+        "max_tokens": max_tokens,
     }
-    headers = {
-        "Authorization": f"Bearer {api_key}",
-        "Content-Type": "application/json",
-        "HTTP-Referer": "https://celerp.com",
-        "X-Title": "Celerp AI",
-    }
+
+    headers = relay_session_headers()
+    if not headers.get("X-Session-Token"):
+        raise RuntimeError("The AI service is not available - no active cloud session.")
+
+    url = f"{relay_http_url()}/ai/complete"
 
     async with _semaphore:
-        for attempt in range(_MAX_RETRIES + 1):
-            async with httpx.AsyncClient(timeout=timeout) as client:
-                resp = await client.post(_BASE_URL, headers=headers, json=payload)
+        async with httpx.AsyncClient(timeout=timeout) as client:
+            resp = await client.post(url, headers=headers, json=body)
 
-            if resp.status_code == 200:
-                body = resp.json()
-                choices = body.get("choices", [])
-                if not choices:
-                    raise RuntimeError("LLM returned empty choices.")
-                return choices[0]["message"]["content"]
+    if resp.status_code == 200:
+        return resp.json().get("answer", "")
 
-            if resp.status_code == 429:
-                if attempt >= _MAX_RETRIES:
-                    raise RuntimeError(
-                        f"LLM rate limit exceeded after {_MAX_RETRIES} retries."
-                    )
-                retry_after = float(resp.headers.get("retry-after", 2 ** attempt))
-                jitter = random.uniform(0, 0.5)
-                wait = retry_after + jitter
-                log.warning(
-                    "LLM rate limited (attempt %d/%d). Waiting %.1fs.",
-                    attempt + 1, _MAX_RETRIES, wait,
-                )
-                await asyncio.sleep(wait)
-                continue
+    if resp.status_code == 402:
+        from fastapi import HTTPException
+        try:
+            detail = resp.json().get("detail", {})
+        except Exception:
+            detail = {}
+        if not isinstance(detail, dict):
+            detail = {"code": "quota_exceeded", "message": str(detail)}
+        raise HTTPException(status_code=402, detail=detail)
 
-            raise RuntimeError(
-                f"LLM API error {resp.status_code}: {resp.text[:400]}"
-            )
+    if resp.status_code in (429, 503):
+        raise RuntimeError("The AI service is temporarily busy.")
 
-    raise RuntimeError("call_llm: exhausted retry loop unexpectedly")
+    raise RuntimeError(f"LLM gateway error {resp.status_code}")

--- a/celerp/ai/quota.py
+++ b/celerp/ai/quota.py
@@ -1,11 +1,10 @@
 # Copyright (c) 2026 Noah Severs
 # SPDX-License-Identifier: LicenseRef-Proprietary
 
-"""Gateway quota client.
+"""Gateway quota status client.
 
-Calls /quota/ai/consume on the relay to enforce per-instance AI query limits.
-If the gateway is not configured, quota checks are skipped (self-hosted installs with no
-cloud subscription run unlimited locally - the gate lives in the cloud).
+Reads AI quota status from the relay for display and tier checks. Quota is
+enforced by the gateway as a query runs; this module only reports it.
 """
 
 from __future__ import annotations
@@ -19,76 +18,13 @@ from celerp.gateway.state import (
     get_session_token,
     relay_http_url,
     relay_session_headers,
-    relay_subscribe_url,
 )
 
-# Private aliases so tests (and any internal callers) can import these from
-# this module rather than reaching into celerp.gateway.state directly.
+# Alias so tests / internal callers import this from here rather than reaching
+# into celerp.gateway.state directly.
 _relay_http_url = relay_http_url
 
-
-def _subscribe_url() -> str:
-    """Return the celerp.com subscribe URL anchored to the AI section."""
-    return relay_subscribe_url(anchor="ai")
-
 log = logging.getLogger(__name__)
-
-# Quota bypass monitoring: count consecutive relay failures
-_unconfirmed: int = 0
-_UNCONFIRMED_THRESHOLD: int = 10
-
-
-async def check_ai_quota(credits: int = 1) -> None:
-    """Consume AI quota credits from the relay.
-
-    credits: number of credits to consume (default 1 for pure text queries).
-    Raises HTTPException(402) if quota exceeded.
-    Raises nothing if gateway is not configured (local-only install).
-    """
-    if not settings.gateway_token or not get_session_token():
-        # No gateway → no quota enforcement (local install)
-        log.debug("Quota check skipped: gateway not configured.")
-        return
-
-    url = f"{relay_http_url()}/quota/ai/consume"
-
-    try:
-        async with httpx.AsyncClient(timeout=5.0) as client:
-            r = await client.post(url, headers=relay_session_headers())
-    except Exception as exc:
-        # Network failure - allow through (don't block user on relay outage)
-        global _unconfirmed
-        _unconfirmed += 1
-        log.warning("Quota check failed (%d unconfirmed): %s. Allowing query.", _unconfirmed, exc)
-        if _unconfirmed >= _UNCONFIRMED_THRESHOLD:
-            log.error("Quota bypass threshold reached: %d consecutive failures. Check relay connectivity.", _unconfirmed)
-        return
-
-    if r.status_code == 200:
-        _unconfirmed = 0
-        return
-
-    if r.status_code == 429:
-        from fastapi import HTTPException
-        detail = r.json().get("detail", {})
-        raise HTTPException(
-            status_code=402,  # Payment Required
-            detail={
-                "code": "quota_exceeded",
-                "message": detail.get("message", "AI query quota exceeded"),
-                "used": detail.get("used", 0),
-                "limit": detail.get("limit", 0),
-                "resets_at": detail.get("resets_at", ""),
-                "upgrade_url": relay_subscribe_url(anchor="ai"),
-            },
-        )
-
-    if r.status_code == 401:
-        # Session expired — allow through (client will reconnect and retry)
-        log.warning("Quota check 401: session token expired. Allowing query.")
-        return
-
-    log.warning("Quota check unexpected status %d — allowing query.", r.status_code)
 
 
 async def get_subscription_tier() -> str | None:

--- a/celerp/ai/service.py
+++ b/celerp/ai/service.py
@@ -24,13 +24,14 @@ import uuid
 from dataclasses import dataclass
 from typing import Any
 
+from fastapi import HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from celerp.ai.commands import parse_bill_commands
 from celerp.ai.files import load_file_for_llm, upload_dir
 from celerp.ai.llm import call_llm
 from celerp.ai.memory import get_memory
-from celerp.ai.models import CLASSIFY, select_model
+from celerp.ai.models import select_model
 from celerp.ai.tools import TOOLS, execute_tool
 
 log = logging.getLogger(__name__)
@@ -101,36 +102,39 @@ If a vendor isn't found in the active contacts list, provide the best guess name
 the system will create a draft contact automatically."""
 
 
-# -- Tool selection via LLM -------------------------------------------------
+# -- Tool selection (heuristic, no model call) ------------------------------
 
-async def _select_tools(query: str, has_files: bool = False) -> list[str]:
-    """Pick up to 4 tools most relevant to the query using the CLASSIFY model."""
+# Query keywords → the ERP tools whose data is worth fetching. Keeping this
+# local means a user query costs exactly one metered model call.
+_TOOL_KEYWORDS: dict[str, tuple[str, ...]] = {
+    "low_stock_items": ("stock", "restock", "reorder", "out of", "inventory level", "running low"),
+    "outstanding_invoices": ("invoice", "unpaid", "owe", "owed", "outstanding", "receivable", "overdue"),
+    "top_items_by_value": ("inventory value", "valuable", "worth", "most stock", "tied up"),
+    "active_deals_summary": ("deal", "pipeline", "crm", "opportunit", "lead", "prospect"),
+    "dormant_contacts": ("dormant", "inactive", "lost customer", "haven't heard", "gone quiet"),
+    "top_sellers": ("best sell", "top sell", "bestseller", "popular", "selling well", "moves fast"),
+    "pending_pos": ("purchase order", "pending po", "incoming", "supplier order", "on order"),
+    "active_contacts_list": ("contact", "customer", "vendor", "supplier", "client"),
+    "active_items_list": ("item", "product", "sku", "catalog"),
+}
+
+
+def _select_tools(query: str, has_files: bool = False) -> list[str]:
+    """Pick up to 4 relevant ERP tools by keyword. No model call."""
     selected: list[str] = []
     if has_files:
         selected.extend(["active_contacts_list", "active_items_list"])
 
-    tool_block = "\n".join(f"- {t.name}: {t.description}" for t in TOOLS.values())
-    prompt = (
-        f"Tools:\n{tool_block}\n\n"
-        f"Query: {query}\n\n"
-        "Return a JSON list of 0-4 tool names most relevant to answering this query. "
-        "Example: [\"dashboard_kpis\", \"low_stock_items\"]"
-    )
-    try:
-        raw = await call_llm(CLASSIFY, "You select ERP tools.", prompt, max_tokens=128)
-        match = re.search(r"\[.*?\]", raw, re.DOTALL)
-        if not match:
-            raise ValueError("No JSON array in response")
-        names = json.loads(match.group())
-        for name in names:
-            if name in TOOLS and name not in selected:
-                selected.append(name)
-        return selected[:4]
-    except Exception as exc:
-        log.warning("LLM tool selection failed, using fallback: %s", exc)
-        if "dashboard_kpis" not in selected:
-            selected.append("dashboard_kpis")
-        return selected[:4]
+    lowered = query.lower()
+    for tool, keywords in _TOOL_KEYWORDS.items():
+        if tool in selected:
+            continue
+        if any(kw in lowered for kw in keywords):
+            selected.append(tool)
+
+    if not selected:
+        selected.append("dashboard_kpis")
+    return selected[:4]
 
 
 
@@ -154,7 +158,7 @@ async def run_query(
     t0 = time.monotonic()
     file_count = len(file_ids) if file_ids else 0
     model = select_model(query, file_count=file_count, is_batch=file_count > 1)
-    tools_to_call = await _select_tools(query, has_files=bool(file_ids))
+    tools_to_call = _select_tools(query, has_files=bool(file_ids))
     tool_data: dict[str, Any] = {}
 
     # Fetch ERP data via tools
@@ -236,6 +240,9 @@ async def run_query(
         )
         _log_query(company_id, user_id, model, called, file_count, t0, result)
         return result
+    except HTTPException:
+        # Quota (402) and similar gateway signals surface to the router as-is.
+        raise
     except Exception as exc:
         log.error("AI query failed: %s", exc)
         result = AIResponse(

--- a/celerp/modules/api.py
+++ b/celerp/modules/api.py
@@ -93,11 +93,7 @@ async def ai_query(
             ),
         )
 
-    # Quota check (decrements from Cloud+AI subscription)
-    from celerp.ai.quota import check_ai_quota
-    await check_ai_quota()
-
-    # Run query through the AI service
+    # Run query through the AI service (the gateway meters usage as the query runs)
     from celerp.ai.service import run_query, AIResponse
     result: AIResponse = await run_query(
         query=query,

--- a/default_modules/celerp-ai/celerp_ai/routes.py
+++ b/default_modules/celerp-ai/celerp_ai/routes.py
@@ -47,7 +47,7 @@ from celerp.ai.conversations import (
     rename_conversation,
 )
 from celerp.ai.page_count import calculate_credits, credits_for_pages, count_pages
-from celerp.ai.quota import check_ai_quota, get_quota_status, get_subscription_tier
+from celerp.ai.quota import get_quota_status, get_subscription_tier
 from celerp.ai.service import AIResponse, run_query
 from celerp.config import settings
 from celerp.db import get_session
@@ -191,8 +191,6 @@ async def ai_query(
     Cloud tier users are limited to 1 file per query.
     """
     await _enforce_cloud_file_limit(body.file_ids)
-    credits = _calculate_query_credits(body.file_ids, company_id)
-    await check_ai_quota(credits=credits)
     result: AIResponse = await run_query(
         query=body.query,
         session=session,
@@ -551,8 +549,6 @@ async def query_in_conversation(
         raise HTTPException(status_code=404, detail="Conversation not found")
 
     await _enforce_cloud_file_limit(body.file_ids)
-    credits = _calculate_query_credits(body.file_ids, company_id)
-    await check_ai_quota(credits=credits)
 
     # Build history from prior messages
     prior_msgs = await get_messages(session, conversation_id)
@@ -630,8 +626,6 @@ async def submit_batch(
     Poll GET /ai/batch/{id} for status.
     """
     await _enforce_cloud_file_limit(body.file_ids)
-    credits = _calculate_query_credits(body.file_ids, company_id)
-    await check_ai_quota(credits=credits)
 
     job = await create_batch_job(
         session, company_id, user.id, body.query, body.file_ids, credits,

--- a/default_modules/celerp-ai/tests/conftest.py
+++ b/default_modules/celerp-ai/tests/conftest.py
@@ -1,17 +1,10 @@
 # Copyright (c) 2026 Noah Severs
 # SPDX-License-Identifier: LicenseRef-Proprietary
-"""AI module test fixtures.
-
-Autouse fixture ensures quota check never hits the real relay,
-regardless of settings state left by other tests.
-"""
+"""AI module test fixtures."""
 from __future__ import annotations
 
 import sys
 import os
-from unittest.mock import AsyncMock, patch
-
-import pytest
 
 # Guarantee celerp-ai src is on sys.path before any test imports.
 _ai_src = os.path.normpath(
@@ -19,15 +12,3 @@ _ai_src = os.path.normpath(
 )
 if _ai_src not in sys.path:
     sys.path.insert(0, _ai_src)
-
-
-@pytest.fixture(autouse=True)
-def _no_ai_quota():
-    """Prevent quota checks from calling the relay in unit tests.
-
-    Patches the name as used in celerp_ai.routes (import site), since
-    the route handler looks up 'check_ai_quota' in its own module globals.
-    """
-    import celerp_ai.routes  # ensure loaded before patching
-    with patch("celerp_ai.routes.check_ai_quota", new=AsyncMock(return_value=None)):
-        yield

--- a/default_modules/celerp-ai/tests/test_coverage_gaps.py
+++ b/default_modules/celerp-ai/tests/test_coverage_gaps.py
@@ -138,7 +138,7 @@ async def test_run_query_with_files_returns_pending_bills(session, company):
         '"line_items": [{"description": "Widget", "quantity": 2, "unit_price": 50.0}]}]}\n```'
     )
 
-    with patch("celerp.ai.service._select_tools", new_callable=AsyncMock, return_value=["active_contacts_list"]):
+    with patch("celerp.ai.service._select_tools", return_value=["active_contacts_list"]):
         with patch("celerp.ai.service.call_llm", new_callable=AsyncMock, return_value=llm_answer):
             result = await run_query("process this receipt", session, company.id, file_ids=[fid])
 
@@ -154,7 +154,7 @@ async def test_run_query_command_extraction_failure(session, company):
     from celerp.ai.service import run_query
 
     llm_answer = "Bills:\n```json\n{invalid json}\n```"
-    with patch("celerp.ai.service._select_tools", new_callable=AsyncMock, return_value=["dashboard_kpis"]):
+    with patch("celerp.ai.service._select_tools", return_value=["dashboard_kpis"]):
         with patch("celerp.ai.service.call_llm", new_callable=AsyncMock, return_value=llm_answer):
             result = await run_query("process receipts", session, company.id)
     assert result.error is None
@@ -172,7 +172,7 @@ async def test_run_query_with_history(session, company):
         return "OK"
 
     history = [{"role": "user", "content": "hi"}, {"role": "assistant", "content": "hello"}]
-    with patch("celerp.ai.service._select_tools", new_callable=AsyncMock, return_value=["dashboard_kpis"]):
+    with patch("celerp.ai.service._select_tools", return_value=["dashboard_kpis"]):
         with patch("celerp.ai.service.call_llm", side_effect=mock_llm):
             await run_query("followup", session, company.id, history=history)
     assert captured["history"] == history
@@ -395,7 +395,7 @@ def test_batch_load_file_wrong_company(tmp_path):
             load_file(fid, co_id)
 
 
-# ── llm.py: history + exhausted retries ──────────────────────────────────────
+# ── llm.py: history injection through the gateway ────────────────────────────
 
 @pytest.mark.asyncio
 async def test_call_llm_with_history():
@@ -408,39 +408,20 @@ async def test_call_llm_with_history():
         captured["messages"] = json["messages"]
         resp = MagicMock()
         resp.status_code = 200
-        resp.json.return_value = {"choices": [{"message": {"content": "result"}}]}
+        resp.json.return_value = {"answer": "result"}
         return resp
 
-    with patch.dict(os.environ, {"OPENROUTER_API_KEY": "sk-test"}):
-        with patch("httpx.AsyncClient.post", side_effect=mock_post):
-            result = await call_llm(
-                "test-model", "system prompt", "user question",
-                history=[{"role": "user", "content": "prior"}, {"role": "assistant", "content": "reply"}],
-            )
+    with patch("celerp.ai.llm.relay_session_headers", return_value={"X-Session-Token": "s", "X-Instance-ID": "i"}):
+        with patch("celerp.ai.llm.relay_http_url", return_value="https://relay"):
+            with patch("httpx.AsyncClient.post", side_effect=mock_post):
+                result = await call_llm(
+                    "test-model", "system prompt", "user question",
+                    history=[{"role": "user", "content": "prior"}, {"role": "assistant", "content": "reply"}],
+                )
 
     assert result == "result"
-    msgs = captured["messages"]
-    roles = [m["role"] for m in msgs]
+    roles = [m["role"] for m in captured["messages"]]
     assert roles == ["system", "user", "assistant", "user"]
-
-
-@pytest.mark.asyncio
-async def test_call_llm_exhausted_retries():
-    """All retries fail with 429 - raises RuntimeError."""
-    from celerp.ai.llm import call_llm
-
-    async def mock_post(url, json=None, **kw):
-        resp = MagicMock()
-        resp.status_code = 429
-        resp.text = "rate limited"
-        resp.headers = {}
-        return resp
-
-    with patch.dict(os.environ, {"OPENROUTER_API_KEY": "sk-test"}):
-        with patch("httpx.AsyncClient.post", side_effect=mock_post):
-            with patch("asyncio.sleep", new_callable=AsyncMock):
-                with pytest.raises(RuntimeError, match="rate limit exceeded"):
-                    await call_llm("test-model", "sys", "user")
 
 
 # ── page_count.py: PDF 0 pages ──────────────────────────────────────────────
@@ -460,29 +441,7 @@ def test_count_pages_pdf_zero_pages():
             count_pages(b"fake pdf", "application/pdf")
 
 
-# ── quota.py: _build_upgrade_url + get_quota_status + unconfirmed ───────────
-
-def test_subscribe_url_with_instance_id():
-    from celerp.ai.quota import _subscribe_url
-    # Patch the LIVE paths: the module-level `settings` import can go stale after
-    # another test reloads celerp.config, and `_instance_id` (set on gateway
-    # connect) overrides settings.gateway_instance_id — patch both at their real
-    # location so this test is immune to that cross-test state.
-    with patch("celerp.gateway.state._instance_id", ""), \
-         patch("celerp.config.settings.gateway_instance_id", "inst-123"):
-        url = _subscribe_url()
-    assert "instance_id=inst-123" in url
-    assert url.endswith("#ai")
-
-
-def test_subscribe_url_without_instance_id():
-    from celerp.ai.quota import _subscribe_url
-    with patch("celerp.gateway.state._instance_id", ""), \
-         patch("celerp.config.settings.gateway_instance_id", ""):
-        url = _subscribe_url()
-    assert "instance_id" not in url
-    assert url.endswith("#ai")
-
+# ── quota.py: get_quota_status ───────────────────────────────────────────────
 
 @pytest.mark.asyncio
 async def test_get_quota_status_no_gateway():
@@ -500,22 +459,6 @@ async def test_get_quota_status_no_instance_id():
             with patch.object(settings, "gateway_instance_id", ""):
                 result = await get_quota_status()
     assert result is None
-
-
-@pytest.mark.asyncio
-async def test_quota_unconfirmed_counter():
-    """Consecutive relay failures increment _unconfirmed counter."""
-    import celerp.ai.quota as quota_mod
-    quota_mod._unconfirmed = 0  # Reset
-    with patch.object(settings, "gateway_token", "tok"):
-        with patch.object(settings, "gateway_instance_id", "inst"):
-            with patch("celerp.ai.quota.get_session_token", return_value="sess"):
-                with patch("httpx.AsyncClient.post", side_effect=ConnectionError("fail")):
-                    await quota_mod.check_ai_quota()
-                    assert quota_mod._unconfirmed == 1
-                    await quota_mod.check_ai_quota()
-                    assert quota_mod._unconfirmed == 2
-    quota_mod._unconfirmed = 0  # Cleanup
 
 
 # ── tools.py: active_contacts_list, active_items_list, pending_pos ───────────

--- a/default_modules/celerp-ai/tests/test_intent.py
+++ b/default_modules/celerp-ai/tests/test_intent.py
@@ -6,7 +6,6 @@
 from __future__ import annotations
 
 import os
-from unittest.mock import AsyncMock, patch
 
 os.environ.setdefault("ALLOW_INSECURE_JWT", "true")
 
@@ -54,38 +53,24 @@ async def test_no_files_always_comprehension():
 
 
 @pytest.mark.asyncio
-async def test_keyword_hit_skips_llm():
-    # Should return ROUTING without calling LLM
-    with patch("celerp.ai.intent.call_llm", new_callable=AsyncMock) as mock:
-        result = await classify_intent("file this invoice", has_files=True)
-    assert result == Intent.ROUTING
-    mock.assert_not_called()
-
-
-@pytest.mark.asyncio
-async def test_llm_fallback_routing():
-    with patch("celerp.ai.intent.call_llm", new_callable=AsyncMock, return_value="ROUTING"):
-        result = await classify_intent("put the receipt somewhere safe", has_files=True)
+async def test_keyword_hit_returns_routing():
+    result = await classify_intent("file this invoice", has_files=True)
     assert result == Intent.ROUTING
 
 
 @pytest.mark.asyncio
-async def test_llm_fallback_comprehension():
-    with patch("celerp.ai.intent.call_llm", new_callable=AsyncMock, return_value="COMPREHENSION"):
-        result = await classify_intent("what does this contract say about termination?", has_files=True)
+async def test_ambiguous_defaults_to_comprehension():
+    result = await classify_intent("put the receipt somewhere safe", has_files=True)
     assert result == Intent.COMPREHENSION
 
 
 @pytest.mark.asyncio
-async def test_llm_fallback_error_defaults_comprehension():
-    with patch("celerp.ai.intent.call_llm", new_callable=AsyncMock, side_effect=RuntimeError("timeout")):
-        result = await classify_intent("do something with this file", has_files=True)
+async def test_question_defaults_to_comprehension():
+    result = await classify_intent("what does this contract say about termination?", has_files=True)
     assert result == Intent.COMPREHENSION
 
 
 @pytest.mark.asyncio
-async def test_routing_zero_credits():
-    """Routing intent queries should consume 0 credits (tested at service level,
-    but we verify the intent value here)."""
+async def test_routing_keyword_with_files():
     result = await classify_intent("save this to contacts", has_files=True)
     assert result == Intent.ROUTING

--- a/default_modules/celerp-ai/tests/test_llm.py
+++ b/default_modules/celerp-ai/tests/test_llm.py
@@ -1,13 +1,12 @@
 # Copyright (c) 2026 Noah Severs
 # SPDX-License-Identifier: LicenseRef-Proprietary
 
-"""Tests for celerp/ai/llm.py - OpenRouter LLM client.
+"""Tests for celerp/ai/llm.py - gateway LLM client.
 
 Covers:
-  - _api_key: missing key raises RuntimeError
   - _build_user_content: text-only vs multimodal
-  - call_llm: 200 success, 429 retry+backoff, retry exhausted, non-429 error,
-              missing key, Retry-After header, semaphore concurrency
+  - call_llm: success, no session, quota (402 -> HTTPException), busy, error,
+              multimodal payload, semaphore concurrency
 """
 
 from __future__ import annotations
@@ -19,37 +18,25 @@ from unittest.mock import AsyncMock, MagicMock, patch
 os.environ.setdefault("ALLOW_INSECURE_JWT", "true")
 
 import pytest
+from fastapi import HTTPException
 
-from celerp.ai.llm import _api_key, _build_user_content, call_llm
+from celerp.ai.llm import _build_user_content, call_llm
 
-
-# -- _api_key ---------------------------------------------------------------
-
-def test_api_key_missing():
-    with patch.dict(os.environ, {"OPENROUTER_API_KEY": ""}, clear=False):
-        # Force re-read by calling the function (it reads os.getenv each time)
-        with patch("celerp.ai.llm.os.getenv", return_value=""):
-            with pytest.raises(RuntimeError, match="OPENROUTER_API_KEY"):
-                _api_key()
-
-
-def test_api_key_present():
-    with patch("celerp.ai.llm.os.getenv", return_value="sk-or-test"):
-        assert _api_key() == "sk-or-test"
+_HDRS = {"X-Session-Token": "stok", "X-Instance-ID": "iid"}
+_NO_SESSION = {"X-Session-Token": "", "X-Instance-ID": ""}
 
 
 # -- _build_user_content ----------------------------------------------------
 
 def test_build_user_content_text_only():
-    result = _build_user_content("hello")
-    assert result == "hello"
+    assert _build_user_content("hello") == "hello"
 
 
 def test_build_user_content_with_files():
     files = [{"media_type": "image/png", "data": "abc123"}]
     result = _build_user_content("describe this", files)
     assert isinstance(result, list)
-    assert len(result) == 2  # 1 image + 1 text
+    assert len(result) == 2
     assert result[0]["type"] == "image_url"
     assert "data:image/png;base64,abc123" in result[0]["image_url"]["url"]
     assert result[1] == {"type": "text", "text": "describe this"}
@@ -61,132 +48,94 @@ def test_build_user_content_multiple_files():
         {"media_type": "application/pdf", "data": "bbb"},
     ]
     result = _build_user_content("analyze", files)
-    assert len(result) == 3  # 2 files + 1 text
+    assert len(result) == 3
     assert result[2]["text"] == "analyze"
 
 
 # -- call_llm ---------------------------------------------------------------
 
-def _mock_client(post_side_effect):
-    """Create a mock httpx.AsyncClient that returns the given side_effect on .post()."""
+def _mock_client(resp):
     client = AsyncMock()
     client.__aenter__ = AsyncMock(return_value=client)
     client.__aexit__ = AsyncMock(return_value=False)
-    client.post = AsyncMock(side_effect=post_side_effect) if isinstance(post_side_effect, list) else AsyncMock(return_value=post_side_effect)
+    client.post = AsyncMock(return_value=resp)
     return client
 
 
-def _resp(status: int, body: dict | None = None, headers: dict | None = None):
+def _resp(status: int, body: dict | None = None):
     r = MagicMock()
     r.status_code = status
     r.json.return_value = body or {}
     r.text = str(body or "")
-    r.headers = headers or {}
     return r
 
 
+def _patches(headers=_HDRS, client=None):
+    return (
+        patch("celerp.ai.llm.relay_session_headers", return_value=headers),
+        patch("celerp.ai.llm.relay_http_url", return_value="https://relay"),
+        patch("celerp.ai.llm.httpx.AsyncClient", return_value=client),
+    )
+
+
 @pytest.mark.asyncio
-async def test_call_llm_missing_key():
-    with patch("celerp.ai.llm.os.getenv", return_value=""):
-        with pytest.raises(RuntimeError, match="OPENROUTER_API_KEY"):
-            await call_llm("model", "sys", "user")
+async def test_call_llm_no_session():
+    with patch("celerp.ai.llm.relay_session_headers", return_value=_NO_SESSION):
+        with pytest.raises(RuntimeError, match="no active cloud session"):
+            await call_llm("m", "s", "u")
 
 
 @pytest.mark.asyncio
 async def test_call_llm_success():
-    resp = _resp(200, {"choices": [{"message": {"content": "Hello!"}}]})
-    client = _mock_client(resp)
-
-    with patch("celerp.ai.llm.os.getenv", return_value="sk-test"):
-        with patch("celerp.ai.llm.httpx.AsyncClient", return_value=client):
-            result = await call_llm("test-model", "sys", "user msg")
+    client = _mock_client(_resp(200, {"answer": "Hello!"}))
+    p1, p2, p3 = _patches(client=client)
+    with p1, p2, p3:
+        result = await call_llm("test-model", "sys", "user msg")
     assert result == "Hello!"
+    assert client.post.call_args[0][0] == "https://relay/ai/complete"
 
 
 @pytest.mark.asyncio
-async def test_call_llm_empty_choices():
-    resp = _resp(200, {"choices": []})
-    client = _mock_client(resp)
-
-    with patch("celerp.ai.llm.os.getenv", return_value="sk-test"):
-        with patch("celerp.ai.llm.httpx.AsyncClient", return_value=client):
-            with pytest.raises(RuntimeError, match="empty choices"):
-                await call_llm("m", "s", "u")
-
-
-@pytest.mark.asyncio
-async def test_call_llm_non_429_error():
-    resp = _resp(500, {"error": "bad"})
-    client = _mock_client(resp)
-
-    with patch("celerp.ai.llm.os.getenv", return_value="sk-test"):
-        with patch("celerp.ai.llm.httpx.AsyncClient", return_value=client):
-            with pytest.raises(RuntimeError, match="500"):
-                await call_llm("m", "s", "u")
-    assert client.post.call_count == 1  # no retry on non-429
+async def test_call_llm_quota_exceeded_raises_402():
+    client = _mock_client(_resp(402, {"detail": {"code": "quota_exceeded", "message": "no credits"}}))
+    p1, p2, p3 = _patches(client=client)
+    with p1, p2, p3:
+        with pytest.raises(HTTPException) as ei:
+            await call_llm("m", "s", "u")
+    assert ei.value.status_code == 402
+    assert ei.value.detail["code"] == "quota_exceeded"
 
 
 @pytest.mark.asyncio
-async def test_call_llm_429_retry_then_success():
-    r429 = _resp(429)
-    r200 = _resp(200, {"choices": [{"message": {"content": "ok"}}]})
-    client = _mock_client([r429, r429, r200])
-
-    with patch("celerp.ai.llm.os.getenv", return_value="sk-test"):
-        with patch("celerp.ai.llm.httpx.AsyncClient", return_value=client):
-            with patch("celerp.ai.llm.asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
-                result = await call_llm("m", "s", "u")
-
-    assert result == "ok"
-    assert client.post.call_count == 3
-    assert mock_sleep.call_count == 2
+async def test_call_llm_busy():
+    client = _mock_client(_resp(503, {}))
+    p1, p2, p3 = _patches(client=client)
+    with p1, p2, p3:
+        with pytest.raises(RuntimeError, match="busy"):
+            await call_llm("m", "s", "u")
 
 
 @pytest.mark.asyncio
-async def test_call_llm_429_respects_retry_after():
-    r429 = _resp(429, headers={"retry-after": "7"})
-    r200 = _resp(200, {"choices": [{"message": {"content": "ok"}}]})
-    client = _mock_client([r429, r200])
-
-    with patch("celerp.ai.llm.os.getenv", return_value="sk-test"):
-        with patch("celerp.ai.llm.httpx.AsyncClient", return_value=client):
-            with patch("celerp.ai.llm.asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
-                with patch("celerp.ai.llm.random.uniform", return_value=0.0):
-                    result = await call_llm("m", "s", "u")
-
-    assert result == "ok"
-    mock_sleep.assert_called_once_with(7.0)
+async def test_call_llm_gateway_error():
+    client = _mock_client(_resp(500, {}))
+    p1, p2, p3 = _patches(client=client)
+    with p1, p2, p3:
+        with pytest.raises(RuntimeError, match="gateway error"):
+            await call_llm("m", "s", "u")
+    assert client.post.call_count == 1
 
 
 @pytest.mark.asyncio
-async def test_call_llm_429_exhausts_retries():
-    r429 = _resp(429)
-    client = _mock_client(r429)
-
-    with patch("celerp.ai.llm.os.getenv", return_value="sk-test"):
-        with patch("celerp.ai.llm.httpx.AsyncClient", return_value=client):
-            with patch("celerp.ai.llm.asyncio.sleep", new_callable=AsyncMock):
-                with pytest.raises(RuntimeError, match="rate limit exceeded"):
-                    await call_llm("m", "s", "u")
-
-    assert client.post.call_count == 4  # initial + 3 retries
-
-
-@pytest.mark.asyncio
-async def test_call_llm_with_files():
-    """Multimodal content is sent correctly."""
-    resp = _resp(200, {"choices": [{"message": {"content": "I see an image"}}]})
-    client = _mock_client(resp)
-
+async def test_call_llm_with_files_multimodal():
+    client = _mock_client(_resp(200, {"answer": "I see an image"}))
     files = [{"media_type": "image/jpeg", "data": "base64data"}]
-    with patch("celerp.ai.llm.os.getenv", return_value="sk-test"):
-        with patch("celerp.ai.llm.httpx.AsyncClient", return_value=client):
-            result = await call_llm("m", "s", "describe", files=files)
-
+    p1, p2, p3 = _patches(client=client)
+    with p1, p2, p3:
+        result = await call_llm("m", "s", "describe", files=files)
     assert result == "I see an image"
-    call_kwargs = client.post.call_args
-    msg_content = call_kwargs[1]["json"]["messages"][1]["content"]
-    assert isinstance(msg_content, list)  # multimodal
+    body = client.post.call_args[1]["json"]
+    assert isinstance(body["messages"][1]["content"], list)
+    assert body["hints"]["file_count"] == 1
 
 
 @pytest.mark.asyncio
@@ -204,6 +153,6 @@ async def test_semaphore_limits_concurrency():
 
     try:
         await asyncio.gather(task(1), task(2))
-        assert results == [1, 2]  # serialized
+        assert results == [1, 2]
     finally:
         llm_mod._semaphore = original

--- a/default_modules/celerp-ai/tests/test_quota.py
+++ b/default_modules/celerp-ai/tests/test_quota.py
@@ -1,31 +1,30 @@
 # Copyright (c) 2026 Noah Severs
 # SPDX-License-Identifier: LicenseRef-Proprietary
 
-"""Tests for celerp/ai/quota.py — 100% line coverage.
+"""Tests for celerp/ai/quota.py — gateway quota status reads.
 
 Covers:
   - _relay_http_url: derivation from wss://, ws://, gateway_http_url override
-  - check_ai_quota: no gateway configured (skip), no instance_id (skip)
-  - check_ai_quota: 200 → pass
-  - check_ai_quota: 429 → HTTPException 402
-  - check_ai_quota: 401 → pass (allow through)
-  - check_ai_quota: other status → pass (allow through)
-  - check_ai_quota: network error → pass (allow through)
-  - check_ai_quota: credits param forwarded as query param
-  - get_subscription_tier: 200 → returns tier
-  - get_subscription_tier: failure → returns None
+  - get_quota_status: no gateway (None), 200 (dict), bad status (None), network error (None)
+  - get_subscription_tier: 200 (tier), no gateway / failure (None)
 """
 
 from __future__ import annotations
 
-import pytest
 import httpx
+import pytest
 import respx
-from fastapi import HTTPException
 
-from celerp.ai.quota import check_ai_quota, get_subscription_tier, _relay_http_url
+from celerp.ai.quota import _relay_http_url, get_quota_status, get_subscription_tier
 from celerp.config import settings
 import celerp.gateway.state as gw_state
+
+
+def _configure(monkeypatch):
+    monkeypatch.setattr(settings, "gateway_token", "tok")
+    monkeypatch.setattr(gw_state, "_session_token", "sess")
+    monkeypatch.setattr(settings, "gateway_instance_id", "test-iid")
+    monkeypatch.setattr(settings, "gateway_http_url", "https://relay.test")
 
 
 # ── _relay_http_url ───────────────────────────────────────────────────────────
@@ -47,164 +46,65 @@ def test_relay_http_url_override(monkeypatch):
     assert _relay_http_url() == "https://custom-relay.example.com"
 
 
-# ── check_ai_quota ────────────────────────────────────────────────────────────
+# ── get_quota_status ──────────────────────────────────────────────────────────
 
 @pytest.mark.asyncio
-async def test_quota_skip_no_gateway(monkeypatch):
-    """No gateway configured → check skipped, no exception."""
+async def test_quota_status_no_gateway(monkeypatch):
     monkeypatch.setattr(settings, "gateway_token", "")
     monkeypatch.setattr(gw_state, "_session_token", "")
-    await check_ai_quota()  # should not raise
+    assert await get_quota_status() is None
 
 
 @pytest.mark.asyncio
-async def test_quota_skip_no_instance_id(monkeypatch):
-    """No instance_id → check skipped."""
-    monkeypatch.setattr(settings, "gateway_token", "tok")
-    monkeypatch.setattr(gw_state, "_session_token", "sess")
-    monkeypatch.setattr(settings, "gateway_instance_id", "")
-    await check_ai_quota()  # should not raise
-
-
-@pytest.mark.asyncio
-async def test_quota_allowed(monkeypatch):
-    """200 from relay → pass."""
-    monkeypatch.setattr(settings, "gateway_token", "tok")
-    monkeypatch.setattr(gw_state, "_session_token", "sess")
-    monkeypatch.setattr(settings, "gateway_instance_id", "test-iid")
-    monkeypatch.setattr(settings, "gateway_http_url", "https://relay.test")
-
+async def test_quota_status_returns_dict(monkeypatch):
+    _configure(monkeypatch)
     with respx.mock:
-        respx.post("https://relay.test/quota/ai/consume").mock(
-            return_value=httpx.Response(200, json={"allowed": True, "used": 1, "limit": 100, "resets_at": "2026-04-01"})
+        respx.get("https://relay.test/quota/ai/status").mock(
+            return_value=httpx.Response(200, json={"tier": "ai", "allowed": True, "used": 5, "limit": 200})
         )
-        await check_ai_quota()  # should not raise
+        status = await get_quota_status()
+    assert status["tier"] == "ai"
+    assert status["limit"] == 200
 
 
 @pytest.mark.asyncio
-async def test_quota_exceeded_429(monkeypatch):
-    """429 from relay → HTTPException 402."""
-    monkeypatch.setattr(settings, "gateway_token", "tok")
-    monkeypatch.setattr(gw_state, "_session_token", "sess")
-    monkeypatch.setattr(settings, "gateway_instance_id", "test-iid")
-    monkeypatch.setattr(settings, "gateway_http_url", "https://relay.test")
-
+async def test_quota_status_bad_status(monkeypatch):
+    _configure(monkeypatch)
     with respx.mock:
-        respx.post("https://relay.test/quota/ai/consume").mock(
-            return_value=httpx.Response(429, json={"detail": {
-                "code": "quota_exceeded",
-                "message": "AI query quota exceeded",
-                "used": 3,
-                "limit": 3,
-                "resets_at": "2026-04-01T00:00:00Z",
-            }})
-        )
-        with pytest.raises(HTTPException) as exc_info:
-            await check_ai_quota()
-    assert exc_info.value.status_code == 402
-    assert exc_info.value.detail["code"] == "quota_exceeded"
-    assert "celerp.com/subscribe" in exc_info.value.detail["upgrade_url"]
+        respx.get("https://relay.test/quota/ai/status").mock(return_value=httpx.Response(503, json={}))
+        assert await get_quota_status() is None
 
 
 @pytest.mark.asyncio
-async def test_quota_expired_session_401(monkeypatch):
-    """401 from relay → allow through (session expired, client will reconnect)."""
-    monkeypatch.setattr(settings, "gateway_token", "tok")
-    monkeypatch.setattr(gw_state, "_session_token", "sess")
-    monkeypatch.setattr(settings, "gateway_instance_id", "test-iid")
-    monkeypatch.setattr(settings, "gateway_http_url", "https://relay.test")
-
+async def test_quota_status_network_error(monkeypatch):
+    _configure(monkeypatch)
     with respx.mock:
-        respx.post("https://relay.test/quota/ai/consume").mock(
-            return_value=httpx.Response(401, json={"detail": "Invalid or expired session token"})
-        )
-        await check_ai_quota()  # should not raise
-
-
-@pytest.mark.asyncio
-async def test_quota_unexpected_status(monkeypatch):
-    """Other status codes → allow through."""
-    monkeypatch.setattr(settings, "gateway_token", "tok")
-    monkeypatch.setattr(gw_state, "_session_token", "sess")
-    monkeypatch.setattr(settings, "gateway_instance_id", "test-iid")
-    monkeypatch.setattr(settings, "gateway_http_url", "https://relay.test")
-
-    with respx.mock:
-        respx.post("https://relay.test/quota/ai/consume").mock(
-            return_value=httpx.Response(503, json={})
-        )
-        await check_ai_quota()  # should not raise
-
-
-@pytest.mark.asyncio
-async def test_quota_network_error(monkeypatch):
-    """Network error → allow through (don't block on relay outage)."""
-    monkeypatch.setattr(settings, "gateway_token", "tok")
-    monkeypatch.setattr(gw_state, "_session_token", "sess")
-    monkeypatch.setattr(settings, "gateway_instance_id", "test-iid")
-    monkeypatch.setattr(settings, "gateway_http_url", "https://relay.test")
-
-    with respx.mock:
-        respx.post("https://relay.test/quota/ai/consume").mock(
-            side_effect=httpx.ConnectError("connection refused")
-        )
-        await check_ai_quota()  # should not raise
-
-
-@pytest.mark.asyncio
-async def test_quota_credits_param_ignored(monkeypatch):
-    """credits parameter accepted but relay always consumes 1."""
-    monkeypatch.setattr(settings, "gateway_token", "tok")
-    monkeypatch.setattr(gw_state, "_session_token", "sess")
-    monkeypatch.setattr(settings, "gateway_instance_id", "test-iid")
-    monkeypatch.setattr(settings, "gateway_http_url", "https://relay.test")
-
-    with respx.mock:
-        route = respx.post("https://relay.test/quota/ai/consume").mock(
-            return_value=httpx.Response(200, json={"allowed": True})
-        )
-        await check_ai_quota(credits=5)
-        assert route.called
+        respx.get("https://relay.test/quota/ai/status").mock(side_effect=httpx.ConnectError("refused"))
+        assert await get_quota_status() is None
 
 
 # ── get_subscription_tier ─────────────────────────────────────────────────────
 
 @pytest.mark.asyncio
 async def test_get_subscription_tier_no_gateway(monkeypatch):
-    """No gateway → returns None."""
     monkeypatch.setattr(settings, "gateway_token", "")
     monkeypatch.setattr(gw_state, "_session_token", "")
-    result = await get_subscription_tier()
-    assert result is None
+    assert await get_subscription_tier() is None
 
 
 @pytest.mark.asyncio
 async def test_get_subscription_tier_returns_tier(monkeypatch):
-    """200 response → returns tier string."""
-    monkeypatch.setattr(settings, "gateway_token", "tok")
-    monkeypatch.setattr(gw_state, "_session_token", "sess")
-    monkeypatch.setattr(settings, "gateway_instance_id", "test-iid")
-    monkeypatch.setattr(settings, "gateway_http_url", "https://relay.test")
-
+    _configure(monkeypatch)
     with respx.mock:
         respx.get("https://relay.test/quota/ai/status").mock(
             return_value=httpx.Response(200, json={"tier": "cloud", "allowed": True, "used": 5, "limit": 100})
         )
-        result = await get_subscription_tier()
-    assert result == "cloud"
+        assert await get_subscription_tier() == "cloud"
 
 
 @pytest.mark.asyncio
 async def test_get_subscription_tier_network_error(monkeypatch):
-    """Network failure → returns None (never raises)."""
-    monkeypatch.setattr(settings, "gateway_token", "tok")
-    monkeypatch.setattr(gw_state, "_session_token", "sess")
-    monkeypatch.setattr(settings, "gateway_instance_id", "test-iid")
-    monkeypatch.setattr(settings, "gateway_http_url", "https://relay.test")
-
+    _configure(monkeypatch)
     with respx.mock:
-        respx.get("https://relay.test/quota/ai/status").mock(
-            side_effect=httpx.ConnectError("refused")
-        )
-        result = await get_subscription_tier()
-    assert result is None
+        respx.get("https://relay.test/quota/ai/status").mock(side_effect=httpx.ConnectError("refused"))
+        assert await get_subscription_tier() is None

--- a/default_modules/celerp-ai/tests/test_router.py
+++ b/default_modules/celerp-ai/tests/test_router.py
@@ -250,14 +250,13 @@ async def test_ai_tier_multi_file_allowed(auth_client):
 
     with patch("celerp_ai.routes.get_subscription_tier", AsyncMock(return_value="ai")):
         with patch("celerp_ai.routes.run_query", AsyncMock(return_value=mock_result)):
-            with patch("celerp_ai.routes.check_ai_quota", AsyncMock()):
-                with patch("celerp_ai.routes._load_file_http") as mock_load:
-                    mock_load.return_value = (b"fake image data", {"content_type": "image/jpeg", "filename": "test.jpg", "company_id": company_id_placeholder})
-                    r = await c.post(
-                        "/ai/query",
-                        json={"query": "process these", "file_ids": file_ids},
-                        headers=headers,
-                    )
+            with patch("celerp_ai.routes._load_file_http") as mock_load:
+                mock_load.return_value = (b"fake image data", {"content_type": "image/jpeg", "filename": "test.jpg", "company_id": company_id_placeholder})
+                r = await c.post(
+                    "/ai/query",
+                    json={"query": "process these", "file_ids": file_ids},
+                    headers=headers,
+                )
     assert r.status_code == 200
 
 

--- a/default_modules/celerp-ai/tests/test_service.py
+++ b/default_modules/celerp-ai/tests/test_service.py
@@ -73,64 +73,42 @@ def test_sanitize_error_generic():
     assert len(msg) > 0
 
 
-# -- _select_tools (async, LLM-driven) -------------------------------------
+# -- _select_tools (heuristic, no model call) ------------------------------
 
-@pytest.mark.asyncio
-async def test_select_tools_llm_picks_tools():
-    """LLM returns relevant tool names."""
-    with patch("celerp.ai.service.call_llm", new_callable=AsyncMock, return_value='["low_stock_items"]'):
-        tools = await _select_tools("show me low stock items")
+def test_select_tools_keyword_stock():
+    tools = _select_tools("show me low stock items")
     assert "low_stock_items" in tools
 
 
-@pytest.mark.asyncio
-async def test_select_tools_llm_multiple():
-    """LLM can return multiple tools (up to 4)."""
-    with patch("celerp.ai.service.call_llm", new_callable=AsyncMock, return_value='["outstanding_invoices", "low_stock_items", "dashboard_kpis"]'):
-        tools = await _select_tools("compare invoices and stock")
-    assert len(tools) == 3
+def test_select_tools_multiple_keywords():
+    tools = _select_tools("compare unpaid invoices and stock")
+    assert "outstanding_invoices" in tools
+    assert "low_stock_items" in tools
 
 
-@pytest.mark.asyncio
-async def test_select_tools_llm_failure_fallback():
-    """On LLM failure, falls back to dashboard_kpis."""
-    with patch("celerp.ai.service.call_llm", new_callable=AsyncMock, side_effect=RuntimeError("network error")):
-        tools = await _select_tools("anything")
-    assert "dashboard_kpis" in tools
+def test_select_tools_no_keyword_falls_back():
+    tools = _select_tools("good morning")
+    assert tools == ["dashboard_kpis"]
 
 
-@pytest.mark.asyncio
-async def test_select_tools_files_always_get_contacts_items():
-    """File queries always include contacts and items."""
-    with patch("celerp.ai.service.call_llm", new_callable=AsyncMock, return_value='["dashboard_kpis"]'):
-        tools = await _select_tools("process these receipts", has_files=True)
+def test_select_tools_files_always_get_contacts_items():
+    tools = _select_tools("process these receipts", has_files=True)
     assert "active_contacts_list" in tools
     assert "active_items_list" in tools
 
 
-@pytest.mark.asyncio
-async def test_select_tools_validates_names():
-    """Invalid tool names from LLM are filtered out."""
-    with patch("celerp.ai.service.call_llm", new_callable=AsyncMock, return_value='["fake_tool", "low_stock_items"]'):
-        tools = await _select_tools("inventory check")
-    assert "low_stock_items" in tools
-    assert "fake_tool" not in tools
-
-
-@pytest.mark.asyncio
-async def test_select_tools_max_four():
-    """Cap at 4 tools even if LLM returns more."""
-    with patch("celerp.ai.service.call_llm", new_callable=AsyncMock,
-               return_value='["dashboard_kpis", "low_stock_items", "outstanding_invoices", "top_items_by_value", "active_deals_summary"]'):
-        tools = await _select_tools("everything")
-    assert len(tools) <= 4
+def test_select_tools_max_four():
+    tools = _select_tools(
+        "low stock, unpaid invoices, deal pipeline, suppliers, dormant customers, valuable inventory"
+    )
+    assert len(tools) == 4
 
 
 # -- run_query --------------------------------------------------------------
 
 @pytest.mark.asyncio
 async def test_run_query_happy_path(session, company):
-    with patch("celerp.ai.service._select_tools", new_callable=AsyncMock, return_value=["dashboard_kpis"]):
+    with patch("celerp.ai.service._select_tools", return_value=["dashboard_kpis"]):
         with patch("celerp.ai.service.call_llm", new_callable=AsyncMock, return_value="You have 3 items."):
             result = await run_query("how many items", session, company.id)
 
@@ -141,7 +119,7 @@ async def test_run_query_happy_path(session, company):
 
 @pytest.mark.asyncio
 async def test_run_query_complex_model(session, company):
-    with patch("celerp.ai.service._select_tools", new_callable=AsyncMock, return_value=["dashboard_kpis"]):
+    with patch("celerp.ai.service._select_tools", return_value=["dashboard_kpis"]):
         with patch("celerp.ai.service.call_llm", new_callable=AsyncMock, return_value="Here's my analysis."):
             result = await run_query("analyse cash flow trends", session, company.id)
 
@@ -160,7 +138,7 @@ async def test_run_query_with_memory(session, company):
         captured_args["user_text"] = user_text
         return "Answer with memory."
 
-    with patch("celerp.ai.service._select_tools", new_callable=AsyncMock, return_value=["dashboard_kpis"]):
+    with patch("celerp.ai.service._select_tools", return_value=["dashboard_kpis"]):
         with patch("celerp.ai.service.call_llm", side_effect=mock_call_llm):
             result = await run_query("give me a business overview", session, company.id)
 
@@ -170,7 +148,7 @@ async def test_run_query_with_memory(session, company):
 
 @pytest.mark.asyncio
 async def test_run_query_api_error_captured(session, company):
-    with patch("celerp.ai.service._select_tools", new_callable=AsyncMock, return_value=["dashboard_kpis"]):
+    with patch("celerp.ai.service._select_tools", return_value=["dashboard_kpis"]):
         with patch("celerp.ai.service.call_llm", new_callable=AsyncMock, side_effect=RuntimeError("timeout")):
             result = await run_query("how many items", session, company.id)
 
@@ -181,7 +159,7 @@ async def test_run_query_api_error_captured(session, company):
 
 @pytest.mark.asyncio
 async def test_run_query_tool_failure_graceful(session, company):
-    with patch("celerp.ai.service._select_tools", new_callable=AsyncMock, return_value=["low_stock_items"]):
+    with patch("celerp.ai.service._select_tools", return_value=["low_stock_items"]):
         with patch("celerp.ai.service.execute_tool", new_callable=AsyncMock, side_effect=Exception("DB error")):
             with patch("celerp.ai.service.call_llm", new_callable=AsyncMock, return_value="Could not fetch data."):
                 result = await run_query("low stock items", session, company.id)
@@ -197,7 +175,7 @@ async def test_run_query_timeout(session, company):
         await asyncio.sleep(100)
         return "never"
 
-    with patch("celerp.ai.service._select_tools", new_callable=AsyncMock, return_value=["dashboard_kpis"]):
+    with patch("celerp.ai.service._select_tools", return_value=["dashboard_kpis"]):
         with patch("celerp.ai.service.call_llm", side_effect=slow_llm):
             # Override the timeout to something very short for testing
             with patch("celerp.ai.service.asyncio.wait_for", side_effect=asyncio.TimeoutError):
@@ -216,7 +194,7 @@ async def test_run_query_pending_bills(session, company):
         '"total": 100.0, "source_file_id": "f1", '
         '"line_items": [{"description": "Widget", "quantity": 2, "unit_price": 50.0}]}]}\n```'
     )
-    with patch("celerp.ai.service._select_tools", new_callable=AsyncMock, return_value=["dashboard_kpis"]):
+    with patch("celerp.ai.service._select_tools", return_value=["dashboard_kpis"]):
         with patch("celerp.ai.service.call_llm", new_callable=AsyncMock, return_value=llm_answer):
             result = await run_query("process receipt", session, company.id)
 
@@ -232,7 +210,7 @@ async def test_run_query_pending_bills(session, company):
 async def test_run_query_invalid_bill_json(session, company):
     """Invalid JSON in code block doesn't crash, pending_bills is None."""
     llm_answer = "Bills:\n```json\n{invalid json}\n```"
-    with patch("celerp.ai.service._select_tools", new_callable=AsyncMock, return_value=["dashboard_kpis"]):
+    with patch("celerp.ai.service._select_tools", return_value=["dashboard_kpis"]):
         with patch("celerp.ai.service.call_llm", new_callable=AsyncMock, return_value=llm_answer):
             result = await run_query("process receipts", session, company.id)
     assert result.error is None


### PR DESCRIPTION
Consolidates AI inference through the cloud gateway for model selection, usage metering, and simplified client configuration. Tool selection moves to a local keyword heuristic, eliminating a per-query model call for classification.

- `llm.py`: `call_llm` posts to the gateway; quota-exhausted surfaces as 402.
- Tool selection is now a local keyword heuristic, so a user query is a single served call (cheaper, simpler).
- `intent.py`: keyword-only (no model call).
- `quota.py`: keeps quota-status reads for display.
- `batch.py`: unchanged — per-file calls flow through the gateway.

Tests updated to match. (Full suite needs the Docker Postgres test env / CI.)