### PR TITLE
AI plan: app copy says 200 queries/month

### DIFF
--- a/ui/locales/ar.json
+++ b/ui/locales/ar.json
@@ -759,7 +759,7 @@
   "msg._web_access": "🌐 الوصول إلى الويب",
   "msg.accepted_formats_csv_utf8": "التنسيقات المقبولة: ‎.csv (UTF-8)",
   "msg.agentic_record_creation": "إنشاء سجل الوكيل",
-  "msg.ai_quota_exceeded": "لقد استخدمت جميع استعلامات {limit} المضمنة AI. الترقية إلى Cloud + AI مقابل 100 استفسار/الشهر.",
+  "msg.ai_quota_exceeded": "لقد استخدمت جميع استعلامات {limit} المضمنة AI. الترقية إلى Cloud + AI مقابل 200 استفسار/الشهر.",
   "msg.ai_subscription_required": "يلزم الاشتراك في Cloud + AI لاستخدام مساعد AI.",
   "msg.api_server_not_running": "تأكد من تشغيل خادم API قبل فتح واجهة المستخدم:",
   "msg.ask_anything_about_your_business_data": "اسأل أي شيء عن بيانات عملك...",

--- a/ui/locales/de.json
+++ b/ui/locales/de.json
@@ -759,7 +759,7 @@
   "msg._web_access": "🌐 Web-Zugang",
   "msg.accepted_formats_csv_utf8": "Akzeptierte Formate: .csv (UTF-8)",
   "msg.agentic_record_creation": "Autonome Datensatzerstellung",
-  "msg.ai_quota_exceeded": "Sie haben alle {limit} enthaltenen KI-Abfragen aufgebraucht. Upgraden Sie auf Cloud + KI für 100 Abfragen/Monat.",
+  "msg.ai_quota_exceeded": "Sie haben alle {limit} enthaltenen KI-Abfragen aufgebraucht. Upgraden Sie auf Cloud + KI für 200 Abfragen/Monat.",
   "msg.ai_subscription_required": "Cloud + KI-Abonnement erforderlich, um den KI-Assistenten zu nutzen.",
   "msg.api_server_not_running": "Stellen Sie sicher, dass der API-Server läuft, bevor Sie die Benutzeroberfläche öffnen:",
   "msg.ask_anything_about_your_business_data": "Stellen Sie beliebige Fragen zu Ihren Geschäftsdaten...",

--- a/ui/locales/en.json
+++ b/ui/locales/en.json
@@ -759,7 +759,7 @@
   "msg._web_access": "🌐 Web Access",
   "msg.accepted_formats_csv_utf8": "Accepted formats: .csv (UTF-8)",
   "msg.agentic_record_creation": "Agentic record creation",
-  "msg.ai_quota_exceeded": "You've used all {limit} included AI queries. Upgrade to AI + Connect for 100 queries/month.",
+  "msg.ai_quota_exceeded": "You've used all {limit} included AI queries. Upgrade to AI + Connect for 200 queries/month.",
   "msg.ai_subscription_required": "AI + Connect subscription required to use the AI assistant.",
   "msg.api_server_not_running": "Make sure the API server is running before opening the UI:",
   "msg.ask_anything_about_your_business_data": "Ask anything about your business data...",

--- a/ui/locales/es.json
+++ b/ui/locales/es.json
@@ -759,7 +759,7 @@
   "msg._web_access": "🌐 Acceso web",
   "msg.accepted_formats_csv_utf8": "Formatos aceptados: .csv (UTF-8)",
   "msg.agentic_record_creation": "Creación de registros agentes",
-  "msg.ai_quota_exceeded": "Ha utilizado todas las consultas {limit} incluidas AI. Actualice a Cloud + AI para 100 consultas/mes.",
+  "msg.ai_quota_exceeded": "Ha utilizado todas las consultas {limit} incluidas AI. Actualice a Cloud + AI para 200 consultas/mes.",
   "msg.ai_subscription_required": "Se requiere suscripción a Cloud + AI para utilizar el asistente AI.",
   "msg.api_server_not_running": "Asegúrese de que el servidor API esté ejecutándose antes de abrir la interfaz de usuario:",
   "msg.ask_anything_about_your_business_data": "Pregunta cualquier cosa sobre los datos de tu negocio...",

--- a/ui/locales/fr.json
+++ b/ui/locales/fr.json
@@ -759,7 +759,7 @@
   "msg._web_access": "🌐 Accès Web",
   "msg.accepted_formats_csv_utf8": "Formats acceptés : .csv (UTF-8)",
   "msg.agentic_record_creation": "Création d'enregistrements agent",
-  "msg.ai_quota_exceeded": "Vous avez utilisé toutes les requêtes {limit} incluses AI. Passez à Cloud + AI pour 100 requêtes/mois.",
+  "msg.ai_quota_exceeded": "Vous avez utilisé toutes les requêtes {limit} incluses AI. Passez à Cloud + AI pour 200 requêtes/mois.",
   "msg.ai_subscription_required": "Cloud + abonnement AI requis pour utiliser l'assistant AI.",
   "msg.api_server_not_running": "Assurez-vous que le serveur API est en cours d'exécution avant d'ouvrir l'interface utilisateur :",
   "msg.ask_anything_about_your_business_data": "Demandez n'importe quoi sur les données de votre entreprise...",

--- a/ui/locales/id.json
+++ b/ui/locales/id.json
@@ -759,7 +759,7 @@
   "msg._web_access": "🌐 Akses Web",
   "msg.accepted_formats_csv_utf8": "Format yang diterima: .csv (UTF-8)",
   "msg.agentic_record_creation": "Pembuatan catatan agenik",
-  "msg.ai_quota_exceeded": "Anda telah menggunakan semua {limit} termasuk AI kueri. Tingkatkan ke Cloud + AI untuk 100 kueri/bulan.",
+  "msg.ai_quota_exceeded": "Anda telah menggunakan semua {limit} termasuk AI kueri. Tingkatkan ke Cloud + AI untuk 200 kueri/bulan.",
   "msg.ai_subscription_required": "Langganan Cloud + AI diperlukan untuk menggunakan asisten AI.",
   "msg.api_server_not_running": "Pastikan server API berjalan sebelum membuka UI:",
   "msg.ask_anything_about_your_business_data": "Tanyakan apa pun tentang data bisnis Anda...",

--- a/ui/locales/it.json
+++ b/ui/locales/it.json
@@ -759,7 +759,7 @@
   "msg._web_access": "🌐 Accesso web",
   "msg.accepted_formats_csv_utf8": "Formati accettati: .csv (UTF-8)",
   "msg.agentic_record_creation": "Creazione record autonoma",
-  "msg.ai_quota_exceeded": "Hai usato tutte le {limit} query AI incluse. Passa a Cloud + AI per 100 query/mese.",
+  "msg.ai_quota_exceeded": "Hai usato tutte le {limit} query AI incluse. Passa a Cloud + AI per 200 query/mese.",
   "msg.ai_subscription_required": "Abbonamento Cloud + AI richiesto per utilizzare l'assistente AI.",
   "msg.api_server_not_running": "Assicurati che il server API sia in esecuzione prima di aprire l'interfaccia:",
   "msg.ask_anything_about_your_business_data": "Fai qualsiasi domanda sui tuoi dati aziendali...",

--- a/ui/locales/ja.json
+++ b/ui/locales/ja.json
@@ -759,7 +759,7 @@
   "msg._web_access": "🌐 ウェブアクセス",
   "msg.accepted_formats_csv_utf8": "受け入れられる形式: .csv (UTF-8)",
   "msg.agentic_record_creation": "エージェントレコードの作成",
-  "msg.ai_quota_exceeded": "{limit} に含まれる AI クエリをすべて使用しました。 100 クエリ/月の場合は Cloud + AI にアップグレードします。",
+  "msg.ai_quota_exceeded": "{limit} に含まれる AI クエリをすべて使用しました。 200 クエリ/月の場合は Cloud + AI にアップグレードします。",
   "msg.ai_subscription_required": "AI アシスタントを使用するには、Cloud + AI サブスクリプションが必要です。",
   "msg.api_server_not_running": "UI を開く前に、API サーバーが実行されていることを確認してください。",
   "msg.ask_anything_about_your_business_data": "ビジネスデータについて何でも質問してください...",

--- a/ui/locales/pt.json
+++ b/ui/locales/pt.json
@@ -759,7 +759,7 @@
   "msg._web_access": "🌐 Acesso à Web",
   "msg.accepted_formats_csv_utf8": "Formatos aceitos: .csv (UTF-8)",
   "msg.agentic_record_creation": "Criação de registro agente",
-  "msg.ai_quota_exceeded": "Você usou todas as consultas {limit} incluídas em AI. Atualize para Cloud + AI para 100 consultas/mês.",
+  "msg.ai_quota_exceeded": "Você usou todas as consultas {limit} incluídas em AI. Atualize para Cloud + AI para 200 consultas/mês.",
   "msg.ai_subscription_required": "Assinatura Cloud + AI necessária para usar o assistente AI.",
   "msg.api_server_not_running": "Certifique-se de que o servidor API esteja em execução antes de abrir a UI:",
   "msg.ask_anything_about_your_business_data": "Pergunte qualquer coisa sobre os dados da sua empresa...",

--- a/ui/locales/th.json
+++ b/ui/locales/th.json
@@ -759,7 +759,7 @@
   "msg._web_access": "🌐 การเข้าถึงเว็บ",
   "msg.accepted_formats_csv_utf8": "รูปแบบที่ยอมรับ: .csv (UTF-8)",
   "msg.agentic_record_creation": "การสร้างบันทึกตัวแทน",
-  "msg.ai_quota_exceeded": "คุณได้ใช้ {limit} รวมคำค้นหา AI ทั้งหมดแล้ว อัปเกรดเป็น Cloud + AI สำหรับการสืบค้น 100 ครั้ง/เดือน",
+  "msg.ai_quota_exceeded": "คุณได้ใช้ {limit} รวมคำค้นหา AI ทั้งหมดแล้ว อัปเกรดเป็น Cloud + AI สำหรับการสืบค้น 200 ครั้ง/เดือน",
   "msg.ai_subscription_required": "ต้องสมัครสมาชิก Cloud + AI เพื่อใช้ผู้ช่วย AI",
   "msg.api_server_not_running": "ตรวจสอบให้แน่ใจว่าเซิร์ฟเวอร์ API ทำงานก่อนที่จะเปิด UI:",
   "msg.ask_anything_about_your_business_data": "ถามอะไรก็ได้เกี่ยวกับข้อมูลธุรกิจของคุณ...",

--- a/ui/locales/vi.json
+++ b/ui/locales/vi.json
@@ -759,7 +759,7 @@
   "msg._web_access": "🌐 Truy cập web",
   "msg.accepted_formats_csv_utf8": "Các định dạng được chấp nhận: .csv (UTF-8)",
   "msg.agentic_record_creation": "Tạo bản ghi đại lý",
-  "msg.ai_quota_exceeded": "Bạn đã sử dụng tất cả các truy vấn {limit} được bao gồm AI. Nâng cấp lên Cloud + AI cho 100 truy vấn/tháng.",
+  "msg.ai_quota_exceeded": "Bạn đã sử dụng tất cả các truy vấn {limit} được bao gồm AI. Nâng cấp lên Cloud + AI cho 200 truy vấn/tháng.",
   "msg.ai_subscription_required": "Cần đăng ký Cloud + AI để sử dụng trợ lý AI.",
   "msg.api_server_not_running": "Đảm bảo máy chủ API đang chạy trước khi mở giao diện người dùng:",
   "msg.ask_anything_about_your_business_data": "Hỏi bất cứ điều gì về dữ liệu kinh doanh của bạn...",

--- a/ui/routes/settings.py
+++ b/ui/routes/settings.py
@@ -4015,7 +4015,7 @@ def _ai_tab() -> FT:
                 "AI Assistant",
                 "Ask your ERP questions in plain English - inventory analysis, AR summaries, "
                 "CRM insights. Connect (USD $29/mo) includes 100 free queries to try it. "
-                "AI + Connect (USD $49/mo) gives 100 queries every month.",
+                "AI + Connect (USD $49/mo) gives 200 queries every month.",
                 price="USD $29/mo",
                 anchor="cloud",
             ),


### PR DESCRIPTION
The quota-exceeded upsell (11 locales) and the settings page still cited **100**/mo for the Cloud+AI tier. Aligns them to **200**, matching the AI-showcase card and the tier itself.