### PR TITLE
feat(stars): gold footer CTA + tooltip + reworded; show founding card on the dashboard

### DIFF
--- a/tests/test_stars_ui.py
+++ b/tests/test_stars_ui.py
@@ -1,21 +1,23 @@
 # Copyright (c) 2026 Noah Severs
 # SPDX-License-Identifier: LicenseRef-Proprietary
 """Render tests for the GitHub-star UI surfaces (footer CTA, supporter badge,
-onboarding card). Pure render — no server."""
+supporter card). Pure render — no server."""
 from __future__ import annotations
 
 from fasthtml.common import to_xml
 
-from ui.components.shell import _topbar, base_shell
+from ui.components.shell import _topbar, base_shell, star_supporter_card
 from ui.routes.auth import _onboarding_view
 
 
-def test_footer_cta_present_in_shell():
+def test_footer_cta_present_and_gold():
     xml = to_xml(base_shell(title="t"))
-    # Footer CTA hydration target + the proxy endpoints the head script fetches.
     assert 'id="star-cta"' in xml
     assert "/stars/cta?medium=footer" in xml
     assert "/stars/badge" in xml
+    # Gold + bold so it stands out from the grey "Powered by" link.
+    seg = xml.split('id="star-cta"')[1][:140]
+    assert "#d4af37" in seg
 
 
 def test_supporter_badge_slot_in_topbar_for_user():
@@ -24,16 +26,21 @@ def test_supporter_badge_slot_in_topbar_for_user():
     assert 'id="supporter-badge"' in xml
 
 
-def test_onboarding_card_present():
-    xml = to_xml(_onboarding_view())
-    assert 'id="star-onboarding-card"' in xml
-    assert "/stars/cta?medium=onboarding" in xml
-    assert "/stars/claim" in xml          # claim handshake link
+def test_supporter_card_component():
+    xml = to_xml(star_supporter_card("dashboard"))
+    assert 'id="star-supporter-card"' in xml
+    assert "/stars/cta?medium=dashboard" in xml
+    assert "/stars/claim" in xml           # claim handshake link
     assert 'id="star-card-dismiss"' in xml  # "Maybe later"
     assert "/stars/dismiss" in xml
+    # Hidden until JS hydrates it (non-neutral + not dismissed).
+    assert "display:none" in xml.split('id="star-supporter-card"')[1][:90]
 
 
-def test_onboarding_card_hidden_by_default():
-    # Card is display:none until JS hydrates it (and only if not dismissed).
-    xml = to_xml(_onboarding_view())
-    assert "display:none" in xml.split('id="star-onboarding-card"')[1][:80]
+def test_card_medium_is_parameterized():
+    assert "/stars/cta?medium=onboarding" in to_xml(star_supporter_card("onboarding"))
+    assert "/stars/cta?medium=dashboard" in to_xml(star_supporter_card("dashboard"))
+
+
+def test_onboarding_view_includes_card():
+    assert 'id="star-supporter-card"' in to_xml(_onboarding_view())

--- a/tests/test_stars_ui.py
+++ b/tests/test_stars_ui.py
@@ -32,13 +32,15 @@ def test_supporter_card_component():
     assert "/stars/cta?medium=dashboard" in xml
     assert "/stars/claim" in xml             # claim handshake link
     assert "/stars/dismiss" in xml
-    # Dismiss is now an X button (top-right), not a "Maybe later" button.
+    # Dismiss is an X button (top-right), not a "Maybe later" button.
     assert 'id="star-card-dismiss"' in xml
     assert "Maybe later" not in xml
     assert "×" in xml
-    # The ask is the header; the explanation + founding-badge promise is the body.
-    assert "<h3" in xml and "Star on GitHub" in xml
-    assert "first 100 people that star us" in xml
+    # Header + body are hydration targets — the COPY comes from the relay (single
+    # source), so it is NOT in the static render; only the placeholders + pre-line are.
+    assert 'id="star-card-headline"' in xml
+    assert 'id="star-card-body"' in xml
+    assert "white-space:pre-line" in xml      # renders the relay's "\n\n" paragraph break
     # Hidden until JS hydrates it (non-neutral + not dismissed).
     assert "display:none" in xml.split('id="star-supporter-card"')[1][:90]
 

--- a/tests/test_stars_ui.py
+++ b/tests/test_stars_ui.py
@@ -30,9 +30,15 @@ def test_supporter_card_component():
     xml = to_xml(star_supporter_card("dashboard"))
     assert 'id="star-supporter-card"' in xml
     assert "/stars/cta?medium=dashboard" in xml
-    assert "/stars/claim" in xml           # claim handshake link
-    assert 'id="star-card-dismiss"' in xml  # "Maybe later"
+    assert "/stars/claim" in xml             # claim handshake link
     assert "/stars/dismiss" in xml
+    # Dismiss is now an X button (top-right), not a "Maybe later" button.
+    assert 'id="star-card-dismiss"' in xml
+    assert "Maybe later" not in xml
+    assert "×" in xml
+    # The ask is the header; the explanation + founding-badge promise is the body.
+    assert "<h3" in xml and "Star on GitHub" in xml
+    assert "first 100 people that star us" in xml
     # Hidden until JS hydrates it (non-neutral + not dismissed).
     assert "display:none" in xml.split('id="star-supporter-card"')[1][:90]
 

--- a/ui/components/shell.py
+++ b/ui/components/shell.py
@@ -765,8 +765,7 @@ _STAR_CTA_JS = """
     if (d.show_count && d.count != null) label = '\\u2605 ' + d.count;  // proof/momentum: star count
     el.textContent = label;
     el.href = d.url;
-    // Explain the ask on hover; the relay's body carries the founding pitch.
-    el.title = d.body || 'Celerp is open source \\u2014 a GitHub star helps other teams find us.';
+    el.title = 'We appreciate your support.';
     el.style.display = '';
   }).catch(function(){});
   fetch('/stars/badge').then(function(r){return r.json()}).then(function(d){
@@ -781,16 +780,14 @@ _STAR_CTA_JS = """
 
 
 def star_supporter_card(medium: str = "dashboard") -> FT:
-    """The founding-supporter ask: a gold-bordered, dismissable card. Hydrates from
-    /stars/cta and shows only in a non-neutral mode (relay reachable) and when not
-    dismissed. Rendered on the dashboard (where setup lands) and the onboarding page."""
+    """The GitHub-star ask: a gold-bordered, dismissable card. Hydrates the star link +
+    visibility from /stars/cta (shows only in a non-neutral mode and when not dismissed);
+    the copy is static. Rendered on the dashboard (where setup lands) and onboarding."""
     js = (
         "(function(){"
         "fetch('/stars/cta?medium=" + medium + "').then(function(r){return r.json()}).then(function(d){"
         "if(!d||!d.url||d.dismissed||d.mode==='neutral')return;"
         "var card=document.getElementById('star-supporter-card');if(!card)return;"
-        "var h=document.getElementById('star-card-headline');if(h)h.textContent=d.headline||'Support Celerp';"
-        "var b=document.getElementById('star-card-body');if(b)b.textContent=d.body||'';"
         "var s=document.getElementById('star-card-star');if(s)s.href=d.url;"
         "card.style.display='';"
         "}).catch(function(){});"
@@ -802,16 +799,23 @@ def star_supporter_card(medium: str = "dashboard") -> FT:
     )
     return Div(
         Div(
-            H3("", id="star-card-headline"),
-            P("", id="star-card-body", cls="auth-subtitle"),
+            # Dismiss = X in the top-right corner.
+            Button("×", id="star-card-dismiss", type="button", title="Dismiss", aria_label="Dismiss",
+                   style="position:absolute;top:10px;right:14px;background:none;border:none;"
+                         "font-size:24px;line-height:1;cursor:pointer;color:#999;padding:0"),
+            H3("Star on GitHub", style="margin:0 0 14px"),
+            P("Celerp is new and open source. A GitHub star is how other teams decide we are worth trying."),
+            P("We want the first 100 people that star us to receive a badge for showing their support so "
+              "that if you interact with our celerp repo, other people will know that you were with us from "
+              "the beginning. Thank you for your support."),
             Div(
                 A("Star on GitHub", id="star-card-star", href="#", target="_blank", rel="noopener", cls="btn btn--primary"),
                 A("Claim your badge", href="/stars/claim", cls="btn btn--secondary"),
-                Button("Maybe later", id="star-card-dismiss", type="button", cls="btn btn--ghost"),
-                cls="mt-md",
+                style="display:flex;gap:14px;justify-content:center;flex-wrap:wrap;margin-top:22px",
             ),
             id="star-supporter-card",
-            style="display:none;margin:16px 0;padding:20px;border:1px solid #d4af37;border-radius:10px;text-align:center",
+            style="display:none;position:relative;margin:16px 0;padding:28px 32px;"
+                  "border:1px solid #d4af37;border-radius:10px;text-align:center",
         ),
         Script(js),
     )

--- a/ui/components/shell.py
+++ b/ui/components/shell.py
@@ -765,7 +765,7 @@ _STAR_CTA_JS = """
     if (d.show_count && d.count != null) label = '\\u2605 ' + d.count;  // proof/momentum: star count
     el.textContent = label;
     el.href = d.url;
-    el.title = 'We appreciate your support.';
+    el.title = d.tooltip || 'We appreciate your support.';
     el.style.display = '';
   }).catch(function(){});
   fetch('/stars/badge').then(function(r){return r.json()}).then(function(d){
@@ -780,14 +780,17 @@ _STAR_CTA_JS = """
 
 
 def star_supporter_card(medium: str = "dashboard") -> FT:
-    """The GitHub-star ask: a gold-bordered, dismissable card. Hydrates the star link +
-    visibility from /stars/cta (shows only in a non-neutral mode and when not dismissed);
-    the copy is static. Rendered on the dashboard (where setup lands) and onboarding."""
+    """The GitHub-star ask: a gold-bordered, dismissable card. The COPY (header + body
+    + tooltip) is the relay's single source of truth, hydrated from /stars/cta; the card
+    shows only in a non-neutral mode (relay reachable) and when not dismissed. Rendered
+    on the dashboard (where setup lands) and onboarding."""
     js = (
         "(function(){"
         "fetch('/stars/cta?medium=" + medium + "').then(function(r){return r.json()}).then(function(d){"
         "if(!d||!d.url||d.dismissed||d.mode==='neutral')return;"
         "var card=document.getElementById('star-supporter-card');if(!card)return;"
+        "var h=document.getElementById('star-card-headline');if(h)h.textContent=d.headline||'Star on GitHub';"
+        "var b=document.getElementById('star-card-body');if(b)b.textContent=d.body||'';"  # \\n\\n -> paragraph (pre-line)
         "var s=document.getElementById('star-card-star');if(s)s.href=d.url;"
         "card.style.display='';"
         "}).catch(function(){});"
@@ -803,11 +806,10 @@ def star_supporter_card(medium: str = "dashboard") -> FT:
             Button("×", id="star-card-dismiss", type="button", title="Dismiss", aria_label="Dismiss",
                    style="position:absolute;top:10px;right:14px;background:none;border:none;"
                          "font-size:24px;line-height:1;cursor:pointer;color:#999;padding:0"),
-            H3("Star on GitHub", style="margin:0 0 14px"),
-            P("Celerp is new and open source. A GitHub star is how other teams decide we are worth trying."),
-            P("We want the first 100 people that star us to receive a badge for showing their support so "
-              "that if you interact with our celerp repo, other people will know that you were with us from "
-              "the beginning. Thank you for your support."),
+            # Header + body are filled from the relay CTA; body uses pre-line so the
+            # relay's "\\n\\n" renders as a paragraph break.
+            H3("", id="star-card-headline", style="margin:0 0 14px"),
+            P("", id="star-card-body", style="white-space:pre-line;margin:0"),
             Div(
                 A("Star on GitHub", id="star-card-star", href="#", target="_blank", rel="noopener", cls="btn btn--primary"),
                 A("Claim your badge", href="/stars/claim", cls="btn btn--secondary"),

--- a/ui/components/shell.py
+++ b/ui/components/shell.py
@@ -761,10 +761,13 @@ _STAR_CTA_JS = """
   fetch('/stars/cta?medium=footer').then(function(r){return r.json()}).then(function(d){
     var el = document.getElementById('star-cta');
     if (!el || !d || !d.url) return;
-    var label = d.cta_label || 'Star on GitHub';
-    if (d.mode === 'founding') label = 'Back us early \\u2605';
-    else if (d.show_count && d.count != null) label = '\\u2605 ' + d.count;
-    el.textContent = label; el.href = d.url; el.style.display = '';
+    var label = '\\u2605 Star on GitHub';
+    if (d.show_count && d.count != null) label = '\\u2605 ' + d.count;  // proof/momentum: star count
+    el.textContent = label;
+    el.href = d.url;
+    // Explain the ask on hover; the relay's body carries the founding pitch.
+    el.title = d.body || 'Celerp is open source \\u2014 a GitHub star helps other teams find us.';
+    el.style.display = '';
   }).catch(function(){});
   fetch('/stars/badge').then(function(r){return r.json()}).then(function(d){
     var el = document.getElementById('supporter-badge');
@@ -775,6 +778,43 @@ _STAR_CTA_JS = """
   }).catch(function(){});
 })();
 """
+
+
+def star_supporter_card(medium: str = "dashboard") -> FT:
+    """The founding-supporter ask: a gold-bordered, dismissable card. Hydrates from
+    /stars/cta and shows only in a non-neutral mode (relay reachable) and when not
+    dismissed. Rendered on the dashboard (where setup lands) and the onboarding page."""
+    js = (
+        "(function(){"
+        "fetch('/stars/cta?medium=" + medium + "').then(function(r){return r.json()}).then(function(d){"
+        "if(!d||!d.url||d.dismissed||d.mode==='neutral')return;"
+        "var card=document.getElementById('star-supporter-card');if(!card)return;"
+        "var h=document.getElementById('star-card-headline');if(h)h.textContent=d.headline||'Support Celerp';"
+        "var b=document.getElementById('star-card-body');if(b)b.textContent=d.body||'';"
+        "var s=document.getElementById('star-card-star');if(s)s.href=d.url;"
+        "card.style.display='';"
+        "}).catch(function(){});"
+        "var dz=document.getElementById('star-card-dismiss');"
+        "if(dz)dz.addEventListener('click',function(){"
+        "fetch('/stars/dismiss',{method:'POST'}).then(function(){"
+        "var c=document.getElementById('star-supporter-card');if(c)c.style.display='none';});});"
+        "})();"
+    )
+    return Div(
+        Div(
+            H3("", id="star-card-headline"),
+            P("", id="star-card-body", cls="auth-subtitle"),
+            Div(
+                A("Star on GitHub", id="star-card-star", href="#", target="_blank", rel="noopener", cls="btn btn--primary"),
+                A("Claim your badge", href="/stars/claim", cls="btn btn--secondary"),
+                Button("Maybe later", id="star-card-dismiss", type="button", cls="btn btn--ghost"),
+                cls="mt-md",
+            ),
+            id="star-supporter-card",
+            style="display:none;margin:16px 0;padding:20px;border:1px solid #d4af37;border-radius:10px;text-align:center",
+        ),
+        Script(js),
+    )
 
 
 def base_shell(*content, title: str = "Celerp", nav_active: str = "", companies: list[dict] | None = None, extra_head: list | None = None, lang: str = "en", request=None) -> FT:
@@ -815,7 +855,8 @@ def base_shell(*content, title: str = "Celerp", nav_active: str = "", companies:
                         A(t("msg.powered_by", lang), href="https://www.celerp.com", target="_blank",
                           cls="brand-footer-link"),
                         A("", id="star-cta", href="#", target="_blank", rel="noopener",
-                          cls="brand-footer-link", style="display:none;margin-left:16px"),
+                          cls="brand-footer-link",
+                          style="display:none;margin-left:16px;color:#d4af37;font-weight:600"),
                         cls="brand-footer",
                     ),
                     cls="content-area",

--- a/ui/routes/auth.py
+++ b/ui/routes/auth.py
@@ -22,7 +22,7 @@ from ui.api_client import APIError, bootstrap_status
 from ui.api_client import login as api_login, login_force as api_login_force, logout as api_logout, register as api_register
 from ui.api_client import my_companies as api_my_companies
 from ui.api_client import get_company as api_get_company
-from ui.components.shell import auth_shell, flash
+from ui.components.shell import auth_shell, flash, star_supporter_card
 from ui.config import COOKIE_NAME, REFRESH_COOKIE_NAME, cookie_domain
 from ui.i18n import t, get_lang
 from celerp.config import settings as _settings
@@ -623,44 +623,6 @@ document.querySelector('#restore-btn').closest('form').addEventListener('submit'
     )
 
 
-_STAR_ONBOARDING_JS = """
-(function(){
-  fetch('/stars/cta?medium=onboarding').then(function(r){return r.json()}).then(function(d){
-    if(!d || !d.url || d.dismissed || d.mode==='neutral') return;
-    var card=document.getElementById('star-onboarding-card'); if(!card) return;
-    var h=document.getElementById('star-card-headline'); if(h) h.textContent=d.headline||'Support Celerp';
-    var b=document.getElementById('star-card-body'); if(b) b.textContent=d.body||'';
-    var s=document.getElementById('star-card-star'); if(s) s.href=d.url;
-    card.style.display='';
-  }).catch(function(){});
-  var dz=document.getElementById('star-card-dismiss');
-  if(dz) dz.addEventListener('click', function(){
-    fetch('/stars/dismiss',{method:'POST'}).then(function(){
-      var c=document.getElementById('star-onboarding-card'); if(c) c.style.display='none';
-    });
-  });
-})();
-"""
-
-
-def _star_onboarding_card() -> FT:
-    return Div(
-        Div(
-            H3("", id="star-card-headline"),
-            P("", id="star-card-body", cls="auth-subtitle"),
-            Div(
-                A("Star on GitHub", id="star-card-star", href="#", target="_blank", rel="noopener", cls="btn btn--primary"),
-                A("Claim your badge", href="/stars/claim", cls="btn btn--secondary"),
-                Button("Maybe later", id="star-card-dismiss", type="button", cls="btn btn--ghost"),
-                cls="mt-md",
-            ),
-            id="star-onboarding-card",
-            style="display:none;margin-top:24px;padding:20px;border:1px solid #d4af37;border-radius:10px;text-align:center",
-        ),
-        Script(_STAR_ONBOARDING_JS),
-    )
-
-
 def _onboarding_view() -> FT:
     integrations = [
         ("/onboarding/upload/items", "Import Inventory", "Upload CSV or JSON", "items"),
@@ -692,7 +654,7 @@ def _onboarding_view() -> FT:
             A(t("btn.go_to_dashboard"), href="/dashboard", cls="btn btn--secondary"),
             cls="mt-lg text-center",
         ),
-        _star_onboarding_card(),
+        star_supporter_card("onboarding"),
         cls="onboarding-card",
     )
 

--- a/ui/routes/dashboard.py
+++ b/ui/routes/dashboard.py
@@ -9,7 +9,7 @@ from starlette.responses import RedirectResponse
 
 import ui.api_client as api
 from ui.api_client import APIError
-from ui.components.shell import base_shell, page_header
+from ui.components.shell import base_shell, page_header, star_supporter_card
 from ui.config import get_token as _token, get_role as _get_role
 from ui.components.table import fmt_money as _fmt_money
 from ui.i18n import t, get_lang
@@ -608,6 +608,9 @@ def setup_routes(app):
             values.pop("margin_pct_sub", None)
         return base_shell(
             page_header(t("page.dashboard", lang)),
+            # Founding-supporter ask shown where setup actually lands (admin only;
+            # hidden in neutral/dismissed). Self-hides once dismissed install-wide.
+            *([star_supporter_card("dashboard")] if _ROLE_LEVELS.get(role, 0) >= _ROLE_LEVELS["admin"] else []),
             _kpi_grid(cfg, values, role=role),
             _secondary_kpi_grid(cfg, values, role=role),
             _charts_section(cfg, valuation, ar_aging,


### PR DESCRIPTION
Polish from testing the live relay-connected flow.

## Footer CTA
- **Gold (`#d4af37`) + bold** so it stands out instead of blending into the grey "Powered by Celerp" link.
- **Hover tooltip** explaining the ask (uses the relay's founding pitch).
- **Reworded**: dropped "Back us early" (reads as *investing*) → "★ Star on GitHub" (or "★ <count>" once there are enough stars). The founding pitch now lives in the tooltip + the card, not a label that sounds financial.

## Founding card — fixes "I never saw the card"
Root cause: the card was rendered on `/onboarding`, but setup → `/setup/activating` → **`/dashboard`** (the activating page hard-redirects to the dashboard). So users never hit the page the card was on.

Fix: extracted a shared `star_supporter_card(medium)` in `shell.py` and render it on the **dashboard** (where setup lands) — admin-only, dismissable, hidden in neutral/dismissed mode — and still on `/onboarding`. Dismissing it hides it install-wide (the existing `/stars/dismiss` flag).

## Tests
Render tests updated (gold-footer assertion, parameterized card, dashboard + onboarding). **1016** UI/setup/stars tests pass.

## Note on copy
The card's headline/body come from the **relay** (`build_cta`): "Be a founding supporter / Celerp is new and open source. A GitHub star is how other teams decide we are worth trying, and you would be one of our first 100." That's star-focused (not financial). If "founding supporter" still feels investment-y to you, it's a one-place change on the relay — say the word.