### PR TITLE
fix(setup): activating page hangs on AI/Cloud Backup (core-folded modules report running=False)

### DIFF
--- a/celerp/modules/loader.py
+++ b/celerp/modules/loader.py
@@ -170,6 +170,24 @@ def loaded_modules() -> list[dict]:
     return list(_loaded)
 
 
+def is_core_folded(pkg_name: str) -> bool:
+    """True if a module is a proprietary cloud component folded into core (ai/backup/
+    connectors). These are wired directly into the app at construction, so they never
+    appear in ``loaded_modules()`` — yet they ARE running whenever the app is up."""
+    return pkg_name in _CORE_FOLDED
+
+
+def is_running(pkg_name: str) -> bool:
+    """Single source of truth for "is this module active in the process".
+
+    A module is running if the pluggable loader loaded it OR it is a core-folded
+    module (wired directly at app construction). Used by /companies/me/modules and
+    the setup activating page so folded modules are never reported as failed to
+    start — that bug made ai/backup spin forever on the activating screen.
+    """
+    return any(m["name"] == pkg_name for m in _loaded) or is_core_folded(pkg_name)
+
+
 # Fields to extract from PLUGIN_MANIFEST for display purposes.
 # All must be string or list-of-strings literals in __init__.py (safe for ast.literal_eval).
 _MANIFEST_DISPLAY_FIELDS: frozenset[str] = frozenset({

--- a/celerp/routers/companies.py
+++ b/celerp/routers/companies.py
@@ -1511,7 +1511,7 @@ async def list_modules(
     import asyncio
     import os
     from pathlib import Path
-    from celerp.modules.loader import loaded_modules, read_manifest_metadata
+    from celerp.modules.loader import is_running, loaded_modules, read_manifest_metadata
     from celerp.modules.registry import get_enabled
 
     company = await session.get(Company, company_id)
@@ -1547,7 +1547,9 @@ async def list_modules(
                     "author": manifest_source.get("author", ""),
                     "depends_on": list(manifest_source.get("depends_on") or []),
                     "enabled": pkg_name in enabled_names,
-                    "running": pkg_name in loaded_by_name,
+                    # Core-folded modules (ai/backup/connectors) are wired at app
+                    # construction, never in loaded_by_name — is_running() counts them.
+                    "running": is_running(pkg_name),
                 })
         return results
 

--- a/tests/test_modules/test_modules_api.py
+++ b/tests/test_modules/test_modules_api.py
@@ -224,6 +224,44 @@ class TestModulesAPIEndpoints:
         assert m["label"] == "Manufacturing"
 
     @pytest.mark.asyncio
+    async def test_core_folded_modules_report_running(self, client):
+        """REGRESSION: core-folded modules (ai/backup/connectors) are wired directly
+        into the app at construction, NOT via the pluggable loader, so they never
+        appear in loaded_modules(). list_modules must still report them running=True —
+        otherwise the setup /activating page waits forever and shows "Some modules
+        failed to start" (the AI/Cloud-Backup-spin-forever bug)."""
+        from celerp.modules.loader import _CORE_FOLDED
+
+        token = await _register(client)
+        default_modules = Path(__file__).parent.parent.parent / "default_modules"
+        with patch.dict(os.environ, {"MODULE_DIR": str(default_modules)}):
+            r = await client.get("/companies/me/modules", headers=_h(token))
+        assert r.status_code == 200
+        by_name = {m["name"]: m for m in r.json()}
+
+        # Every folded module present on disk must be reported running.
+        on_disk_folded = [n for n in _CORE_FOLDED if (default_modules / n).is_dir()]
+        assert "celerp-ai" in on_disk_folded and "celerp-backup" in on_disk_folded, \
+            "AI + Backup must be on disk for this regression test to be meaningful"
+        for name in on_disk_folded:
+            assert name in by_name, f"folded module {name} missing from /me/modules"
+            assert by_name[name]["running"] is True, (
+                f"folded module {name} reported running=False — the activating page "
+                "would spin forever waiting for it"
+            )
+
+    @pytest.mark.asyncio
+    async def test_is_running_counts_folded_modules(self):
+        """Unit guard for the single source of truth used by the activating page."""
+        from celerp.modules.loader import is_core_folded, is_running
+
+        assert is_core_folded("celerp-ai") and is_core_folded("celerp-backup")
+        assert not is_core_folded("celerp-verticals")
+        # Folded modules are running even with an empty pluggable-loader registry.
+        assert is_running("celerp-ai") is True
+        assert is_running("celerp-verticals") is False
+
+    @pytest.mark.asyncio
     async def test_subscriptions_outer_manifest_is_literal(self):
         """Outer celerp-subscriptions/__init__.py must define PLUGIN_MANIFEST as a dict literal.
 


### PR DESCRIPTION
## Symptom
Creating a new company → `/setup/activating` spins forever, then **"Some modules failed to start"** when **AI Assistant** or **Cloud Backup** are enabled.

## Root cause
`_CORE_FOLDED` modules (`celerp-ai`, `celerp-backup`, `celerp-connectors`) are wired directly into the app at construction (`celerp/main.py`, `ui/app.py`) and are **deliberately skipped** by the pluggable loader (`loader.py` `load_all`), so they never appear in `loaded_modules()`.

But `/companies/me/modules` computed `running = pkg in loaded_by_name` → these modules **always reported `running=False`**. The activating page polls until every requested module is running, so enabling AI/Backup made it wait forever.

Folding was introduced in #115; the recent AI work lives in this area, which is why it surfaced now. The modules themselves load fine — only the *running detection* was wrong.

## Fix
A single source of truth in the loader — `is_running()` / `is_core_folded()` — that counts folded modules as running. `/companies/me/modules` now uses it. (Folded modules are wired unconditionally, so they are running whenever the app is up.)

## Why the existing tests missed it
`tests/test_browser/test_activating_page.py` **mocks** the `/setup/activating-status` response (`phase: 'ready'` with fake modules), so it never exercised the real `running` flag for folded modules.

## Regression tests added
- `test_core_folded_modules_report_running` — every on-disk `_CORE_FOLDED` module reports `running=True` via the **real** `/companies/me/modules` endpoint. **Fails without the fix.**
- `test_is_running_counts_folded_modules` — unit guard on the helper.

These lock the data contract the activating page depends on, so changing the loader/folding/modules in the future can't silently break the page again.

## Verification
Regression test fails without the fix, passes with it. **1228 tests green** across loader / modules / setup / companies / UI.

Note: the bug exists on `main` too (folding predates the current develop work) — recommend fast-tracking this; can retarget to `main` if you want it shipped ahead of the next release.