### PR TITLE
hotfix: activating page hangs on AI/Cloud Backup (v1.2.0/v1.2.1 regression) → v1.2.2

### DIFF
--- a/celerp/modules/loader.py
+++ b/celerp/modules/loader.py
@@ -170,6 +170,24 @@ def loaded_modules() -> list[dict]:
     return list(_loaded)
 
 
+def is_core_folded(pkg_name: str) -> bool:
+    """True if a module is a proprietary cloud component folded into core (ai/backup/
+    connectors). These are wired directly into the app at construction, so they never
+    appear in ``loaded_modules()`` — yet they ARE running whenever the app is up."""
+    return pkg_name in _CORE_FOLDED
+
+
+def is_running(pkg_name: str) -> bool:
+    """Single source of truth for "is this module active in the process".
+
+    A module is running if the pluggable loader loaded it OR it is a core-folded
+    module (wired directly at app construction). Used by /companies/me/modules and
+    the setup activating page so folded modules are never reported as failed to
+    start — that bug made ai/backup spin forever on the activating screen.
+    """
+    return any(m["name"] == pkg_name for m in _loaded) or is_core_folded(pkg_name)
+
+
 # Fields to extract from PLUGIN_MANIFEST for display purposes.
 # All must be string or list-of-strings literals in __init__.py (safe for ast.literal_eval).
 _MANIFEST_DISPLAY_FIELDS: frozenset[str] = frozenset({

--- a/celerp/routers/companies.py
+++ b/celerp/routers/companies.py
@@ -1511,7 +1511,7 @@ async def list_modules(
     import asyncio
     import os
     from pathlib import Path
-    from celerp.modules.loader import loaded_modules, read_manifest_metadata
+    from celerp.modules.loader import is_running, loaded_modules, read_manifest_metadata
     from celerp.modules.registry import get_enabled
 
     company = await session.get(Company, company_id)
@@ -1547,7 +1547,9 @@ async def list_modules(
                     "author": manifest_source.get("author", ""),
                     "depends_on": list(manifest_source.get("depends_on") or []),
                     "enabled": pkg_name in enabled_names,
-                    "running": pkg_name in loaded_by_name,
+                    # Core-folded modules (ai/backup/connectors) are wired at app
+                    # construction, never in loaded_by_name — is_running() counts them.
+                    "running": is_running(pkg_name),
                 })
         return results
 

--- a/tests/test_modules/test_modules_api.py
+++ b/tests/test_modules/test_modules_api.py
@@ -224,6 +224,44 @@ class TestModulesAPIEndpoints:
         assert m["label"] == "Manufacturing"
 
     @pytest.mark.asyncio
+    async def test_core_folded_modules_report_running(self, client):
+        """REGRESSION: core-folded modules (ai/backup/connectors) are wired directly
+        into the app at construction, NOT via the pluggable loader, so they never
+        appear in loaded_modules(). list_modules must still report them running=True —
+        otherwise the setup /activating page waits forever and shows "Some modules
+        failed to start" (the AI/Cloud-Backup-spin-forever bug)."""
+        from celerp.modules.loader import _CORE_FOLDED
+
+        token = await _register(client)
+        default_modules = Path(__file__).parent.parent.parent / "default_modules"
+        with patch.dict(os.environ, {"MODULE_DIR": str(default_modules)}):
+            r = await client.get("/companies/me/modules", headers=_h(token))
+        assert r.status_code == 200
+        by_name = {m["name"]: m for m in r.json()}
+
+        # Every folded module present on disk must be reported running.
+        on_disk_folded = [n for n in _CORE_FOLDED if (default_modules / n).is_dir()]
+        assert "celerp-ai" in on_disk_folded and "celerp-backup" in on_disk_folded, \
+            "AI + Backup must be on disk for this regression test to be meaningful"
+        for name in on_disk_folded:
+            assert name in by_name, f"folded module {name} missing from /me/modules"
+            assert by_name[name]["running"] is True, (
+                f"folded module {name} reported running=False — the activating page "
+                "would spin forever waiting for it"
+            )
+
+    @pytest.mark.asyncio
+    async def test_is_running_counts_folded_modules(self):
+        """Unit guard for the single source of truth used by the activating page."""
+        from celerp.modules.loader import is_core_folded, is_running
+
+        assert is_core_folded("celerp-ai") and is_core_folded("celerp-backup")
+        assert not is_core_folded("celerp-verticals")
+        # Folded modules are running even with an empty pluggable-loader registry.
+        assert is_running("celerp-ai") is True
+        assert is_running("celerp-verticals") is False
+
+    @pytest.mark.asyncio
     async def test_subscriptions_outer_manifest_is_literal(self):
         """Outer celerp-subscriptions/__init__.py must define PLUGIN_MANIFEST as a dict literal.
 


### PR DESCRIPTION
**Hotfix for a shipped regression** in **v1.2.0 and v1.2.1**: creating a company with **AI Assistant** or **Cloud Backup** enabled makes `/setup/activating` spin forever → *"Some modules failed to start."*

Identical fix to #137 (develop companion) — the touched files (`loader.py`, `companies.py`, `test_modules_api.py`) are **byte-identical on main and develop**, so this cherry-picks cleanly. The AI refactor changed the AI gateway internals, not the module-loading code.

## Root cause
`_CORE_FOLDED` modules (`celerp-ai`, `celerp-backup`, `celerp-connectors`) are wired into the app at construction and skipped by the pluggable loader, so they never appear in `loaded_modules()`. `/companies/me/modules` computed `running = pkg in loaded_by_name`, so they **always reported `running=False`** and the activating page never reached "ready". Introduced by the folding in #115 (first shipped in v1.2.0).

## Fix
Single source of truth in the loader — `is_running()` / `is_core_folded()` — that counts folded modules as running. `/companies/me/modules` uses it.

## Regression tests
The existing browser test mocks the activating-status response, so it never exercised the real running flag. Added:
- `test_core_folded_modules_report_running` — every on-disk `_CORE_FOLDED` module reports `running=True` via the real endpoint. **Fails without the fix.**
- `test_is_running_counts_folded_modules` — unit guard.

## Verify
17/17 in `test_modules_api.py` on the main base; regression test red without the fix, green with it.

## Affected releases
v1.2.0, v1.2.1 (v1.1.x and earlier are clean — ai/backup were pluggable then). Recommend tagging **v1.2.2** off this. Companion develop PR: #137.