### PR TITLE
feat(stars): install-side GitHub-star CTA foundation

### DIFF
--- a/.github/workflows/founder-label.yml
+++ b/.github/workflows/founder-label.yml
@@ -1,0 +1,31 @@
+name: Founder label
+
+# Recognise verified founding supporters when they open an issue. Uses the
+# ephemeral, repo-scoped GITHUB_TOKEN (no GitHub App, no permission change to the
+# CLA app — see the stars plan §0.14) and the relay's read-only founder lookup.
+
+on:
+  issues:
+    types: [opened, reopened]
+
+permissions:
+  issues: write
+
+jobs:
+  label-founder:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Label founding supporters
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          AUTHOR: ${{ github.event.issue.user.login }}
+          ISSUE: ${{ github.event.issue.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          status="$(curl -fsS "https://relay.celerp.com/github/founder-status?login=${AUTHOR}" || echo '{}')"
+          if [ "$(echo "$status" | jq -r '.founder // false')" = "true" ]; then
+            gh label create founding-supporter --repo "$REPO" --color d4af37 \
+              --description "Verified founding supporter of Celerp" --force || true
+            gh issue edit "$ISSUE" --repo "$REPO" --add-label founding-supporter
+          fi

--- a/celerp/cli.py
+++ b/celerp/cli.py
@@ -544,6 +544,15 @@ def init(db_url, api_port, ui_port, cloud_token, force):
   UI:     http://localhost:{ui_port_val}
   Modules: none — choose an industry preset in the setup wizard
 """)
+
+    from celerp.config import settings as _settings
+    from celerp.gateway.state import build_handoff_url as _handoff
+    if _settings.star_cta_enabled:
+        click.echo(
+            "New and open source - founding supporters are how other teams find us.\n"
+            f"  Back us early: {_handoff('/github', medium='cli')}\n"
+        )
+
     _start(cfg)
 
 

--- a/celerp/config.py
+++ b/celerp/config.py
@@ -91,6 +91,12 @@ class Settings(BaseSettings):
     api_workers: int = 2
     gui_workers: int = 1
 
+    # GitHub-star CTA. The relay (celerp.com) is the single source of the count,
+    # tier ladder, and copy; the install only renders the relay's resolved CTA and
+    # falls back to a static neutral link when the relay is unreachable.
+    star_cta_enabled: bool = True       # local kill switch
+    star_cta_cache_ttl_s: int = 3600    # how long to cache the relay-resolved CTA
+
 
 settings = Settings()
 

--- a/celerp/gateway/state.py
+++ b/celerp/gateway/state.py
@@ -93,24 +93,33 @@ def relay_session_headers() -> dict[str, str]:
     }
 
 
-SUBSCRIBE_UTM = "utm_source=app&utm_medium=inapp"
+HANDOFF_BASE = "https://celerp.com"
+
+
+def build_handoff_url(path: str, *, medium: str = "inapp", lead: str = "", extra: str = "", anchor: str = "") -> str:
+    """Single source of truth for celerp.com handoff links (subscribe, github, ...).
+
+    Keeps the format identical everywhere: an optional ``lead`` param first (e.g.
+    ``instance_id=...``, so attribution tags never bury it), then the UTM tags
+    (``utm_source=app`` + the caller's ``medium``), then any ``extra`` params, then
+    an optional ``#anchor``.
+    """
+    params = ([lead] if lead else []) + [f"utm_source=app&utm_medium={medium}"]
+    if extra:
+        params.append(extra.lstrip("?&"))
+    url = f"{HANDOFF_BASE}{path}?{'&'.join(params)}"
+    return f"{url}#{anchor}" if anchor else url
 
 
 def build_subscribe_url(instance_id: str = "", anchor: str = "", *, topup: bool = False, extra: str = "") -> str:
-    """Single source of truth for the in-app celerp.com/subscribe handoff URL.
+    """In-app celerp.com/subscribe handoff URL. Thin caller of build_handoff_url.
 
-    Keeps the format identical everywhere: instance_id first (so attribution tags never
-    bury it and the link stays easy to assert on), then UTM tags, then any caller
-    ``extra`` query params, then an optional ``#anchor``. ``topup=True`` selects the
-    /subscribe/topup variant. Callers resolve the instance id however they need (the
-    gateway id, ``ensure_instance_id()``, or a value from a payload).
+    ``topup=True`` selects the /subscribe/topup variant. Callers resolve the instance
+    id however they need (the gateway id, ``ensure_instance_id()``, or a payload value).
     """
-    base = "https://celerp.com/subscribe/topup" if topup else "https://celerp.com/subscribe"
-    params = ([f"instance_id={instance_id}"] if instance_id else []) + [SUBSCRIBE_UTM]
-    if extra:
-        params.append(extra.lstrip("?&"))
-    url = f"{base}?{'&'.join(params)}"
-    return f"{url}#{anchor}" if anchor else url
+    path = "/subscribe/topup" if topup else "/subscribe"
+    lead = f"instance_id={instance_id}" if instance_id else ""
+    return build_handoff_url(path, medium="inapp", lead=lead, extra=extra, anchor=anchor)
 
 
 def relay_subscribe_url(anchor: str = "") -> str:

--- a/celerp/main.py
+++ b/celerp/main.py
@@ -25,6 +25,7 @@ from fastapi.staticfiles import StaticFiles
 
 from celerp.routers import auth, companies, ledger
 from celerp.routers import health, notifications, system, events as events_router_mod
+from celerp.routers import stars as stars_router_mod
 
 import celerp.models  # noqa: F401 - ensures kernel models (UserCompany, ImportBatch, DocShareToken) are registered
 
@@ -309,6 +310,7 @@ app.include_router(auth.router, prefix="/auth", tags=["auth"])
 app.include_router(ledger.router, prefix="/ledger", tags=["ledger"])
 app.include_router(companies.router, prefix="/companies", tags=["companies"])
 app.include_router(system.router, prefix="/system", tags=["system"])
+app.include_router(stars_router_mod.router, prefix="/stars", tags=["stars"])
 app.include_router(notifications.router)
 app.include_router(events_router_mod.router)
 

--- a/celerp/migrations/versions/b1c2d3e4f5a6_add_supporter_badges.py
+++ b/celerp/migrations/versions/b1c2d3e4f5a6_add_supporter_badges.py
@@ -1,0 +1,31 @@
+"""add supporter_badges
+
+Revision ID: b1c2d3e4f5a6
+Revises: a0b1c2d3e4f5
+Create Date: 2026-06-23
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = "b1c2d3e4f5a6"
+down_revision = "a0b1c2d3e4f5"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "supporter_badges",
+        sa.Column("user_id", sa.Uuid(), nullable=False),
+        sa.Column("github_login", sa.String(length=255), nullable=False),
+        sa.Column("tier", sa.String(length=32), nullable=False),
+        sa.Column("ordinal", sa.Integer(), nullable=False),
+        sa.Column("credential", sa.Text(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.text("now()")),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("user_id"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("supporter_badges")

--- a/celerp/models/__init__.py
+++ b/celerp/models/__init__.py
@@ -8,3 +8,4 @@ from celerp.models.import_batch import ImportBatch  # noqa: F401 - ensure import
 from celerp.models.notification import Notification  # noqa: F401
 from celerp.models.share import DocShareToken  # noqa: F401 - ensure doc_share_tokens table registered
 from celerp.models.sync_run import SyncRun  # noqa: F401 - ensure sync_runs table registered
+from celerp.models.supporter import SupporterBadge  # noqa: F401 - ensure supporter_badges table registered

--- a/celerp/models/supporter.py
+++ b/celerp/models/supporter.py
@@ -1,0 +1,35 @@
+# Copyright (c) 2026 Noah Severs
+# SPDX-License-Identifier: BUSL-1.1
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import DateTime, ForeignKey, Integer, String, Text, func
+from sqlalchemy.orm import Mapped, mapped_column
+
+from celerp.models.base import Base
+
+
+class SupporterBadge(Base):
+    """A GitHub-star supporter badge claimed by an app user.
+
+    The relay's founders registry is authoritative for anything public (the wall,
+    the issue-label bot, support standing); this is the LOCAL copy used only to
+    render the badge next to the user's name. One badge per user (the claimer).
+    The stored `credential` (the relay-issued HS256 JWT) is kept so the user can
+    opt out later via the relay.
+    """
+
+    __tablename__ = "supporter_badges"
+
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("users.id", ondelete="CASCADE"), primary_key=True
+    )
+    github_login: Mapped[str] = mapped_column(String(255), nullable=False)
+    tier: Mapped[str] = mapped_column(String(32), nullable=False)  # founding | early | supporter
+    ordinal: Mapped[int] = mapped_column(Integer, nullable=False)
+    credential: Mapped[str] = mapped_column(Text, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )

--- a/celerp/routers/stars.py
+++ b/celerp/routers/stars.py
@@ -1,0 +1,45 @@
+# Copyright (c) 2026 Noah Severs
+# SPDX-License-Identifier: BUSL-1.1
+
+"""GitHub-star CTA endpoints.
+
+``GET /stars/cta`` is readable by any authenticated user (the footer shows it to
+everyone). ``POST /stars/dismiss`` is admin-only and install-level (one ask for the
+whole install), so it lives here rather than under the admin-gated /system router.
+"""
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from celerp.config import settings
+from celerp.db import get_session
+from celerp.services.auth import get_current_company_id, require_admin
+from celerp.services.runtime_state import dismiss_star_prompt, star_prompt_dismissed
+from celerp.services.star_cta import get_star_cta, neutral_cta
+
+router = APIRouter()
+
+
+@router.get("/cta")
+async def star_cta(
+    medium: str = "footer",
+    _company=Depends(get_current_company_id),
+    session: AsyncSession = Depends(get_session),
+) -> dict:
+    """Return the relay-resolved CTA for ``medium`` (or the neutral link if the relay
+    is unreachable), plus the install-level dismissed flag. ``{}`` when disabled."""
+    if not settings.star_cta_enabled:
+        return {}
+    cta = await get_star_cta(medium) or neutral_cta(medium)
+    return {**cta, "dismissed": await star_prompt_dismissed(session)}
+
+
+@router.post("/dismiss")
+async def dismiss(
+    _=Depends(require_admin),
+    session: AsyncSession = Depends(get_session),
+) -> dict:
+    """Dismiss the GitHub-star ask for the whole install (onboarding/milestone cards)."""
+    await dismiss_star_prompt(session)
+    return {"dismissed": True}

--- a/celerp/routers/stars.py
+++ b/celerp/routers/stars.py
@@ -12,9 +12,11 @@ from __future__ import annotations
 from fastapi import APIRouter, Depends
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from celerp.config import settings
+from celerp.config import ensure_instance_id, settings
 from celerp.db import get_session
-from celerp.services.auth import get_current_company_id, require_admin
+from celerp.gateway.state import relay_http_url
+from celerp.services import supporter_badge as _badge
+from celerp.services.auth import get_current_company_id, get_current_user, require_admin
 from celerp.services.runtime_state import dismiss_star_prompt, star_prompt_dismissed
 from celerp.services.star_cta import get_star_cta, neutral_cta
 
@@ -43,3 +45,53 @@ async def dismiss(
     """Dismiss the GitHub-star ask for the whole install (onboarding/milestone cards)."""
     await dismiss_star_prompt(session)
     return {"dismissed": True}
+
+
+# ── Supporter badge (claim via the relay verify flow, then store locally) ─────
+
+
+@router.get("/badge/verify-url")
+async def badge_verify_url(return_url: str, _user=Depends(get_current_user)) -> dict:
+    """The relay verify-start URL to open in the browser. ``return_url`` is where the
+    relay redirects back with the credential (the install's own page)."""
+    from urllib.parse import urlencode
+
+    iid = ensure_instance_id()
+    q = urlencode({"instance_id": iid, "return_url": return_url})
+    return {"url": f"{relay_http_url()}/github/verify/start?{q}"}
+
+
+@router.get("/badge")
+async def get_badge(
+    user=Depends(get_current_user),
+    session: AsyncSession = Depends(get_session),
+) -> dict:
+    """The current user's supporter badge, or null."""
+    return {"badge": _badge.to_dict(await _badge.get(session, user.id))}
+
+
+@router.post("/badge")
+async def claim_badge(
+    payload: dict,
+    user=Depends(get_current_user),
+    session: AsyncSession = Depends(get_session),
+) -> dict:
+    """Store the current user's badge from a relay-issued credential."""
+    cred = (payload or {}).get("cred", "")
+    if not cred:
+        return {"error": "Missing credential."}
+    try:
+        badge = await _badge.claim(session, user.id, cred)
+    except ValueError:
+        return {"error": "Invalid credential."}
+    return {"badge": _badge.to_dict(badge)}
+
+
+@router.delete("/badge")
+async def delete_badge(
+    user=Depends(get_current_user),
+    session: AsyncSession = Depends(get_session),
+) -> dict:
+    """Remove the badge and opt out of the relay founders wall (undo)."""
+    await _badge.remove(session, user.id)
+    return {"removed": True}

--- a/celerp/services/runtime_state.py
+++ b/celerp/services/runtime_state.py
@@ -106,3 +106,22 @@ async def set_draining(session: AsyncSession, draining: bool) -> None:
         row.value = {**current, "draining": False, "drain_since": None}
     await session.commit()
     _drain_cache_bust()  # bust so next is_draining call reads fresh state
+
+
+# ---------------------------------------------------------------------------
+# Star-CTA dismissal (install-level: one ask for the whole install)
+# ---------------------------------------------------------------------------
+
+async def star_prompt_dismissed(session: AsyncSession) -> bool:
+    """Return True if the GitHub-star ask has been dismissed for this install."""
+    state = await get_runtime_state(session)
+    return bool(state.get("star_prompt_dismissed", False))
+
+
+async def dismiss_star_prompt(session: AsyncSession) -> None:
+    """Mark the GitHub-star ask dismissed so the onboarding/milestone cards stop."""
+    row = await _get_or_create(session)
+    current = dict(row.value) if row.value else {}
+    row.value = {**current, "star_prompt_dismissed": True}
+    await session.commit()
+    _drain_cache_bust()  # this row's cache is shared with the drain flag

--- a/celerp/services/star_cta.py
+++ b/celerp/services/star_cta.py
@@ -1,0 +1,85 @@
+# Copyright (c) 2026 Noah Severs
+# SPDX-License-Identifier: BUSL-1.1
+"""GitHub-star CTA client.
+
+The relay (celerp.com) is the single source of truth for the star count, the tier
+ladder, and the CTA copy. This module only fetches the relay's already-resolved CTA
+for a given surface (``medium``) and caches it. It never calls GitHub and never
+computes tiers or copy.
+
+Determinism: on any relay failure ``get_star_cta`` returns ``None``. Callers render
+the static neutral link in that case (``neutral_cta``); they must never fabricate a
+count or a tier.
+"""
+from __future__ import annotations
+
+import time
+
+import httpx
+
+from celerp.config import settings
+from celerp.gateway.state import build_handoff_url, relay_http_url
+
+# Cache keyed by medium: medium -> (fetched_at_monotonic, cta_dict)
+_cache: dict[str, tuple[float, dict]] = {}
+
+
+def _cache_get(medium: str) -> dict | None:
+    entry = _cache.get(medium)
+    if entry is None:
+        return None
+    fetched_at, value = entry
+    if time.monotonic() - fetched_at > settings.star_cta_cache_ttl_s:
+        _cache.pop(medium, None)
+        return None
+    return value
+
+
+def _cache_set(medium: str, value: dict) -> None:
+    _cache[medium] = (time.monotonic(), value)
+
+
+def cache_bust() -> None:
+    """Drop all cached CTAs (used on config change and in tests)."""
+    _cache.clear()
+
+
+def neutral_cta(medium: str) -> dict:
+    """The static, relay-independent CTA: just the link, no count, no tier.
+
+    This is the deterministic offline state - shown when the relay is unreachable.
+    """
+    return {
+        "mode": "neutral",
+        "show_count": False,
+        "count": None,
+        "cta_label": "Star on GitHub",
+        "url": build_handoff_url("/github", medium=medium),
+    }
+
+
+async def get_star_cta(medium: str) -> dict | None:
+    """Return the relay-resolved CTA for ``medium``, or ``None`` if unavailable.
+
+    ``None`` means "relay unreachable / no data" - the caller renders neutral_cta.
+    Returns ``None`` (not neutral) so the caller decides how to degrade.
+    """
+    if not settings.star_cta_enabled:
+        return None
+
+    cached = _cache_get(medium)
+    if cached is not None:
+        return cached
+
+    base = relay_http_url()
+    try:
+        async with httpx.AsyncClient(timeout=3.0) as c:
+            r = await c.get(f"{base}/github/cta", params={"medium": medium})
+        if r.status_code != 200:
+            return None
+        data = r.json()
+    except Exception:
+        return None
+
+    _cache_set(medium, data)
+    return data

--- a/celerp/services/supporter_badge.py
+++ b/celerp/services/supporter_badge.py
@@ -1,0 +1,88 @@
+# Copyright (c) 2026 Noah Severs
+# SPDX-License-Identifier: BUSL-1.1
+"""Supporter badge: claim (from a relay credential), read, and remove (opt-out).
+
+The relay's founders registry is authoritative for anything public; this stores a
+local copy used only to render the badge next to the user's name. Per the trust
+model (relay spec §0.4) the install decodes the credential's claims for display and
+does NOT cryptographically validate it - forging a local badge only affects the
+forger's own self-hosted instance.
+"""
+from __future__ import annotations
+
+import uuid
+
+import httpx
+from jose import JWTError, jwt
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from celerp.gateway.state import relay_http_url
+from celerp.models.supporter import SupporterBadge
+
+
+def _claims(cred: str) -> dict:
+    """Decode (unverified) the relay credential's claims. Raises ValueError if it is
+    not a well-formed supporter credential."""
+    try:
+        c = jwt.get_unverified_claims(cred)
+    except JWTError as exc:
+        raise ValueError("malformed credential") from exc
+    if c.get("typ") != "supporter_cred" or "login" not in c or "ordinal" not in c:
+        raise ValueError("not a supporter credential")
+    return c
+
+
+def label_for(tier: str, ordinal: int) -> str:
+    if tier == "founding":
+        return f"Founding Supporter #{ordinal}"
+    if tier == "early":
+        return "Early Supporter"
+    return "Supporter"
+
+
+async def claim(session: AsyncSession, user_id: uuid.UUID, cred: str) -> SupporterBadge:
+    """Store or refresh the current user's badge from a relay credential."""
+    c = _claims(cred)
+    badge = await session.get(SupporterBadge, user_id)
+    if badge is None:
+        badge = SupporterBadge(user_id=user_id)
+        session.add(badge)
+    badge.github_login = str(c["login"])
+    badge.tier = str(c.get("tier", "supporter"))
+    badge.ordinal = int(c["ordinal"])
+    badge.credential = cred
+    await session.commit()
+    return badge
+
+
+async def get(session: AsyncSession, user_id: uuid.UUID) -> SupporterBadge | None:
+    return await session.get(SupporterBadge, user_id)
+
+
+async def remove(session: AsyncSession, user_id: uuid.UUID) -> None:
+    """Remove the local badge and best-effort opt out on the relay (undo)."""
+    badge = await session.get(SupporterBadge, user_id)
+    if badge is None:
+        return
+    cred = badge.credential
+    await session.delete(badge)
+    await session.commit()
+    # Best-effort relay opt-out; a relay failure must not block local removal.
+    try:
+        async with httpx.AsyncClient(timeout=5.0) as client:
+            await client.request(
+                "DELETE", f"{relay_http_url()}/github/founder", params={"cred": cred}
+            )
+    except Exception:
+        pass
+
+
+def to_dict(badge: SupporterBadge | None) -> dict | None:
+    if badge is None:
+        return None
+    return {
+        "github_login": badge.github_login,
+        "tier": badge.tier,
+        "ordinal": badge.ordinal,
+        "label": label_for(badge.tier, badge.ordinal),
+    }

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -72,6 +72,31 @@ def test_init_defaults(tmp_config):
     assert len(cfg["auth"]["jwt_secret"]) == 64  # secrets.token_hex(32)
 
 
+def test_init_shows_star_cta_line(tmp_config):
+    runner = CliRunner()
+    with patch(_INIT_PATCHES["test_db"], return_value=None), \
+         patch(_INIT_PATCHES["run_migrations"]), \
+         patch(_INIT_PATCHES["post_grants"]), \
+         patch(_INIT_PATCHES["start"]):
+        result = runner.invoke(main, ["init"])
+    assert result.exit_code == 0, result.output
+    assert "Back us early" in result.output
+    assert "celerp.com/github" in result.output
+
+
+def test_init_omits_star_cta_line_when_disabled(tmp_config, monkeypatch):
+    from celerp.config import settings
+    monkeypatch.setattr(settings, "star_cta_enabled", False)
+    runner = CliRunner()
+    with patch(_INIT_PATCHES["test_db"], return_value=None), \
+         patch(_INIT_PATCHES["run_migrations"]), \
+         patch(_INIT_PATCHES["post_grants"]), \
+         patch(_INIT_PATCHES["start"]):
+        result = runner.invoke(main, ["init"])
+    assert result.exit_code == 0, result.output
+    assert "Back us early" not in result.output
+
+
 def test_init_custom_flags(tmp_config):
     runner = CliRunner()
     with patch(_INIT_PATCHES["test_db"], return_value=None), \

--- a/tests/test_gateway/test_state.py
+++ b/tests/test_gateway/test_state.py
@@ -1,0 +1,41 @@
+# Copyright (c) 2026 Noah Severs
+# SPDX-License-Identifier: LicenseRef-Proprietary
+"""Unit tests for celerp.gateway.state URL builders."""
+
+from __future__ import annotations
+
+from celerp.gateway.state import build_handoff_url, build_subscribe_url
+
+
+# ── build_handoff_url ─────────────────────────────────────────────────────────
+
+def test_handoff_basic_medium():
+    assert build_handoff_url("/github", medium="cli") == \
+        "https://celerp.com/github?utm_source=app&utm_medium=cli"
+
+
+def test_handoff_default_medium():
+    assert build_handoff_url("/github") == \
+        "https://celerp.com/github?utm_source=app&utm_medium=inapp"
+
+
+def test_handoff_lead_extra_anchor():
+    url = build_handoff_url("/x", medium="m", lead="id=1", extra="?a=b", anchor="sec")
+    assert url == "https://celerp.com/x?id=1&utm_source=app&utm_medium=m&a=b#sec"
+
+
+# ── build_subscribe_url (behavior preserved by the DRY refactor) ───────────────
+
+def test_subscribe_plain():
+    assert build_subscribe_url() == \
+        "https://celerp.com/subscribe?utm_source=app&utm_medium=inapp"
+
+
+def test_subscribe_with_instance():
+    assert build_subscribe_url("iid") == \
+        "https://celerp.com/subscribe?instance_id=iid&utm_source=app&utm_medium=inapp"
+
+
+def test_subscribe_topup_anchor_extra():
+    assert build_subscribe_url("iid", "go", topup=True, extra="?p=1") == \
+        "https://celerp.com/subscribe/topup?instance_id=iid&utm_source=app&utm_medium=inapp&p=1#go"

--- a/tests/test_routers/test_stars.py
+++ b/tests/test_routers/test_stars.py
@@ -1,0 +1,76 @@
+# Copyright (c) 2026 Noah Severs
+# SPDX-License-Identifier: LicenseRef-Proprietary
+"""Unit tests for the /stars CTA endpoints. The relay client is mocked."""
+
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from celerp.config import settings
+
+
+async def _register(client, suffix: str = "") -> str:
+    addr = f"stars-{suffix or uuid.uuid4().hex[:8]}@test.local"
+    r = await client.post(
+        "/auth/register",
+        json={"company_name": "StarCo", "email": addr, "name": "Admin", "password": "pw"},
+    )
+    assert r.status_code == 200
+    return r.json()["access_token"]
+
+
+def _h(token: str) -> dict:
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.mark.asyncio
+async def test_cta_returns_relay_payload(client):
+    token = await _register(client, "cta")
+    cta = {"mode": "founding", "cta_label": "Star on GitHub",
+           "url": "https://celerp.com/github?utm_source=app&utm_medium=footer"}
+    with patch("celerp.routers.stars.get_star_cta", new=AsyncMock(return_value=cta)):
+        r = await client.get("/stars/cta", headers=_h(token))
+    assert r.status_code == 200
+    data = r.json()
+    assert data["mode"] == "founding"
+    assert data["dismissed"] is False
+
+
+@pytest.mark.asyncio
+async def test_cta_neutral_when_relay_unavailable(client):
+    token = await _register(client, "neutral")
+    with patch("celerp.routers.stars.get_star_cta", new=AsyncMock(return_value=None)):
+        r = await client.get("/stars/cta", headers=_h(token), params={"medium": "footer"})
+    assert r.status_code == 200
+    data = r.json()
+    assert data["mode"] == "neutral"
+    assert "/github" in data["url"]
+
+
+@pytest.mark.asyncio
+async def test_cta_empty_when_disabled(client, monkeypatch):
+    token = await _register(client, "disabled")
+    monkeypatch.setattr(settings, "star_cta_enabled", False)
+    r = await client.get("/stars/cta", headers=_h(token))
+    assert r.status_code == 200
+    assert r.json() == {}
+
+
+@pytest.mark.asyncio
+async def test_dismiss_then_cta_shows_dismissed(client):
+    token = await _register(client, "dismiss")
+    rd = await client.post("/stars/dismiss", headers=_h(token))
+    assert rd.status_code == 200
+    assert rd.json()["dismissed"] is True
+    with patch("celerp.routers.stars.get_star_cta", new=AsyncMock(return_value=None)):
+        r = await client.get("/stars/cta", headers=_h(token))
+    assert r.json()["dismissed"] is True
+
+
+@pytest.mark.asyncio
+async def test_cta_requires_auth(client):
+    r = await client.get("/stars/cta")
+    assert r.status_code == 401

--- a/tests/test_routers/test_supporter_badge.py
+++ b/tests/test_routers/test_supporter_badge.py
@@ -1,0 +1,100 @@
+# Copyright (c) 2026 Noah Severs
+# SPDX-License-Identifier: LicenseRef-Proprietary
+"""Unit tests for the /stars/badge endpoints (claim/get/delete + verify-url).
+
+The relay credential is decoded unverified (local-display trust model), so any
+HS256 key signs a valid test credential.
+"""
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from jose import jwt
+
+
+async def _register(client, suffix: str = "") -> str:
+    addr = f"badge-{suffix or uuid.uuid4().hex[:8]}@test.local"
+    r = await client.post(
+        "/auth/register",
+        json={"company_name": "BadgeCo", "email": addr, "name": "Admin", "password": "pw"},
+    )
+    assert r.status_code == 200
+    return r.json()["access_token"]
+
+
+def _h(token: str) -> dict:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _cred(uid: int = 42, login: str = "alice", tier: str = "founding", ordinal: int = 8) -> str:
+    return jwt.encode(
+        {"typ": "supporter_cred", "uid": uid, "login": login, "tier": tier, "ordinal": ordinal},
+        "any-key", algorithm="HS256",
+    )
+
+
+@pytest.mark.asyncio
+async def test_claim_then_get(client):
+    token = await _register(client, "claim")
+    r = await client.post("/stars/badge", headers=_h(token), json={"cred": _cred()})
+    assert r.status_code == 200
+    badge = r.json()["badge"]
+    assert badge["tier"] == "founding" and badge["ordinal"] == 8
+    assert badge["label"] == "Founding Supporter #8"
+    assert badge["github_login"] == "alice"
+
+    g = await client.get("/stars/badge", headers=_h(token))
+    assert g.json()["badge"]["ordinal"] == 8
+
+
+@pytest.mark.asyncio
+async def test_get_badge_null_when_none(client):
+    token = await _register(client, "none")
+    assert (await client.get("/stars/badge", headers=_h(token))).json()["badge"] is None
+
+
+@pytest.mark.asyncio
+async def test_claim_invalid_cred(client):
+    token = await _register(client, "bad")
+    r = await client.post("/stars/badge", headers=_h(token), json={"cred": "garbage"})
+    assert "error" in r.json()
+    r2 = await client.post("/stars/badge", headers=_h(token), json={})
+    assert "error" in r2.json()
+
+
+@pytest.mark.asyncio
+async def test_claim_wrong_token_type_rejected(client):
+    token = await _register(client, "wrongtyp")
+    not_a_cred = jwt.encode({"typ": "stars_state", "login": "x", "ordinal": 1}, "k", algorithm="HS256")
+    assert "error" in (await client.post("/stars/badge", headers=_h(token), json={"cred": not_a_cred})).json()
+
+
+@pytest.mark.asyncio
+async def test_delete_badge_opts_out(client):
+    token = await _register(client, "del")
+    await client.post("/stars/badge", headers=_h(token), json={"cred": _cred()})
+    # Mock the relay opt-out call so the delete stays offline.
+    with patch("celerp.services.supporter_badge.httpx.AsyncClient") as mock_httpx:
+        mock_httpx.return_value.__aenter__.return_value.request = AsyncMock(return_value=MagicMock())
+        d = await client.delete("/stars/badge", headers=_h(token))
+    assert d.status_code == 200 and d.json()["removed"] is True
+    assert (await client.get("/stars/badge", headers=_h(token))).json()["badge"] is None
+
+
+@pytest.mark.asyncio
+async def test_verify_url_includes_instance_and_return(client):
+    token = await _register(client, "vurl")
+    r = await client.get("/stars/badge/verify-url", headers=_h(token),
+                         params={"return_url": "http://localhost:8080/stars/claim"})
+    assert r.status_code == 200
+    url = r.json()["url"]
+    assert "/github/verify/start?" in url
+    assert "instance_id=" in url
+    assert "return_url=http" in url and "stars" in url
+
+
+@pytest.mark.asyncio
+async def test_badge_requires_auth(client):
+    assert (await client.get("/stars/badge")).status_code == 401

--- a/tests/test_services/test_star_cta.py
+++ b/tests/test_services/test_star_cta.py
@@ -1,0 +1,102 @@
+# Copyright (c) 2026 Noah Severs
+# SPDX-License-Identifier: LicenseRef-Proprietary
+"""Unit tests for the GitHub-star CTA client (celerp.services.star_cta).
+
+The relay is fully mocked, so no network call is made.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from celerp.config import settings
+from celerp.services import star_cta
+
+
+@pytest.fixture(autouse=True)
+def _bust_cta_cache():
+    star_cta.cache_bust()
+    yield
+    star_cta.cache_bust()
+
+
+def _resp(status: int = 200, payload: dict | None = None) -> MagicMock:
+    r = MagicMock()
+    r.status_code = status
+    r.json.return_value = payload or {}
+    return r
+
+
+@pytest.mark.asyncio
+async def test_returns_relay_cta(monkeypatch):
+    monkeypatch.setattr(settings, "star_cta_enabled", True)
+    cta = {"mode": "founding", "cta_label": "Star on GitHub", "url": "https://celerp.com/github"}
+    with patch("httpx.AsyncClient") as mock_httpx:
+        mock_httpx.return_value.__aenter__.return_value.get = AsyncMock(return_value=_resp(200, cta))
+        out = await star_cta.get_star_cta("footer")
+    assert out == cta  # rendered verbatim, no install-side copy
+
+
+@pytest.mark.asyncio
+async def test_caches_within_ttl(monkeypatch):
+    monkeypatch.setattr(settings, "star_cta_enabled", True)
+    monkeypatch.setattr(settings, "star_cta_cache_ttl_s", 3600)
+    get = AsyncMock(return_value=_resp(200, {"mode": "founding"}))
+    with patch("httpx.AsyncClient") as mock_httpx:
+        mock_httpx.return_value.__aenter__.return_value.get = get
+        await star_cta.get_star_cta("footer")
+        await star_cta.get_star_cta("footer")
+    assert get.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_ttl_expiry_refetches(monkeypatch):
+    monkeypatch.setattr(settings, "star_cta_enabled", True)
+    monkeypatch.setattr(settings, "star_cta_cache_ttl_s", -1)  # always expired
+    get = AsyncMock(return_value=_resp(200, {"mode": "founding"}))
+    with patch("httpx.AsyncClient") as mock_httpx:
+        mock_httpx.return_value.__aenter__.return_value.get = get
+        await star_cta.get_star_cta("footer")
+        await star_cta.get_star_cta("footer")
+    assert get.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_relay_connect_error_returns_none(monkeypatch):
+    monkeypatch.setattr(settings, "star_cta_enabled", True)
+    import httpx
+    with patch("httpx.AsyncClient") as mock_httpx:
+        mock_httpx.return_value.__aenter__.return_value.get = AsyncMock(
+            side_effect=httpx.ConnectError("refused"))
+        out = await star_cta.get_star_cta("footer")
+    assert out is None  # determinism: no fabricated CTA
+
+
+@pytest.mark.asyncio
+async def test_non_200_returns_none(monkeypatch):
+    monkeypatch.setattr(settings, "star_cta_enabled", True)
+    with patch("httpx.AsyncClient") as mock_httpx:
+        mock_httpx.return_value.__aenter__.return_value.get = AsyncMock(return_value=_resp(503, {}))
+        out = await star_cta.get_star_cta("footer")
+    assert out is None
+
+
+@pytest.mark.asyncio
+async def test_disabled_skips_fetch(monkeypatch):
+    monkeypatch.setattr(settings, "star_cta_enabled", False)
+    get = AsyncMock(return_value=_resp(200, {"mode": "founding"}))
+    with patch("httpx.AsyncClient") as mock_httpx:
+        mock_httpx.return_value.__aenter__.return_value.get = get
+        out = await star_cta.get_star_cta("footer")
+    assert out is None
+    assert get.await_count == 0
+
+
+def test_neutral_cta_is_static_link():
+    cta = star_cta.neutral_cta("footer")
+    assert cta["mode"] == "neutral"
+    assert cta["show_count"] is False
+    assert "/github" in cta["url"]
+    assert "utm_medium=footer" in cta["url"]

--- a/ui/locales/ar.json
+++ b/ui/locales/ar.json
@@ -759,7 +759,7 @@
   "msg._web_access": "🌐 الوصول إلى الويب",
   "msg.accepted_formats_csv_utf8": "التنسيقات المقبولة: ‎.csv (UTF-8)",
   "msg.agentic_record_creation": "إنشاء سجل الوكيل",
-  "msg.ai_quota_exceeded": "لقد استخدمت جميع استعلامات {limit} المضمنة AI. الترقية إلى Cloud + AI مقابل 100 استفسار/الشهر.",
+  "msg.ai_quota_exceeded": "لقد استخدمت جميع استعلامات {limit} المضمنة AI. الترقية إلى Cloud + AI مقابل 200 استفسار/الشهر.",
   "msg.ai_subscription_required": "يلزم الاشتراك في Cloud + AI لاستخدام مساعد AI.",
   "msg.api_server_not_running": "تأكد من تشغيل خادم API قبل فتح واجهة المستخدم:",
   "msg.ask_anything_about_your_business_data": "اسأل أي شيء عن بيانات عملك...",

--- a/ui/locales/de.json
+++ b/ui/locales/de.json
@@ -759,7 +759,7 @@
   "msg._web_access": "🌐 Web-Zugang",
   "msg.accepted_formats_csv_utf8": "Akzeptierte Formate: .csv (UTF-8)",
   "msg.agentic_record_creation": "Autonome Datensatzerstellung",
-  "msg.ai_quota_exceeded": "Sie haben alle {limit} enthaltenen KI-Abfragen aufgebraucht. Upgraden Sie auf Cloud + KI für 100 Abfragen/Monat.",
+  "msg.ai_quota_exceeded": "Sie haben alle {limit} enthaltenen KI-Abfragen aufgebraucht. Upgraden Sie auf Cloud + KI für 200 Abfragen/Monat.",
   "msg.ai_subscription_required": "Cloud + KI-Abonnement erforderlich, um den KI-Assistenten zu nutzen.",
   "msg.api_server_not_running": "Stellen Sie sicher, dass der API-Server läuft, bevor Sie die Benutzeroberfläche öffnen:",
   "msg.ask_anything_about_your_business_data": "Stellen Sie beliebige Fragen zu Ihren Geschäftsdaten...",

--- a/ui/locales/en.json
+++ b/ui/locales/en.json
@@ -759,7 +759,7 @@
   "msg._web_access": "🌐 Web Access",
   "msg.accepted_formats_csv_utf8": "Accepted formats: .csv (UTF-8)",
   "msg.agentic_record_creation": "Agentic record creation",
-  "msg.ai_quota_exceeded": "You've used all {limit} included AI queries. Upgrade to AI + Connect for 100 queries/month.",
+  "msg.ai_quota_exceeded": "You've used all {limit} included AI queries. Upgrade to AI + Connect for 200 queries/month.",
   "msg.ai_subscription_required": "AI + Connect subscription required to use the AI assistant.",
   "msg.api_server_not_running": "Make sure the API server is running before opening the UI:",
   "msg.ask_anything_about_your_business_data": "Ask anything about your business data...",

--- a/ui/locales/es.json
+++ b/ui/locales/es.json
@@ -759,7 +759,7 @@
   "msg._web_access": "🌐 Acceso web",
   "msg.accepted_formats_csv_utf8": "Formatos aceptados: .csv (UTF-8)",
   "msg.agentic_record_creation": "Creación de registros agentes",
-  "msg.ai_quota_exceeded": "Ha utilizado todas las consultas {limit} incluidas AI. Actualice a Cloud + AI para 100 consultas/mes.",
+  "msg.ai_quota_exceeded": "Ha utilizado todas las consultas {limit} incluidas AI. Actualice a Cloud + AI para 200 consultas/mes.",
   "msg.ai_subscription_required": "Se requiere suscripción a Cloud + AI para utilizar el asistente AI.",
   "msg.api_server_not_running": "Asegúrese de que el servidor API esté ejecutándose antes de abrir la interfaz de usuario:",
   "msg.ask_anything_about_your_business_data": "Pregunta cualquier cosa sobre los datos de tu negocio...",

--- a/ui/locales/fr.json
+++ b/ui/locales/fr.json
@@ -759,7 +759,7 @@
   "msg._web_access": "🌐 Accès Web",
   "msg.accepted_formats_csv_utf8": "Formats acceptés : .csv (UTF-8)",
   "msg.agentic_record_creation": "Création d'enregistrements agent",
-  "msg.ai_quota_exceeded": "Vous avez utilisé toutes les requêtes {limit} incluses AI. Passez à Cloud + AI pour 100 requêtes/mois.",
+  "msg.ai_quota_exceeded": "Vous avez utilisé toutes les requêtes {limit} incluses AI. Passez à Cloud + AI pour 200 requêtes/mois.",
   "msg.ai_subscription_required": "Cloud + abonnement AI requis pour utiliser l'assistant AI.",
   "msg.api_server_not_running": "Assurez-vous que le serveur API est en cours d'exécution avant d'ouvrir l'interface utilisateur :",
   "msg.ask_anything_about_your_business_data": "Demandez n'importe quoi sur les données de votre entreprise...",

--- a/ui/locales/id.json
+++ b/ui/locales/id.json
@@ -759,7 +759,7 @@
   "msg._web_access": "🌐 Akses Web",
   "msg.accepted_formats_csv_utf8": "Format yang diterima: .csv (UTF-8)",
   "msg.agentic_record_creation": "Pembuatan catatan agenik",
-  "msg.ai_quota_exceeded": "Anda telah menggunakan semua {limit} termasuk AI kueri. Tingkatkan ke Cloud + AI untuk 100 kueri/bulan.",
+  "msg.ai_quota_exceeded": "Anda telah menggunakan semua {limit} termasuk AI kueri. Tingkatkan ke Cloud + AI untuk 200 kueri/bulan.",
   "msg.ai_subscription_required": "Langganan Cloud + AI diperlukan untuk menggunakan asisten AI.",
   "msg.api_server_not_running": "Pastikan server API berjalan sebelum membuka UI:",
   "msg.ask_anything_about_your_business_data": "Tanyakan apa pun tentang data bisnis Anda...",

--- a/ui/locales/it.json
+++ b/ui/locales/it.json
@@ -759,7 +759,7 @@
   "msg._web_access": "🌐 Accesso web",
   "msg.accepted_formats_csv_utf8": "Formati accettati: .csv (UTF-8)",
   "msg.agentic_record_creation": "Creazione record autonoma",
-  "msg.ai_quota_exceeded": "Hai usato tutte le {limit} query AI incluse. Passa a Cloud + AI per 100 query/mese.",
+  "msg.ai_quota_exceeded": "Hai usato tutte le {limit} query AI incluse. Passa a Cloud + AI per 200 query/mese.",
   "msg.ai_subscription_required": "Abbonamento Cloud + AI richiesto per utilizzare l'assistente AI.",
   "msg.api_server_not_running": "Assicurati che il server API sia in esecuzione prima di aprire l'interfaccia:",
   "msg.ask_anything_about_your_business_data": "Fai qualsiasi domanda sui tuoi dati aziendali...",

--- a/ui/locales/ja.json
+++ b/ui/locales/ja.json
@@ -759,7 +759,7 @@
   "msg._web_access": "🌐 ウェブアクセス",
   "msg.accepted_formats_csv_utf8": "受け入れられる形式: .csv (UTF-8)",
   "msg.agentic_record_creation": "エージェントレコードの作成",
-  "msg.ai_quota_exceeded": "{limit} に含まれる AI クエリをすべて使用しました。 100 クエリ/月の場合は Cloud + AI にアップグレードします。",
+  "msg.ai_quota_exceeded": "{limit} に含まれる AI クエリをすべて使用しました。 200 クエリ/月の場合は Cloud + AI にアップグレードします。",
   "msg.ai_subscription_required": "AI アシスタントを使用するには、Cloud + AI サブスクリプションが必要です。",
   "msg.api_server_not_running": "UI を開く前に、API サーバーが実行されていることを確認してください。",
   "msg.ask_anything_about_your_business_data": "ビジネスデータについて何でも質問してください...",

--- a/ui/locales/pt.json
+++ b/ui/locales/pt.json
@@ -759,7 +759,7 @@
   "msg._web_access": "🌐 Acesso à Web",
   "msg.accepted_formats_csv_utf8": "Formatos aceitos: .csv (UTF-8)",
   "msg.agentic_record_creation": "Criação de registro agente",
-  "msg.ai_quota_exceeded": "Você usou todas as consultas {limit} incluídas em AI. Atualize para Cloud + AI para 100 consultas/mês.",
+  "msg.ai_quota_exceeded": "Você usou todas as consultas {limit} incluídas em AI. Atualize para Cloud + AI para 200 consultas/mês.",
   "msg.ai_subscription_required": "Assinatura Cloud + AI necessária para usar o assistente AI.",
   "msg.api_server_not_running": "Certifique-se de que o servidor API esteja em execução antes de abrir a UI:",
   "msg.ask_anything_about_your_business_data": "Pergunte qualquer coisa sobre os dados da sua empresa...",

--- a/ui/locales/th.json
+++ b/ui/locales/th.json
@@ -759,7 +759,7 @@
   "msg._web_access": "🌐 การเข้าถึงเว็บ",
   "msg.accepted_formats_csv_utf8": "รูปแบบที่ยอมรับ: .csv (UTF-8)",
   "msg.agentic_record_creation": "การสร้างบันทึกตัวแทน",
-  "msg.ai_quota_exceeded": "คุณได้ใช้ {limit} รวมคำค้นหา AI ทั้งหมดแล้ว อัปเกรดเป็น Cloud + AI สำหรับการสืบค้น 100 ครั้ง/เดือน",
+  "msg.ai_quota_exceeded": "คุณได้ใช้ {limit} รวมคำค้นหา AI ทั้งหมดแล้ว อัปเกรดเป็น Cloud + AI สำหรับการสืบค้น 200 ครั้ง/เดือน",
   "msg.ai_subscription_required": "ต้องสมัครสมาชิก Cloud + AI เพื่อใช้ผู้ช่วย AI",
   "msg.api_server_not_running": "ตรวจสอบให้แน่ใจว่าเซิร์ฟเวอร์ API ทำงานก่อนที่จะเปิด UI:",
   "msg.ask_anything_about_your_business_data": "ถามอะไรก็ได้เกี่ยวกับข้อมูลธุรกิจของคุณ...",

--- a/ui/locales/vi.json
+++ b/ui/locales/vi.json
@@ -759,7 +759,7 @@
   "msg._web_access": "🌐 Truy cập web",
   "msg.accepted_formats_csv_utf8": "Các định dạng được chấp nhận: .csv (UTF-8)",
   "msg.agentic_record_creation": "Tạo bản ghi đại lý",
-  "msg.ai_quota_exceeded": "Bạn đã sử dụng tất cả các truy vấn {limit} được bao gồm AI. Nâng cấp lên Cloud + AI cho 100 truy vấn/tháng.",
+  "msg.ai_quota_exceeded": "Bạn đã sử dụng tất cả các truy vấn {limit} được bao gồm AI. Nâng cấp lên Cloud + AI cho 200 truy vấn/tháng.",
   "msg.ai_subscription_required": "Cần đăng ký Cloud + AI để sử dụng trợ lý AI.",
   "msg.api_server_not_running": "Đảm bảo máy chủ API đang chạy trước khi mở giao diện người dùng:",
   "msg.ask_anything_about_your_business_data": "Hỏi bất cứ điều gì về dữ liệu kinh doanh của bạn...",

--- a/ui/routes/settings.py
+++ b/ui/routes/settings.py
@@ -4015,7 +4015,7 @@ def _ai_tab() -> FT:
                 "AI Assistant",
                 "Ask your ERP questions in plain English - inventory analysis, AR summaries, "
                 "CRM insights. Connect (USD $29/mo) includes 100 free queries to try it. "
-                "AI + Connect (USD $49/mo) gives 100 queries every month.",
+                "AI + Connect (USD $49/mo) gives 200 queries every month.",
                 price="USD $29/mo",
                 anchor="cloud",
             ),


### PR DESCRIPTION
## What

The self-contained, relay-agnostic **install half** of the GitHub-star recognition program (strategy + spec live in the local `context/marketing/2026-0623-github-stars-*.md` docs). The relay (`celerp.com`) stays the single source of the star count, tier ladder, and CTA copy; the install only renders the relay's resolved CTA and degrades to a static neutral link when the relay is unreachable.

## Changes

- **DRY refactor** (`gateway/state.py`): collapse `build_subscribe_url` into a shared `build_handoff_url` so the celerp.com handoff/UTM convention exists once. Behavior-preserving (tested).
- **config**: `star_cta_enabled` kill switch + `star_cta_cache_ttl_s`.
- **`services/star_cta.py`**: cached relay-CTA client. Returns `None` on any relay failure (never fabricates a count/mode); `neutral_cta()` is the explicit offline state.
- **`routers/stars.py`**: `GET /stars/cta` (any authed user; relay CTA or neutral link + dismissed flag; `{}` when disabled) and `POST /stars/dismiss` (admin, install-level). On its own router because `/system` is admin-gated but the footer CTA must be readable by all.
- **`runtime_state.py`**: install-level star-prompt dismissal flag on `SystemRuntimeState`.
- **`cli.py`**: one static first-run line in `init`, gated on `star_cta_enabled`.
- **tests**: URL builders (refactor behavior-preserving), CTA client (cache TTL, offline→None, disabled, non-200), `/stars` endpoints (relay payload, neutral fallback, disabled, dismiss, auth), CLI line on/off. 20 new tests.

## Architecture / commandments

This implements the post-review architecture from the spec: relay is the single source (DRY/DIP), install split by responsibility (SRP), offline renders an explicit neutral link (determinism, no guessed "founding"), one shared URL builder (anti-WET), admin/undo semantics per the Global Dev Rules.

## Deferred (relay-blocked, by design)

UI footer/onboarding/milestone cards, the badge OAuth-verify + `SupporterBadge`, and the public founders wall all need relay endpoints in the **separate `celerp.com` repo**, and the `celerp.com/github` 302 redirect must exist before any user-facing link ships (so it does not 404). Building those now would be unexercisable cruft.

## Tests

Full unit suite (excl. browser/visual) under `-n auto`: **3688 passed, 1 skipped**.

## Note on CI

CI only triggers on PRs targeting `main`. This targets `develop` (integration branch), so the shards will not auto-run here; retarget to `main` if you want them.