### PR TITLE
feat: feature-request flow via Discussions (Ideas)

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/ideas.yml
+++ b/.github/DISCUSSION_TEMPLATE/ideas.yml
@@ -1,0 +1,78 @@
+title: "Idea: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: >
+        Thanks for helping shape Celerp! Please skim
+        [existing ideas](https://github.com/celerp/celerp/discussions/categories/ideas) first, and
+        👍 the ones you'd like to see - upvotes help us prioritize.
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does this solve?
+      description: The use case or pain point. What are you trying to do, and where does Celerp get in the way today?
+      placeholder: "When I ..., I have to ... because ..."
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: What you'd like Celerp to do. Rough is fine.
+    validations:
+      required: true
+  - type: textarea
+    id: so_that
+    attributes:
+      label: So that…
+      description: The outcome this unlocks - the real benefit. Finish the sentence so we understand the "why".
+      placeholder: "...so that I can ..."
+    validations:
+      required: true
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      description: Which part of Celerp does this touch?
+      options:
+        - Inventory
+        - Invoicing / documents
+        - Purchasing
+        - Manufacturing
+        - Accounting
+        - Contacts / CRM
+        - Reporting
+        - Connectors / integrations / API
+        - Setup / admin / permissions
+        - Other / not sure
+    validations:
+      required: false
+  - type: input
+    id: page
+    attributes:
+      label: Related page or link
+      description: If this adds to or changes a specific Celerp page, paste its URL or path (e.g. `/inventory`). A link to a mockup or example elsewhere works too. Optional.
+      placeholder: "e.g. /inventory"
+    validations:
+      required: false
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other ways you've tried to solve this, or workarounds you use today.
+    validations:
+      required: false
+  - type: textarea
+    id: anything_else
+    attributes:
+      label: Anything else?
+      description: Mockups, examples from other tools, or any extra context.
+    validations:
+      required: false
+  - type: markdown
+    attributes:
+      value: >
+        Thanks for the idea! If Celerp is useful to you, a ⭐ on
+        [GitHub](https://github.com/celerp/celerp) genuinely helps others find it - and early
+        supporters can claim a founding-supporter badge.

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,13 +1,14 @@
 name: Bug Report
 description: Report a bug to help us improve Celerp
 title: "Bug: "
-labels: [bug, triage]
+labels: [bug]
 body:
   - type: markdown
     attributes:
       value: >
-        **Have a question or feature request?** Please use
-        [Discussions](https://github.com/celerp/celerp/discussions) instead.
+        This template is for **bugs**. Have a **feature idea** or a **question**? Please use
+        [Discussions](https://github.com/celerp/celerp/discussions) - ideas go in the
+        **Ideas** category.
   - type: input
     id: version
     attributes:

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -37,6 +37,14 @@ body:
         - Other
     validations:
       required: true
+  - type: input
+    id: page
+    attributes:
+      label: Page / URL where it happened
+      description: The Celerp page you were on (e.g. `/inventory`). Pre-filled when you open this from inside the app.
+      placeholder: "e.g. /inventory"
+    validations:
+      required: false
   - type: textarea
     id: repro
     attributes:

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Feature request / idea
+    url: https://github.com/celerp/celerp/discussions/new?category=ideas
+    about: Share and vote on feature ideas in Discussions - this keeps Issues for bugs and committed work.
+  - name: Questions & support
+    url: https://github.com/celerp/celerp/discussions/new?category=q-a
+    about: Ask a question or get help.

--- a/ui/components/shell.py
+++ b/ui/components/shell.py
@@ -907,6 +907,8 @@ _BUG_REPORT_URL: str | None = None
 def _bug_report_url() -> str:
     """GitHub 'new issue' link that opens the bug_report.yml issue form with the
     Celerp version and host OS pre-filled (the two fields users most often leave out).
+    The current page is appended to the form's `page` field client-side on click (see
+    the menu link's onclick), since the path is only known in the browser.
 
     Built once per process - version and OS don't change at runtime. Uses the form's
     field-prefill query params, so the form's own label (bug) still applies for
@@ -1059,6 +1061,10 @@ def _topbar(companies: list[dict], lang: str = "en", user_email: str | None = No
                         target="_blank",
                         rel="noopener",
                         cls="user-menu__item",
+                        # Append the current page to the bug form's `page` field at click time
+                        # (server-side URL is cached/page-agnostic; the path is only known client-side).
+                        onclick="this.href=this.dataset.base+'&page='+encodeURIComponent(location.pathname+location.search)",
+                        **{"data-base": _bug_report_url()},
                     ),
                     A(
                         "💡 " + t("nav.suggest_feature", lang, default="Suggest a feature"),

--- a/ui/components/shell.py
+++ b/ui/components/shell.py
@@ -909,7 +909,7 @@ def _bug_report_url() -> str:
     Celerp version and host OS pre-filled (the two fields users most often leave out).
 
     Built once per process - version and OS don't change at runtime. Uses the form's
-    field-prefill query params, so the form's own labels (bug, triage) still apply for
+    field-prefill query params, so the form's own label (bug) still applies for
     every reporter (unlike inline body prefill, which would suppress the template).
     """
     global _BUG_REPORT_URL
@@ -1056,6 +1056,13 @@ def _topbar(companies: list[dict], lang: str = "en", user_email: str | None = No
                     A(
                         "🐞 " + t("nav.report_bug", lang, default="Report a bug"),
                         href=_bug_report_url(),
+                        target="_blank",
+                        rel="noopener",
+                        cls="user-menu__item",
+                    ),
+                    A(
+                        "💡 " + t("nav.suggest_feature", lang, default="Suggest a feature"),
+                        href="https://github.com/celerp/celerp/discussions/new?category=ideas",
                         target="_blank",
                         rel="noopener",
                         cls="user-menu__item",

--- a/ui/locales/ar.json
+++ b/ui/locales/ar.json
@@ -852,6 +852,7 @@
   "nav.lists_quotations": "القوائم / عروض الأسعار",
   "nav.logout": "تسجيل الخروج",
   "nav.report_bug": "الإبلاغ عن خطأ",
+  "nav.suggest_feature": "اقتراح ميزة",
   "nav.manufacturing": "تصنيع",
   "nav.payments": "المدفوعات",
   "nav.purchase_orders": "طلبات الشراء",

--- a/ui/locales/de.json
+++ b/ui/locales/de.json
@@ -852,6 +852,7 @@
   "nav.lists_quotations": "Listen / Angebote",
   "nav.logout": "Abmelden",
   "nav.report_bug": "Fehler melden",
+  "nav.suggest_feature": "Funktion vorschlagen",
   "nav.manufacturing": "Fertigung",
   "nav.payments": "Zahlungen",
   "nav.purchase_orders": "Bestellungen",

--- a/ui/locales/en.json
+++ b/ui/locales/en.json
@@ -852,6 +852,7 @@
   "nav.lists_quotations": "Lists / Quotations",
   "nav.logout": "Logout",
   "nav.report_bug": "Report a bug",
+  "nav.suggest_feature": "Suggest a feature",
   "nav.manufacturing": "Manufacturing",
   "nav.payments": "Payments",
   "nav.purchase_orders": "Purchase Orders",

--- a/ui/locales/es.json
+++ b/ui/locales/es.json
@@ -852,6 +852,7 @@
   "nav.lists_quotations": "Listas / Cotizaciones",
   "nav.logout": "Cerrar sesión",
   "nav.report_bug": "Reportar un error",
+  "nav.suggest_feature": "Sugerir una función",
   "nav.manufacturing": "Fabricación",
   "nav.payments": "Pagos",
   "nav.purchase_orders": "Órdenes de compra",

--- a/ui/locales/fr.json
+++ b/ui/locales/fr.json
@@ -852,6 +852,7 @@
   "nav.lists_quotations": "Listes / Devis",
   "nav.logout": "Déconnexion",
   "nav.report_bug": "Signaler un bug",
+  "nav.suggest_feature": "Suggérer une fonctionnalité",
   "nav.manufacturing": "Fabrication",
   "nav.payments": "Paiements",
   "nav.purchase_orders": "Bons de commande",

--- a/ui/locales/id.json
+++ b/ui/locales/id.json
@@ -852,6 +852,7 @@
   "nav.lists_quotations": "Daftar / Penawaran",
   "nav.logout": "Keluar",
   "nav.report_bug": "Laporkan bug",
+  "nav.suggest_feature": "Sarankan fitur",
   "nav.manufacturing": "Manufaktur",
   "nav.payments": "Pembayaran",
   "nav.purchase_orders": "Pesanan Pembelian",

--- a/ui/locales/it.json
+++ b/ui/locales/it.json
@@ -852,6 +852,7 @@
   "nav.lists_quotations": "Liste / Preventivi",
   "nav.logout": "Esci",
   "nav.report_bug": "Segnala un bug",
+  "nav.suggest_feature": "Suggerisci una funzione",
   "nav.manufacturing": "Produzione",
   "nav.payments": "Pagamenti",
   "nav.purchase_orders": "Ordini d'acquisto",

--- a/ui/locales/ja.json
+++ b/ui/locales/ja.json
@@ -852,6 +852,7 @@
   "nav.lists_quotations": "リスト・見積",
   "nav.logout": "ログアウト",
   "nav.report_bug": "バグを報告",
+  "nav.suggest_feature": "機能を提案",
   "nav.manufacturing": "製造業",
   "nav.payments": "支払い",
   "nav.purchase_orders": "注文書",

--- a/ui/locales/pt.json
+++ b/ui/locales/pt.json
@@ -852,6 +852,7 @@
   "nav.lists_quotations": "Listas / Cotações",
   "nav.logout": "Sair",
   "nav.report_bug": "Reportar bug",
+  "nav.suggest_feature": "Sugerir um recurso",
   "nav.manufacturing": "Fabricação",
   "nav.payments": "Pagamentos",
   "nav.purchase_orders": "Pedidos de compra",

--- a/ui/locales/th.json
+++ b/ui/locales/th.json
@@ -852,6 +852,7 @@
   "nav.lists_quotations": "รายการ / ใบเสนอราคา",
   "nav.logout": "ออกจากระบบ",
   "nav.report_bug": "รายงานข้อผิดพลาด",
+  "nav.suggest_feature": "แนะนำฟีเจอร์",
   "nav.manufacturing": "การผลิต",
   "nav.payments": "การชำระเงิน",
   "nav.purchase_orders": "ใบสั่งซื้อ",

--- a/ui/locales/vi.json
+++ b/ui/locales/vi.json
@@ -852,6 +852,7 @@
   "nav.lists_quotations": "Danh sách / Báo giá",
   "nav.logout": "Đăng xuất",
   "nav.report_bug": "Báo lỗi",
+  "nav.suggest_feature": "Đề xuất tính năng",
   "nav.manufacturing": "Chế tạo",
   "nav.payments": "Thanh toán",
   "nav.purchase_orders": "Đơn đặt hàng",


### PR DESCRIPTION
A structured **Feature Request** intake, routed to **Discussions (Ideas)** 

## What's added
- **`.github/DISCUSSION_TEMPLATE/ideas.yml`** - a discussion category form for the **Ideas** category (filename matches the category slug, as GitHub requires). Fields: problem/use-case, proposed solution, area dropdown, alternatives, anything-else. Labeled `enhancement`. Footer carries a low-key star ask (a ⭐ helps others find Celerp; early supporters can claim a founding badge) and the intro nudges 👍 on existing ideas for prioritization.

## Consistency cleanup
- **`bug_report.yml`** - note trimmed: this template is for **bugs**; feature ideas and questions go to **Discussions**.
- **`config.yml`** - New Issue chooser now shows contact links: **Feature request / idea → Ideas**, **Questions & support → Q&A**. Blank issues left enabled (non-restrictive).

## Result
- **New Issue** → Bug Report + links out to Ideas/Q&A.
- **New Discussion** in Ideas → the structured feature-request form.