### PR TITLE
feat(ui): nudge notification badge on in-page htmx actions

### DIFF
--- a/ui/components/shell.py
+++ b/ui/components/shell.py
@@ -497,6 +497,9 @@ document.addEventListener('DOMContentLoaded', function() {
   var list = document.getElementById('notif-list');
   if (!badge || !panel) return;
 
+  var NOTIF_FLOOR_MS = 60000;   // cap opportunistic refreshes to ~1/min
+  var lastNotifFetch = 0;
+
   function updateBadge(count) {
     if (count > 0) {
       badge.textContent = count > 99 ? '99+' : count;
@@ -507,6 +510,7 @@ document.addEventListener('DOMContentLoaded', function() {
   }
 
   function loadNotifications() {
+    lastNotifFetch = Date.now();
     fetch('/notifications')
       .then(function(r) { return r.json(); })
       .then(function(data) {
@@ -572,6 +576,18 @@ document.addEventListener('DOMContentLoaded', function() {
 
   // Initial load
   loadNotifications();
+
+  // Opportunistic badge refresh: in-page htmx actions nudge notifications so the
+  // badge doesn't lag while the user stays on one page (the relay can't push -
+  // see M1). The floor caps this at ~1 fetch/min regardless of activity and we
+  // skip hidden tabs, so it adds strictly less load than the per-navigation
+  // fetch and never becomes a poll. loadNotifications is a plain fetch, so this
+  // listener can't re-trigger itself.
+  document.addEventListener('htmx:afterSettle', function() {
+    if (document.visibilityState === 'hidden') return;
+    if (Date.now() - lastNotifFetch < NOTIF_FLOOR_MS) return;
+    loadNotifications();
+  });
 
   // Request browser notification permission
   if (typeof Notification !== 'undefined' && Notification.permission === 'default') {

--- a/ui/components/shell.py
+++ b/ui/components/shell.py
@@ -578,8 +578,8 @@ document.addEventListener('DOMContentLoaded', function() {
   loadNotifications();
 
   // Opportunistic badge refresh: in-page htmx actions nudge notifications so the
-  // badge doesn't lag while the user stays on one page (the relay can't push -
-  // see M1). The floor caps this at ~1 fetch/min regardless of activity and we
+  // badge doesn't lag while the user stays on one page (the relay can't push)
+  // The floor caps this at ~1 fetch/min regardless of activity and we
   // skip hidden tabs, so it adds strictly less load than the per-navigation
   // fetch and never becomes a poll. loadNotifications is a plain fetch, so this
   // listener can't re-trigger itself.


### PR DESCRIPTION
When real-time notification push isn't available (e.g. when running over the cloud relay, where the muxed SSE stream is suppressed), the shell refreshes notifications only on **full-page navigation** (`loadNotifications()` on every page load, since nav is plain `<a href>`, no hx-boost) and on **bell-open** (`toggleNotifPanel` re-fetches, always fresh). The gap: the badge count can lag while a user stays on **one page** doing in-page htmx work (search, filters, inline edits) without navigating.