### PR TITLE
feat(stars): install UI surfaces - footer CTA, supporter badge, onboarding card, claim handshake

### DIFF
--- a/tests/test_stars_ui.py
+++ b/tests/test_stars_ui.py
@@ -1,0 +1,39 @@
+# Copyright (c) 2026 Noah Severs
+# SPDX-License-Identifier: LicenseRef-Proprietary
+"""Render tests for the GitHub-star UI surfaces (footer CTA, supporter badge,
+onboarding card). Pure render — no server."""
+from __future__ import annotations
+
+from fasthtml.common import to_xml
+
+from ui.components.shell import _topbar, base_shell
+from ui.routes.auth import _onboarding_view
+
+
+def test_footer_cta_present_in_shell():
+    xml = to_xml(base_shell(title="t"))
+    # Footer CTA hydration target + the proxy endpoints the head script fetches.
+    assert 'id="star-cta"' in xml
+    assert "/stars/cta?medium=footer" in xml
+    assert "/stars/badge" in xml
+
+
+def test_supporter_badge_slot_in_topbar_for_user():
+    # The badge slot lives in the user-menu, which renders only when logged in.
+    xml = to_xml(_topbar([], user_email="admin@test.local"))
+    assert 'id="supporter-badge"' in xml
+
+
+def test_onboarding_card_present():
+    xml = to_xml(_onboarding_view())
+    assert 'id="star-onboarding-card"' in xml
+    assert "/stars/cta?medium=onboarding" in xml
+    assert "/stars/claim" in xml          # claim handshake link
+    assert 'id="star-card-dismiss"' in xml  # "Maybe later"
+    assert "/stars/dismiss" in xml
+
+
+def test_onboarding_card_hidden_by_default():
+    # Card is display:none until JS hydrates it (and only if not dismissed).
+    xml = to_xml(_onboarding_view())
+    assert "display:none" in xml.split('id="star-onboarding-card"')[1][:80]

--- a/ui/app.py
+++ b/ui/app.py
@@ -52,7 +52,7 @@ from ui.config import COOKIE_NAME, REFRESH_COOKIE_NAME, cookie_domain
 from ui.routes import (
     auth, setup, search, settings, settings_import,
     settings_general, settings_sales, settings_purchasing, settings_inventory, settings_accounting,
-    settings_contacts, settings_cloud, settings_connectors, notifications, events,
+    settings_contacts, settings_cloud, settings_connectors, notifications, events, stars,
 )
 from fasthtml.common import *
 from starlette.responses import HTMLResponse
@@ -342,7 +342,7 @@ if not _ENABLED_MODULES and os.environ.get("MODULE_DIR"):
 # Kernel UI routes — always registered
 for mod in (auth, setup, search, settings, settings_import,
             settings_general, settings_sales, settings_purchasing, settings_inventory, settings_accounting,
-            settings_contacts, settings_cloud, settings_connectors, notifications, events):
+            settings_contacts, settings_cloud, settings_connectors, notifications, events, stars):
     mod.setup_routes(app)
 
 # Module-conditional UI routes

--- a/ui/components/shell.py
+++ b/ui/components/shell.py
@@ -756,6 +756,27 @@ document.addEventListener('DOMContentLoaded', function() {
 });
 """
 
+_STAR_CTA_JS = """
+(function(){
+  fetch('/stars/cta?medium=footer').then(function(r){return r.json()}).then(function(d){
+    var el = document.getElementById('star-cta');
+    if (!el || !d || !d.url) return;
+    var label = d.cta_label || 'Star on GitHub';
+    if (d.mode === 'founding') label = 'Back us early \\u2605';
+    else if (d.show_count && d.count != null) label = '\\u2605 ' + d.count;
+    el.textContent = label; el.href = d.url; el.style.display = '';
+  }).catch(function(){});
+  fetch('/stars/badge').then(function(r){return r.json()}).then(function(d){
+    var el = document.getElementById('supporter-badge');
+    if (!el || !d || !d.badge) return;
+    el.textContent = '\\u2605 ' + d.badge.label;
+    el.title = 'Thank you for being ' + d.badge.label;
+    el.style.display = '';
+  }).catch(function(){});
+})();
+"""
+
+
 def base_shell(*content, title: str = "Celerp", nav_active: str = "", companies: list[dict] | None = None, extra_head: list | None = None, lang: str = "en", request=None) -> FT:
     """Outer chrome: sidebar nav + top header + content area."""
     from ui.config import get_user_email, get_relay_info
@@ -775,6 +796,7 @@ def base_shell(*content, title: str = "Celerp", nav_active: str = "", companies:
         Script(_HEALTH_BANNER_JS),
         Script(_NOTIFICATION_JS),
         Script(_USER_MENU_JS),
+        Script(_STAR_CTA_JS),
     ]
     if extra_head:
         head_items.extend(extra_head)
@@ -792,6 +814,8 @@ def base_shell(*content, title: str = "Celerp", nav_active: str = "", companies:
                     Footer(
                         A(t("msg.powered_by", lang), href="https://www.celerp.com", target="_blank",
                           cls="brand-footer-link"),
+                        A("", id="star-cta", href="#", target="_blank", rel="noopener",
+                          cls="brand-footer-link", style="display:none;margin-left:16px"),
                         cls="brand-footer",
                     ),
                     cls="content-area",
@@ -947,6 +971,8 @@ def _topbar(companies: list[dict], lang: str = "en", user_email: str | None = No
             Div(
                 # Email pill = dropdown trigger
                 Div(
+                    Span("", id="supporter-badge", cls="supporter-badge", title="",
+                         style="display:none;margin-right:8px;color:#d4af37;font-size:12px"),
                     Span(user_email, cls="user-menu__email-text"),
                     cls="user-menu__trigger",
                     onclick="toggleUserMenu()",

--- a/ui/routes/auth.py
+++ b/ui/routes/auth.py
@@ -623,6 +623,44 @@ document.querySelector('#restore-btn').closest('form').addEventListener('submit'
     )
 
 
+_STAR_ONBOARDING_JS = """
+(function(){
+  fetch('/stars/cta?medium=onboarding').then(function(r){return r.json()}).then(function(d){
+    if(!d || !d.url || d.dismissed || d.mode==='neutral') return;
+    var card=document.getElementById('star-onboarding-card'); if(!card) return;
+    var h=document.getElementById('star-card-headline'); if(h) h.textContent=d.headline||'Support Celerp';
+    var b=document.getElementById('star-card-body'); if(b) b.textContent=d.body||'';
+    var s=document.getElementById('star-card-star'); if(s) s.href=d.url;
+    card.style.display='';
+  }).catch(function(){});
+  var dz=document.getElementById('star-card-dismiss');
+  if(dz) dz.addEventListener('click', function(){
+    fetch('/stars/dismiss',{method:'POST'}).then(function(){
+      var c=document.getElementById('star-onboarding-card'); if(c) c.style.display='none';
+    });
+  });
+})();
+"""
+
+
+def _star_onboarding_card() -> FT:
+    return Div(
+        Div(
+            H3("", id="star-card-headline"),
+            P("", id="star-card-body", cls="auth-subtitle"),
+            Div(
+                A("Star on GitHub", id="star-card-star", href="#", target="_blank", rel="noopener", cls="btn btn--primary"),
+                A("Claim your badge", href="/stars/claim", cls="btn btn--secondary"),
+                Button("Maybe later", id="star-card-dismiss", type="button", cls="btn btn--ghost"),
+                cls="mt-md",
+            ),
+            id="star-onboarding-card",
+            style="display:none;margin-top:24px;padding:20px;border:1px solid #d4af37;border-radius:10px;text-align:center",
+        ),
+        Script(_STAR_ONBOARDING_JS),
+    )
+
+
 def _onboarding_view() -> FT:
     integrations = [
         ("/onboarding/upload/items", "Import Inventory", "Upload CSV or JSON", "items"),
@@ -654,6 +692,7 @@ def _onboarding_view() -> FT:
             A(t("btn.go_to_dashboard"), href="/dashboard", cls="btn btn--secondary"),
             cls="mt-lg text-center",
         ),
+        _star_onboarding_card(),
         cls="onboarding-card",
     )
 

--- a/ui/routes/stars.py
+++ b/ui/routes/stars.py
@@ -1,0 +1,109 @@
+# Copyright (c) 2026 Noah Severs
+# SPDX-License-Identifier: LicenseRef-Proprietary
+
+"""GitHub-star UI proxy routes + the badge-claim handshake.
+
+The UI server (8080) proxies the star endpoints to the API (so the shell JS can call
+same-origin) and hosts /stars/claim, which bounces the browser to the relay verify
+flow and stores the returned credential.
+"""
+from __future__ import annotations
+
+import html
+
+import httpx
+from starlette.requests import Request
+from starlette.responses import HTMLResponse, RedirectResponse, Response
+
+from ui.config import API_BASE, get_token as _token
+
+
+def _claim_result_page(title: str, body: str) -> str:
+    return (
+        "<!doctype html><meta charset=utf-8><title>Celerp</title>"
+        "<div style='font-family:system-ui,sans-serif;max-width:560px;margin:80px auto;"
+        "text-align:center;line-height:1.5'>"
+        f"<h1>{html.escape(title)}</h1><p style='color:#555'>{body}</p>"
+        "<p><a href='/' style='display:inline-block;margin-top:12px;padding:10px 20px;"
+        "background:#1f883d;color:#fff;border-radius:6px;text-decoration:none'>Back to Celerp</a></p>"
+        "</div>"
+    )
+
+
+def setup_routes(app):
+
+    @app.get("/stars/cta")
+    async def proxy_star_cta(request: Request) -> Response:
+        token = _token(request)
+        if not token:
+            return Response("{}", media_type="application/json")
+        params = {"medium": request.query_params.get("medium", "footer")}
+        async with httpx.AsyncClient(base_url=API_BASE, timeout=10.0) as c:
+            try:
+                r = await c.get("/stars/cta", params=params, headers={"Authorization": f"Bearer {token}"})
+                return Response(r.content, media_type="application/json", status_code=r.status_code)
+            except (httpx.ConnectError, httpx.TimeoutException):
+                return Response("{}", media_type="application/json")
+
+    @app.get("/stars/badge")
+    async def proxy_star_badge(request: Request) -> Response:
+        token = _token(request)
+        if not token:
+            return Response('{"badge":null}', media_type="application/json")
+        async with httpx.AsyncClient(base_url=API_BASE, timeout=10.0) as c:
+            try:
+                r = await c.get("/stars/badge", headers={"Authorization": f"Bearer {token}"})
+                return Response(r.content, media_type="application/json", status_code=r.status_code)
+            except (httpx.ConnectError, httpx.TimeoutException):
+                return Response('{"badge":null}', media_type="application/json")
+
+    @app.post("/stars/dismiss")
+    async def proxy_star_dismiss(request: Request) -> Response:
+        token = _token(request)
+        if not token:
+            return Response(status_code=401)
+        async with httpx.AsyncClient(base_url=API_BASE, timeout=10.0) as c:
+            try:
+                r = await c.post("/stars/dismiss", headers={"Authorization": f"Bearer {token}"})
+                return Response(r.content, status_code=r.status_code)
+            except (httpx.ConnectError, httpx.TimeoutException):
+                return Response(status_code=503)
+
+    @app.get("/stars/claim")
+    async def stars_claim(request: Request):
+        """Badge-claim handshake. No cred -> bounce to the relay verify flow with this
+        page as the return URL. With cred -> store the badge and confirm."""
+        token = _token(request)
+        if not token:
+            return RedirectResponse("/login", status_code=302)
+
+        cred = request.query_params.get("cred")
+        if cred:
+            async with httpx.AsyncClient(base_url=API_BASE, timeout=10.0) as c:
+                try:
+                    r = await c.post("/stars/badge", json={"cred": cred},
+                                     headers={"Authorization": f"Bearer {token}"})
+                    data = r.json()
+                except Exception:
+                    return HTMLResponse(_claim_result_page(
+                        "Couldn't save your badge", "Please try claiming again from Celerp."))
+            if data.get("error") or not data.get("badge"):
+                return HTMLResponse(_claim_result_page(
+                    "We couldn't verify a star", "Star Celerp on GitHub, then claim again."))
+            label = html.escape(data["badge"]["label"])
+            return HTMLResponse(_claim_result_page(
+                "Thank you", f"You are recognised as <strong>{label}</strong>."))
+
+        # No cred yet: ask the API for the relay verify-start URL, return here after.
+        return_url = str(request.base_url).rstrip("/") + "/stars/claim"
+        async with httpx.AsyncClient(base_url=API_BASE, timeout=10.0) as c:
+            try:
+                r = await c.get("/stars/badge/verify-url", params={"return_url": return_url},
+                                headers={"Authorization": f"Bearer {token}"})
+                url = r.json().get("url")
+            except Exception:
+                url = None
+        if not url:
+            return HTMLResponse(_claim_result_page(
+                "Cloud unavailable", "Couldn't reach the Celerp relay. Try again later."))
+        return RedirectResponse(url, status_code=302)


### PR DESCRIPTION
The install-side **UI layer** for the GitHub-stars program. The backend (CTA client, `/stars/cta`, dismissal, CLI line, badge model + `/stars/badge` endpoints, the founder-label workflow) already merged via #135 — this PR is just the presentation + the browser claim handshake.

## What's here
- **`ui/routes/stars.py`** — same-origin proxy routes (`/stars/cta`, `/stars/badge`, `/stars/dismiss`) so the shell JS can call the API, plus **`/stars/claim`**: the cross-server handshake (bounce the browser to the relay verify flow with this page as `return_url`; on `?cred=` store the badge and confirm).
- **`shell.py`** — footer star CTA (founding/momentum/proof/neutral copy) + a supporter-badge slot in the user menu, both hydrated by `_STAR_CTA_JS`.
- **`auth.py`** — onboarding card (admin onboarding view): relay headline/body, Star + Claim + Maybe-later (dismiss); hidden under neutral/dismissed.

## Behaviour
Everything degrades to a passive "Star on GitHub" link when the relay is unreachable — **no fabricated count, no broken card**.

## Tests + live run
- Render tests (`tests/test_stars_ui.py`): footer CTA, badge slot, onboarding card (hidden by default).
- Full `test_ui.py` suite green (the shell change touches every page): **954 passed**.
- **Live run-through**: launched the API+UI servers and verified end-to-end — `/onboarding` renders the card, `/items` (full shell) renders the footer CTA, and `/stars/cta` proxied UI→API→relay(down)→correct neutral CTA.

## Depends on (sequencing)
The user-facing links only resolve once the **relay** stars endpoints + the `celerp.com/github` redirect are live (relay PR ngsevers/celerp-cloud#9, after the main-CI fix #10). Until then this ships harmlessly as the neutral link.