### PR TITLE
Bulk-attach result filtering + file-name links in activity

### DIFF
--- a/celerp/events/schemas.py
+++ b/celerp/events/schemas.py
@@ -900,6 +900,7 @@ class EntityFileTagged(BaseModel):
     entity_type: str
     file_id: str
     document_tag: str
+    filename: str | None = None  # captured at emit for the activity log
 
 
 class EntityFileDescriptionUpdated(BaseModel):
@@ -907,18 +908,21 @@ class EntityFileDescriptionUpdated(BaseModel):
     entity_type: str
     file_id: str
     description: str
+    filename: str | None = None  # captured at emit for the activity log
 
 
 class EntityFileDeleted(BaseModel):
     entity_id: str
     entity_type: str
     file_id: str
+    filename: str | None = None  # captured at emit so the log keeps the name post-delete
 
 
 class EntityFileHeroSet(BaseModel):
     entity_id: str
     entity_type: str  # always "item"
     file_id: str  # the file to mark as hero (must be an image MIME)
+    filename: str | None = None  # captured at emit for the activity log
 
 
 EVENT_SCHEMA_MAP: dict[str, type[BaseModel]] = {

--- a/default_modules/celerp-contacts/celerp_contacts/routes.py
+++ b/default_modules/celerp-contacts/celerp_contacts/routes.py
@@ -299,14 +299,14 @@ async def tag_contact_file(
     row = await session.get(Projection, {"company_id": company_id, "entity_id": contact_id})
     if row is None or row.entity_type != "contact":
         raise HTTPException(status_code=404, detail="Not found")
-    _get_contact_file(row.state.get("files", []), file_id)
+    f = _get_contact_file(row.state.get("files", []), file_id)
     await emit_event(
         session,
         company_id=company_id,
         entity_id=contact_id,
         entity_type="contact",
         event_type="crm.contact.file_tagged",
-        data={"entity_id": contact_id, "entity_type": "contact", "file_id": file_id, "document_tag": document_tag},
+        data={"entity_id": contact_id, "entity_type": "contact", "file_id": file_id, "document_tag": document_tag, "filename": f.get("filename")},
         actor_id=user.id,
         location_id=None,
         source="api",
@@ -330,14 +330,14 @@ async def update_contact_file_description(
     row = await session.get(Projection, {"company_id": company_id, "entity_id": contact_id})
     if row is None or row.entity_type != "contact":
         raise HTTPException(status_code=404, detail="Not found")
-    _get_contact_file(row.state.get("files", []), file_id)
+    f = _get_contact_file(row.state.get("files", []), file_id)
     await emit_event(
         session,
         company_id=company_id,
         entity_id=contact_id,
         entity_type="contact",
         event_type="crm.contact.file_description_updated",
-        data={"entity_id": contact_id, "entity_type": "contact", "file_id": file_id, "description": description},
+        data={"entity_id": contact_id, "entity_type": "contact", "file_id": file_id, "description": description, "filename": f.get("filename")},
         actor_id=user.id,
         location_id=None,
         source="api",
@@ -391,7 +391,7 @@ async def delete_contact_file(
     row = await session.get(Projection, {"company_id": company_id, "entity_id": contact_id})
     if row is None or row.entity_type != "contact":
         raise HTTPException(status_code=404, detail="Not found")
-    _get_contact_file(row.state.get("files", []), file_id)
+    f = _get_contact_file(row.state.get("files", []), file_id)
 
     entry = await emit_event(
         session,
@@ -399,7 +399,7 @@ async def delete_contact_file(
         entity_id=contact_id,
         entity_type="contact",
         event_type="crm.contact.file_deleted",
-        data={"entity_id": contact_id, "entity_type": "contact", "file_id": file_id},
+        data={"entity_id": contact_id, "entity_type": "contact", "file_id": file_id, "filename": f.get("filename")},
         actor_id=user.id,
         location_id=None,
         source="api",

--- a/default_modules/celerp-docs/celerp_docs/routes.py
+++ b/default_modules/celerp-docs/celerp_docs/routes.py
@@ -3955,14 +3955,14 @@ async def tag_doc_file(
     session: AsyncSession = Depends(get_session),
 ) -> dict:
     row = await _get_doc(session, company_id, entity_id)
-    _get_doc_file(row.state.get("files", []), file_id)
+    f = _get_doc_file(row.state.get("files", []), file_id)
     await emit_event(
         session,
         company_id=company_id,
         entity_id=entity_id,
         entity_type="doc",
         event_type="doc.file_tagged",
-        data={"entity_id": entity_id, "entity_type": "doc", "file_id": file_id, "document_tag": document_tag},
+        data={"entity_id": entity_id, "entity_type": "doc", "file_id": file_id, "document_tag": document_tag, "filename": f.get("filename")},
         actor_id=user.id,
         location_id=None,
         source="api",
@@ -3984,14 +3984,14 @@ async def update_doc_file_description(
     session: AsyncSession = Depends(get_session),
 ) -> dict:
     row = await _get_doc(session, company_id, entity_id)
-    _get_doc_file(row.state.get("files", []), file_id)
+    f = _get_doc_file(row.state.get("files", []), file_id)
     await emit_event(
         session,
         company_id=company_id,
         entity_id=entity_id,
         entity_type="doc",
         event_type="doc.file_description_updated",
-        data={"entity_id": entity_id, "entity_type": "doc", "file_id": file_id, "description": description},
+        data={"entity_id": entity_id, "entity_type": "doc", "file_id": file_id, "description": description, "filename": f.get("filename")},
         actor_id=user.id,
         location_id=None,
         source="api",
@@ -4012,14 +4012,14 @@ async def delete_doc_file(
     session: AsyncSession = Depends(get_session),
 ) -> dict:
     row = await _get_doc(session, company_id, entity_id)
-    _get_doc_file(row.state.get("files", []), file_id)
+    f = _get_doc_file(row.state.get("files", []), file_id)
     entry = await emit_event(
         session,
         company_id=company_id,
         entity_id=entity_id,
         entity_type="doc",
         event_type="doc.file_deleted",
-        data={"entity_id": entity_id, "entity_type": "doc", "file_id": file_id},
+        data={"entity_id": entity_id, "entity_type": "doc", "file_id": file_id, "filename": f.get("filename")},
         actor_id=user.id,
         location_id=None,
         source="api",

--- a/default_modules/celerp-inventory/celerp_inventory/routes_attachments.py
+++ b/default_modules/celerp-inventory/celerp_inventory/routes_attachments.py
@@ -430,14 +430,14 @@ async def tag_item_file(
     row = await session.get(Projection, {"company_id": company_id, "entity_id": entity_id})
     if row is None:
         raise HTTPException(status_code=404, detail="Item not found")
-    _get_item_file(row.state.get("files", []), file_id)
+    f = _get_item_file(row.state.get("files", []), file_id)
     await emit_event(
         session,
         company_id=company_id,
         entity_id=entity_id,
         entity_type="item",
         event_type="item.file.tagged",
-        data={"entity_id": entity_id, "entity_type": "item", "file_id": file_id, "document_tag": document_tag},
+        data={"entity_id": entity_id, "entity_type": "item", "file_id": file_id, "document_tag": document_tag, "filename": f.get("filename")},
         actor_id=user.id,
         location_id=None,
         source="api",
@@ -461,14 +461,14 @@ async def update_item_file_description(
     row = await session.get(Projection, {"company_id": company_id, "entity_id": entity_id})
     if row is None:
         raise HTTPException(status_code=404, detail="Item not found")
-    _get_item_file(row.state.get("files", []), file_id)
+    f = _get_item_file(row.state.get("files", []), file_id)
     await emit_event(
         session,
         company_id=company_id,
         entity_id=entity_id,
         entity_type="item",
         event_type="item.file.description_updated",
-        data={"entity_id": entity_id, "entity_type": "item", "file_id": file_id, "description": description},
+        data={"entity_id": entity_id, "entity_type": "item", "file_id": file_id, "description": description, "filename": f.get("filename")},
         actor_id=user.id,
         location_id=None,
         source="api",
@@ -501,7 +501,7 @@ async def set_item_file_hero(
         entity_id=entity_id,
         entity_type="item",
         event_type="item.file.hero_set",
-        data={"entity_id": entity_id, "entity_type": "item", "file_id": file_id},
+        data={"entity_id": entity_id, "entity_type": "item", "file_id": file_id, "filename": target.get("filename")},
         actor_id=user.id,
         location_id=None,
         source="api",
@@ -523,14 +523,14 @@ async def delete_item_file(
     row = await session.get(Projection, {"company_id": company_id, "entity_id": entity_id})
     if row is None:
         raise HTTPException(status_code=404, detail="Item not found")
-    _get_item_file(row.state.get("files", []), file_id)
+    f = _get_item_file(row.state.get("files", []), file_id)
     await emit_event(
         session,
         company_id=company_id,
         entity_id=entity_id,
         entity_type="item",
         event_type="item.file.deleted",
-        data={"entity_id": entity_id, "entity_type": "item", "file_id": file_id},
+        data={"entity_id": entity_id, "entity_type": "item", "file_id": file_id, "filename": f.get("filename")},
         actor_id=user.id,
         location_id=None,
         source="api",

--- a/tests/test_browser/test_bulk_attach_filter.py
+++ b/tests/test_browser/test_bulk_attach_filter.py
@@ -1,0 +1,66 @@
+# Copyright (c) 2026 Noah Severs. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-Proprietary
+"""Browser test for M5 — bulk-attach result matched/unmatched filter.
+
+Uploads a ZIP with one SKU-matching file (→ ok) and one non-matching file
+(→ unmatched), then exercises the client-side filter pills (All / Matched /
+Unmatched) and asserts rows show/hide accordingly.
+"""
+from __future__ import annotations
+
+import io
+import zipfile
+
+import pytest
+
+pytestmark = pytest.mark.browser
+
+
+def _make_zip(names: list[str]) -> bytes:
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        for n in names:
+            # minimal JPEG-ish bytes; store_upload only needs a readable blob
+            zf.writestr(n, b"\xff\xd8\xff\xe0" + b"fake-image-bytes")
+    return buf.getvalue()
+
+
+def test_bulk_attach_result_status_filter(page, fresh_company, ui_server, tmp_path):
+    api = fresh_company
+
+    # Seed one item so a file matches by SKU.
+    sku = "BULKFILT1"
+    r = api.post("/items", json={"sku": sku, "name": "Filter Test", "quantity": 1, "sell_by": "piece"})
+    assert r.status_code in (200, 201), f"item create failed: {r.text}"
+
+    # ZIP: one matching (→ ok) + one non-matching (→ unmatched).
+    zip_path = tmp_path / "attach.zip"
+    zip_path.write_bytes(_make_zip([f"{sku}.jpg", "NOSUCHSKU.jpg"]))
+
+    page.goto(f"{ui_server}/settings/inventory?tab=bulk-attach", wait_until="domcontentloaded")
+    page.locator("input[type='file']").first.set_input_files(str(zip_path))
+    page.locator("form:has(input[type='file']) button[type='submit']").first.click()
+
+    # Result rows render after the HTMX swap.
+    page.wait_for_selector("#bulk-attach-result tbody tr", timeout=15000)
+    ok_row = page.locator("#bulk-attach-result tbody tr[data-status='ok']")
+    un_row = page.locator("#bulk-attach-result tbody tr[data-status='unmatched']")
+    assert ok_row.count() == 1, "expected one matched (ok) row"
+    assert un_row.count() == 1, "expected one unmatched row"
+
+    # Default: everything visible.
+    assert ok_row.is_visible() and un_row.is_visible()
+
+    # Filter → Unmatched: only the unmatched row remains.
+    page.locator(".bulk-filter-btn[data-filter='unmatched']").click()
+    assert un_row.is_visible()
+    assert ok_row.is_hidden()
+
+    # Filter → Matched: only the ok row remains.
+    page.locator(".bulk-filter-btn[data-filter='ok']").click()
+    assert ok_row.is_visible()
+    assert un_row.is_hidden()
+
+    # Filter → All: both visible again.
+    page.locator(".bulk-filter-btn[data-filter='all']").click()
+    assert ok_row.is_visible() and un_row.is_visible()

--- a/tests/test_browser/test_file_activity.py
+++ b/tests/test_browser/test_file_activity.py
@@ -1,0 +1,30 @@
+# Copyright (c) 2026 Noah Severs. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-Proprietary
+"""Browser test for M6 — file events show the filename as a download link in
+the item's Activity tab."""
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.browser
+
+
+def test_item_activity_shows_file_link(page, fresh_company, ui_server):
+    api = fresh_company
+
+    r = api.post("/items", json={"sku": "FILEACT1", "name": "File Act", "quantity": 1, "sell_by": "piece"})
+    assert r.status_code in (200, 201), f"item create failed: {r.text}"
+    item_id = r.json()["id"]
+
+    r = api.post(
+        f"/items/{item_id}/files",
+        files={"file": ("photo.jpg", b"\xff\xd8\xff\xe0image-bytes", "image/jpeg")},
+    )
+    assert r.status_code == 200, f"attach failed: {r.text}"
+
+    page.goto(f"{ui_server}/inventory/{item_id}?tab=activity", wait_until="domcontentloaded")
+    page.wait_for_selector("text=File attached", timeout=15000)
+
+    link = page.locator(f"a[href*='/items/{item_id}/files/'][href$='/download']")
+    assert link.count() >= 1, "expected a file download link in the activity row"
+    assert "photo.jpg" in link.first.inner_text()

--- a/tests/test_entity_files.py
+++ b/tests/test_entity_files.py
@@ -179,6 +179,59 @@ async def test_doc_file_upload(client):
     assert any(f.get("id") == fid for f in files), f"File {fid} not in {files}"
 
 
+async def _ledger_by_type(client, h: dict, entity_id: str) -> dict:
+    r = await client.get("/ledger", params={"entity_id": entity_id, "limit": 200}, headers=h)
+    assert r.status_code == 200, r.text
+    out: dict[str, list[dict]] = {}
+    for e in r.json()["items"]:
+        out.setdefault(e["event_type"], []).append(e)
+    return out
+
+
+@pytest.mark.asyncio
+async def test_contact_file_events_capture_filename(client):
+    """M6: contact file events keep the filename in the activity log (incl. delete)."""
+    h = await _headers(client)
+    cid = (await client.post("/crm/contacts", json={"name": "Eve"}, headers=h)).json()["id"]
+    fid = (await client.post(f"/crm/contacts/{cid}/files",
+                             files={"file": ("evidence.pdf", _SMALL_PDF, "application/pdf")},
+                             headers=h)).json()["id"]
+    assert (await client.post(f"/crm/contacts/{cid}/files/{fid}/tag",
+                              data={"document_tag": "contracts"}, headers=h)).status_code == 200
+    assert (await client.patch(f"/crm/contacts/{cid}/files/{fid}/description",
+                               data={"description": "signed"}, headers=h)).status_code == 200
+    assert (await client.delete(f"/crm/contacts/{cid}/files/{fid}", headers=h)).status_code == 200
+
+    by_type = await _ledger_by_type(client, h, cid)
+    fname = by_type["crm.contact.file_attached"][0]["data"].get("filename")
+    assert fname, "attached event must carry the filename"
+    for et in ("crm.contact.file_tagged", "crm.contact.file_description_updated", "crm.contact.file_deleted"):
+        assert et in by_type, f"missing event {et}"
+        assert by_type[et][0]["data"].get("filename") == fname, f"{et} did not capture the filename"
+
+
+@pytest.mark.asyncio
+async def test_doc_file_events_capture_filename(client):
+    """M6: doc file events keep the filename in the activity log (incl. delete)."""
+    h = await _headers(client)
+    doc_id = await _create_draft_doc(client, h)
+    fid = (await client.post(f"/docs/{doc_id}/files",
+                             files={"file": ("scan.pdf", _SMALL_PDF, "application/pdf")},
+                             headers=h)).json()["id"]
+    assert (await client.patch(f"/docs/{doc_id}/files/{fid}/tag",
+                               data={"document_tag": "scans"}, headers=h)).status_code == 200
+    assert (await client.patch(f"/docs/{doc_id}/files/{fid}/description",
+                               data={"description": "page 1"}, headers=h)).status_code == 200
+    assert (await client.delete(f"/docs/{doc_id}/files/{fid}", headers=h)).status_code == 200
+
+    by_type = await _ledger_by_type(client, h, doc_id)
+    fname = by_type["doc.file_attached"][0]["data"].get("filename")
+    assert fname, "attached event must carry the filename"
+    for et in ("doc.file_tagged", "doc.file_description_updated", "doc.file_deleted"):
+        assert et in by_type, f"missing event {et}"
+        assert by_type[et][0]["data"].get("filename") == fname, f"{et} did not capture the filename"
+
+
 @pytest.mark.asyncio
 async def test_doc_file_delete(client):
     h = await _headers(client)

--- a/tests/test_file_activity.py
+++ b/tests/test_file_activity.py
@@ -1,0 +1,122 @@
+# Copyright (c) 2026 Noah Severs
+# SPDX-License-Identifier: LicenseRef-Proprietary
+"""M6 — file events in the activity log carry the filename and render as a link.
+
+Backend: attach / tag / describe / set-hero / delete a file and assert each
+item.file.* ledger event captures the filename.
+Render: activity_table shows the nice labels + the filename linked to the file's
+download URL, with no live link once the file is deleted.
+"""
+from __future__ import annotations
+
+import pytest
+from fasthtml.common import to_xml
+
+from ui.components.activity import activity_table
+
+
+async def _token(client) -> str:
+    r = await client.post(
+        "/auth/register",
+        json={"company_name": "Files Co", "email": "files@acme.com", "name": "Admin", "password": "pw"},
+    )
+    return r.json()["access_token"]
+
+
+async def _seed(client, headers) -> str:
+    r = await client.post(
+        "/items",
+        json={"sku": "FILESKU", "name": "Has Files", "quantity": 1, "sell_by": "piece"},
+        headers=headers,
+    )
+    assert r.status_code == 200, r.text
+    return r.json()["id"]
+
+
+@pytest.mark.asyncio
+async def test_file_events_capture_filename(client):
+    h = {"Authorization": f"Bearer {await _token(client)}"}
+    item_id = await _seed(client, h)
+
+    r = await client.post(
+        f"/items/{item_id}/files",
+        files={"file": ("photo.jpg", b"\xff\xd8\xff\xe0image-bytes", "image/jpeg")},
+        headers=h,
+    )
+    assert r.status_code == 200, r.text
+    file_id = r.json()["file_id"]
+
+    assert (await client.post(f"/items/{item_id}/files/{file_id}/tag",
+                              data={"document_tag": "certificates"}, headers=h)).status_code == 200
+    assert (await client.patch(f"/items/{item_id}/files/{file_id}/description",
+                               data={"description": "front view"}, headers=h)).status_code == 200
+    assert (await client.post(f"/items/{item_id}/files/{file_id}/hero", headers=h)).status_code == 200
+    assert (await client.delete(f"/items/{item_id}/files/{file_id}", headers=h)).status_code == 204
+
+    r = await client.get("/ledger", params={"entity_id": item_id, "limit": 200}, headers=h)
+    assert r.status_code == 200, r.text
+    by_type: dict[str, list[dict]] = {}
+    for e in r.json()["items"]:
+        by_type.setdefault(e["event_type"], []).append(e)
+
+    fname = by_type["item.file.attached"][0]["data"].get("filename")
+    assert fname, "attached event must carry the filename"
+    for et in ("item.file.tagged", "item.file.description_updated",
+               "item.file.hero_set", "item.file.deleted"):
+        assert et in by_type, f"missing event {et}"
+        assert by_type[et][0]["data"].get("filename") == fname, f"{et} did not capture the filename"
+
+
+# file event types per entity (attached / tagged / description / deleted) — the renderer
+# handles all three identically, keyed by entity_type for the download URL segment.
+_FILE_EVENTS = {
+    "item": ("item.file.attached", "item.file.tagged",
+             "item.file.description_updated", "item.file.deleted"),
+    "contact": ("crm.contact.file_attached", "crm.contact.file_tagged",
+                "crm.contact.file_description_updated", "crm.contact.file_deleted"),
+    "doc": ("doc.file_attached", "doc.file_tagged",
+            "doc.file_description_updated", "doc.file_deleted"),
+}
+_ENTITY_SEG = {"item": "items", "contact": "contacts", "doc": "docs"}
+
+
+def _file_entry(event_type: str, entity_type: str, entity_id: str, file_id: str, **extra) -> dict:
+    return {
+        "id": f"e-{event_type}",
+        "event_type": event_type,
+        "entity_id": entity_id,
+        "ts": "2026-06-23T00:00:00+00:00",
+        "data": {"entity_id": entity_id, "entity_type": entity_type,
+                 "file_id": file_id, "filename": "photo.jpg", **extra},
+    }
+
+
+@pytest.mark.parametrize("entity_type", ["item", "contact", "doc"])
+def test_file_event_activity_render_labels_and_links(entity_type):
+    attached, tagged, described, deleted = _FILE_EVENTS[entity_type]
+    seg, entity_id, file_id = _ENTITY_SEG[entity_type], f"{entity_type}:abc", "file-123"
+    ledger = [
+        _file_entry(attached, entity_type, entity_id, file_id),
+        _file_entry(tagged, entity_type, entity_id, file_id, document_tag="certificates"),
+        _file_entry(described, entity_type, entity_id, file_id, description="front view"),
+        _file_entry(deleted, entity_type, entity_id, file_id),
+    ]
+    html = to_xml(activity_table(ledger, max_display=50))
+    for label in ("File attached", "File tagged", "File description updated", "File removed"):
+        assert label in html, f"{entity_type}: missing label {label}"
+    assert "photo.jpg" in html
+    assert f"/{seg}/{entity_id}/files/{file_id}/download" in html, f"{entity_type}: missing download link"
+
+
+@pytest.mark.parametrize("entity_type", ["item", "contact", "doc"])
+def test_deleted_file_event_has_no_live_link(entity_type):
+    _, _, _, deleted = _FILE_EVENTS[entity_type]
+    entity_id, file_id = f"{entity_type}:abc", "file-123"
+    html = to_xml(activity_table([_file_entry(deleted, entity_type, entity_id, file_id)], max_display=10))
+    assert "photo.jpg" in html, f"{entity_type}: deleted event should still name the file"
+    assert "/download" not in html, f"{entity_type}: a deleted file must not render a live link"
+
+
+def test_item_hero_event_label():
+    html = to_xml(activity_table([_file_entry("item.file.hero_set", "item", "item:abc", "f1")], max_display=10))
+    assert "Hero image set" in html

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -13754,3 +13754,36 @@ async def test_item_files_section_applies_tag_filter(ui_client):
     body = r.text
     assert "gia-report" in body, "the certificates file should be shown"
     assert "front-photo" not in body, "the product_images file must be filtered out"
+
+
+@pytest.mark.asyncio
+async def test_bulk_attach_result_has_status_filters(ui_client):
+    """M5: the bulk-attach result tags each row with data-status and renders
+    All/Matched/Unmatched/Errors filter pills wired to celerpBulkFilter()."""
+    fake_result = {
+        "matched": 1,
+        "unmatched": 1,
+        "errors": [],
+        "report": [
+            {"sku": "SKU-OK", "file": "SKU-OK.jpg", "status": "ok", "tag": "", "is_hero": True},
+            {"sku": "NOPE", "file": "NOPE.jpg", "status": "unmatched"},
+        ],
+    }
+    with patch("ui.api_client.bulk_attach", new=AsyncMock(return_value=fake_result)):
+        r = await ui_client.post(
+            "/settings/bulk-attach",
+            cookies=_authed(),
+            files={"file": ("archive.zip", b"PK\x03\x04stub", "application/zip")},
+        )
+    assert r.status_code == 200, r.text
+    html = r.text
+    # Each row carries its status for the client-side filter.
+    assert 'data-status="ok"' in html
+    assert 'data-status="unmatched"' in html
+    # Filter pills are present, wired to the toggle, and only for statuses that occur.
+    assert "bulk-filter-btn" in html
+    assert "celerpBulkFilter" in html
+    assert 'data-filter="all"' in html
+    assert 'data-filter="ok"' in html
+    assert 'data-filter="unmatched"' in html
+    assert 'data-filter="error"' not in html  # no errors in this batch → no Errors pill

--- a/ui/components/activity.py
+++ b/ui/components/activity.py
@@ -75,12 +75,58 @@ EVENT_TYPE_LABELS: dict[str, str] = {
 }
 
 
+# File events (item.file.*, doc.file_*, crm.contact.file_*) share one label set and one
+# renderer across all entity types, keyed by the operation suffix (attached/tagged/...).
+_FILE_ENTITY_SEG = {"item": "items", "contact": "contacts", "doc": "docs"}
+_FILE_OP_LABELS = {
+    "attached": "File attached",
+    "tagged": "File tagged",
+    "deleted": "File removed",
+    "description_updated": "File description updated",
+    "hero_set": "Hero image set",
+}
+
+
+def _is_file_event(event_type: str) -> bool:
+    """True for any entity's file event (item.file.*, doc.file_*, crm.contact.file_*)."""
+    return ".file." in event_type or ".file_" in event_type
+
+
+def _file_op(event_type: str) -> str:
+    """The operation of a file event (attached/tagged/deleted/...), entity-agnostic."""
+    return event_type.split("file")[-1].lstrip("._")
+
+
+def _title_case(event_type: str) -> str:
+    return event_type.replace(".", " ").replace("_", " ").title()
+
+
 def event_label(event_type: str) -> str:
     """Human label for a ledger event_type string."""
-    return EVENT_TYPE_LABELS.get(
-        event_type,
-        event_type.replace(".", " ").replace("_", " ").title(),
-    )
+    if _is_file_event(event_type):
+        return _FILE_OP_LABELS.get(_file_op(event_type), _title_case(event_type))
+    return EVENT_TYPE_LABELS.get(event_type, _title_case(event_type))
+
+
+def _file_event_detail(e: dict, data: dict, event_type: str):
+    """Detail cell for file events (item/contact/doc): the filename linked to the
+    file's download URL — except deletions, where the file is gone (name only).
+    Old events that predate the captured filename fall back to a short file id."""
+    op = _file_op(event_type)
+    file_id = str(data.get("file_id") or "")
+    entity_id = str(e.get("entity_id") or "")
+    filename = data.get("filename") or (file_id[:8] if file_id else "file")
+    seg = _FILE_ENTITY_SEG.get(str(data.get("entity_type") or ""))
+    if op == "deleted" or not (seg and file_id and entity_id):
+        name_ft = filename
+    else:
+        name_ft = A(filename, href=f"/{seg}/{entity_id}/files/{file_id}/download", cls="table-link")
+    suffix = ""
+    if op == "tagged" and data.get("document_tag"):
+        suffix = f" → {data['document_tag']}"
+    elif op == "description_updated" and data.get("description"):
+        suffix = f": {data['description']}"
+    return Span(name_ft, suffix) if suffix else name_ft
 
 
 def relative_time(ts: str) -> str:
@@ -952,6 +998,9 @@ def activity_table(ledger: list[dict], *, title: str = "Recent Activity",
         content = A(display_text, href=url, cls="table-link") if url else display_text
 
         data = e.get("data") or {}
+        # File events (any entity): filename linked to the file (name only once deleted).
+        if _is_file_event(raw_type) and isinstance(data, dict):
+            return [_assemble(e, content, _file_event_detail(e, data, raw_type), "")]
         detail = detail_from_entry(data, raw_type, currency) if isinstance(data, dict) else ""
 
         # Drop rows that carried only noise (empty→empty field changes with no other detail)

--- a/ui/routes/settings.py
+++ b/ui/routes/settings.py
@@ -1560,24 +1560,39 @@ def setup_routes(app):
             return Div(P(str(e.detail), cls="error-banner"), id="bulk-attach-result")
 
         report = result.get("report", [])
+        n_matched = result.get("matched", 0)
+        n_unmatched = result.get("unmatched", 0)
+        n_errors = len(result.get("errors", []))
 
         def _row(r: dict) -> FT:
             status = r.get("status", "")
             cls = {"ok": "status-ok", "unmatched": "status-warn", "error": "status-error"}.get(status, "")
             hero_icon = "⭐" if r.get("is_hero") else ""
+            # data-status lets the client-side filter (celerpBulkFilter) show/hide rows.
             return Tr(
                 Td(r.get("sku", "")),
                 Td(r.get("file", "")),
                 Td(Span(status, cls=f"badge badge--{cls}") if cls else Span(status)),
                 Td(r.get("tag", "") or r.get("detail", "")),
                 Td(hero_icon, style="text-align:center;"),
+                data_status=status or "unknown",
+            )
+
+        def _filter_btn(label: str, value: str, flash_cls: str, active: bool = False) -> FT:
+            return Button(
+                label,
+                type="button",
+                cls=f"flash {flash_cls} bulk-filter-btn{' is-active' if active else ''}",
+                data_filter=value,
+                onclick=f"celerpBulkFilter('{value}', this)",
             )
 
         return Div(
             Div(
-                Span(f"✓ {result.get('matched', 0)} matched", cls="flash flash--success"),
-                Span(f"⚠ {result.get('unmatched', 0)} unmatched", cls="flash flash--warning") if result.get("unmatched") else "",
-                Span(f"✕ {len(result.get('errors', []))} errors", cls="flash flash--error") if result.get("errors") else "",
+                _filter_btn(f"All {len(report)}", "all", "flash--muted", active=True),
+                _filter_btn(f"✓ {n_matched} matched", "ok", "flash--success"),
+                _filter_btn(f"⚠ {n_unmatched} unmatched", "unmatched", "flash--warning") if n_unmatched else "",
+                _filter_btn(f"✕ {n_errors} errors", "error", "flash--error") if n_errors else "",
                 cls="bulk-result-summary",
             ),
             Table(
@@ -4139,6 +4154,22 @@ def _import_history_tab(batches: list[dict]) -> FT:
 def _bulk_attach_tab() -> FT:
     """Bulk Attachments tab - upload a ZIP of files named by SKU."""
     return Div(
+        # Client-side filter for the result report: the summary pills (rendered by the
+        # /settings/bulk-attach response) call this to show only matched/unmatched/error rows.
+        Style(
+            ".bulk-filter-btn{cursor:pointer;border:none;}"
+            ".bulk-filter-btn.is-active{outline:2px solid currentColor;outline-offset:1px;}"
+        ),
+        Script(
+            "function celerpBulkFilter(status, btn){"
+            "var root=document.getElementById('bulk-attach-result');if(!root)return;"
+            "var rows=root.querySelectorAll('tbody tr');"
+            "for(var i=0;i<rows.length;i++){var s=rows[i].getAttribute('data-status');"
+            "rows[i].style.display=(status==='all'||s===status)?'':'none';}"
+            "var btns=root.querySelectorAll('.bulk-filter-btn');"
+            "for(var j=0;j<btns.length;j++){btns[j].classList.remove('is-active');}"
+            "if(btn){btn.classList.add('is-active');}}"
+        ),
         H3(t("page.bulk_attach_images_documents"), cls="section-title"),
         Div(
             H4(t("page.file_naming_convention")),


### PR DESCRIPTION
## Summary

Two independent UX improvements.

**1. Bulk-attach result — filter by matched / unmatched.**
After a bulk attach, the result was one long mixed list of matched / unmatched / error
files with no way to narrow it. The summary counts are now clickable **filter pills**
(All / Matched / Unmatched / Errors) that show/hide rows client-side. Each result row
carries its status; no backend change.

**2. File events show the file name + a download link in the activity log.**
Across **items, contacts, and docs**, file events (attach / remove / tag /
description-update / hero-set) now show *which* file — the **filename linked to the file's
download URL**, and name-only once the file is deleted (the file is gone). File events that
previously carried only a file id now capture the filename **at emit time** (new optional
field — backward-compatible with already-stored events), and all file events get readable
labels. The rendering is shared/DRY: one operation→label map and one entity→URL-segment map
cover all three entity types.

## Changes

- **Bulk attach** (`ui/routes/settings.py`): `data-status` on each row + filter pills + a
  small client-side toggle.
- **Event schemas** (`celerp/events/schemas.py`): optional `filename` on the file `tagged`
  / `description_updated` / `deleted` / `hero_set` events.
- **Emit sites** (inventory / contacts / docs routes): capture the filename when emitting
  those events.
- **Activity component** (`ui/components/activity.py`): file-event labels +
  filename-as-download-link rendering, generalized across item/contact/doc.

## Tests

- **Unit:** bulk-attach result markup (status tags + pills); file-event emit captures the
  filename (item, contact, doc); activity render parametrized over item/contact/doc, incl.
  deleted → no live link.
- **Browser:** bulk-attach filter toggles row visibility; item Activity tab shows the file
  download link.
- Full unit + browser suites pass locally; no regressions.


## Contributor License Agreement

By submitting this pull request you acknowledge that it cannot be merged into an official Celerp
repository until the required **CLA acceptance** has been completed. If you have not already accepted the
current version of [`CLA.md`](https://github.com/celerp/celerp/blob/main/CLA.md), the CLA bot will comment
with the exact acceptance phrase. Posting that phrase from your authenticated GitHub account records your
acceptance of the current version of `CLA.md`.

- [X] I have read [`CONTRIBUTING.md`](https://github.com/celerp/celerp/blob/main/CONTRIBUTING.md) and
      [`CLA.md`](https://github.com/celerp/celerp/blob/main/CLA.md), and I will complete CLA acceptance
      through the CLA workflow when prompted.

## Checklist

- [X] Tests added or updated, and the relevant suites pass locally
- [X] License headers are correct for the paths touched (see `LICENSING.md`; enforced by `scripts/licenses.py`)
- [X] No new self-attribution or tool watermarks in code, commits, or docs
