### PR TITLE
fix(release): build into a draft + publish only after all platforms succeed (no 404 window, no partial release)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -551,3 +551,49 @@ jobs:
             exit 1
           fi
           echo "Published $TAG as latest."
+
+  # ── Alert on a failed release build ──────────────────────────────────────────
+  # When any platform (or prepare/publish) fails on a v* tag, the release is left as
+  # a draft and `latest` keeps serving the previous version - correct, but SILENT.
+  # GitHub's default failure email only reaches whoever pushed the tag, if their
+  # personal notification settings allow it. Open (or comment on) a tracking issue
+  # so a stuck/failed release is loud and team-visible regardless of those settings.
+  # This is the only signal that e.g. macOS notarization broke (Apple agreement
+  # expiry) - after which NO platform ships until it is fixed and the tag re-pushed.
+  notify-release-failure:
+    needs: [prepare-release, setup-matrix, build, publish-release]
+    if: ${{ failure() && startsWith(github.ref, 'refs/tags/v') }}
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Open or update the release-failure issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          TAG: ${{ github.ref_name }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -eo pipefail
+          gh label create release-failure --repo "$REPO" --color B60205 --force \
+            --description "A release build failed; the release is stuck as a draft" || true
+          cat > /tmp/release_failure.md <<EOF
+          The build for **$TAG** failed, so the release was left as a **draft and not published**.
+
+          \`releases/latest\` still serves the previous complete release (no 404 window), but **$TAG will not ship on any platform until the build is fixed and the tag is re-pushed**.
+
+          - Failed run: $RUN_URL
+          - Check which platform failed in the logs (e.g. macOS notarization / an expired Apple agreement).
+
+          Re-pushing the tag after a fix re-drafts and re-publishes automatically once every platform succeeds.
+          EOF
+          TITLE="Release build failed: $TAG"
+          EXISTING=$(gh issue list --repo "$REPO" --state open --label release-failure \
+            --json number,title --jq "map(select(.title == \"$TITLE\")) | .[0].number // empty")
+          if [ -n "$EXISTING" ]; then
+            gh issue comment "$EXISTING" --repo "$REPO" --body "Another failed run: $RUN_URL"
+            echo "Commented on existing issue #$EXISTING"
+          else
+            gh issue create --repo "$REPO" --title "$TITLE" \
+              --label release-failure --body-file /tmp/release_failure.md
+          fi

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,7 +47,14 @@ jobs:
             echo "No existing release for $TAG - nothing to clear"
             exit 0
           fi
-          echo "Release $RELEASE_ID found for $TAG - clearing assets"
+          echo "Release $RELEASE_ID found for $TAG - reverting to draft + clearing assets"
+          # Take the existing release out of "latest" while we rebuild (retag), so
+          # /releases/latest/download/* keeps serving the previous complete release
+          # instead of 404-ing on a half-uploaded asset. publish-release re-publishes
+          # it once every platform succeeds.
+          curl -s -X PATCH -H "Authorization: token $GH_TOKEN" \
+            "https://api.github.com/repos/celerp/celerp/releases/$RELEASE_ID" \
+            -d '{"draft":true}' >/dev/null
           ASSET_IDS=$(curl -s -H "Authorization: token $GH_TOKEN" \
             "https://api.github.com/repos/celerp/celerp/releases/$RELEASE_ID/assets" \
             | python3 -c "import sys,json; [print(a['id']) for a in json.load(sys.stdin)]" 2>/dev/null || true)
@@ -504,3 +511,43 @@ jobs:
             electron/dist/Celerp.AppImage
           draft: false
           prerelease: true
+
+  # ── Publish the release (tag builds only) ────────────────────────────────
+  # Platform builds upload their assets to a DRAFT release (electron-builder
+  # publish releaseType=draft). Only once EVERY platform job has succeeded do we
+  # flip the release to published + latest - atomically, with all assets present.
+  # If any platform fails (e.g. macOS notarization), this job is skipped, the
+  # release stays a draft, and /releases/latest keeps serving the previous
+  # complete release: no 404 window during a build, and no partial release.
+  publish-release:
+    needs: [build]
+    if: ${{ success() && startsWith(github.ref, 'refs/tags/v') }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Publish the draft release as latest
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -eo pipefail
+          TAG="${GITHUB_REF_NAME}"
+          # The release is still a draft; get-release-by-tag only returns published
+          # releases, so list releases (drafts included for an authed token) and
+          # match on tag_name.
+          RELEASE_ID=$(curl -s -H "Authorization: token $GH_TOKEN" \
+            "https://api.github.com/repos/celerp/celerp/releases?per_page=100" \
+            | python3 -c "import sys,json; tag='$TAG'; print(next((r['id'] for r in json.load(sys.stdin) if r['tag_name']==tag), ''))" 2>/dev/null || true)
+          if [ -z "$RELEASE_ID" ]; then
+            echo "ERROR: no release found for tag $TAG to publish" >&2
+            exit 1
+          fi
+          echo "Publishing release $RELEASE_ID ($TAG) as latest"
+          STATUS=$(curl -s -o /dev/null -w "%{http_code}" -X PATCH \
+            -H "Authorization: token $GH_TOKEN" \
+            "https://api.github.com/repos/celerp/celerp/releases/$RELEASE_ID" \
+            -d '{"draft":false,"make_latest":"true"}')
+          if [ "$STATUS" -ge 300 ]; then
+            echo "ERROR: publish PATCH returned HTTP $STATUS" >&2
+            exit 1
+          fi
+          echo "Published $TAG as latest."

--- a/default_modules/celerp-docs/celerp_docs/routes.py
+++ b/default_modules/celerp-docs/celerp_docs/routes.py
@@ -844,6 +844,8 @@ async def send_doc(entity_id: str, payload: DocSendBody, company_id: str = Depen
     row = await _get_doc(session, company_id, entity_id)
     if row.state.get("status") == "void":
         raise HTTPException(status_code=409, detail="Cannot send void document")
+    if not (row.state.get("line_items") or []):
+        raise HTTPException(status_code=422, detail="Add at least one line item before sending this document.")
     from celerp_docs.doc_constants import NO_SEND_DOC_TYPES
     doc_type = row.state.get("doc_type", "")
     if doc_type in NO_SEND_DOC_TYPES:
@@ -894,6 +896,8 @@ async def finalize_doc(entity_id: str, company_id: str = Depends(get_current_com
     row = await _get_doc(session, company_id, entity_id)
     if row.state.get("status") == "void":
         raise HTTPException(status_code=409, detail="Cannot finalize void document")
+    if not (row.state.get("line_items") or []):
+        raise HTTPException(status_code=422, detail="Add at least one line item before finalizing this document.")
 
     # Snapshot scalar values early — avoids ORM lazy-load issues after multiple flush() calls.
     _initial_doc_state = dict(row.state)

--- a/default_modules/celerp-docs/tests/test_line_delete_persist.py
+++ b/default_modules/celerp-docs/tests/test_line_delete_persist.py
@@ -1,0 +1,85 @@
+# Copyright (c) 2026 Noah Severs
+# SPDX-License-Identifier: MIT
+"""Issue #153: deleting the last/only line of a document must persist (the line was
+silently reverting on refresh), and an empty document must not be issuable.
+
+Behaviour (Option 3): emptying a document is allowed and sticks; finalizing or sending
+a zero-line document is blocked with a clear error, for every issue-type doc."""
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+
+async def _register(client) -> str:
+    addr = f"admin-{uuid.uuid4().hex[:8]}@linedel.test"
+    r = await client.post("/auth/register", json={
+        "company_name": "LineDel Co", "email": addr, "name": "A", "password": "pw"})
+    assert r.status_code == 200
+    return r.json()["access_token"]
+
+
+def _h(t):
+    return {"Authorization": f"Bearer {t}"}
+
+
+@pytest.mark.asyncio
+async def test_deleting_the_only_line_persists(client):
+    """The core bug: delete the sole line (autosave sends line_items: []), and a fresh
+    read still shows it gone - it must not reappear."""
+    t = await _register(client)
+    line = {"sku": "DEMO-PRL-001", "name": "Pearl", "description": "Pearl",
+            "quantity": 1, "unit_price": 100}
+    doc = (await client.post("/docs", headers=_h(t), json={
+        "doc_type": "invoice", "line_items": [line], "total": 100})).json()["id"]
+
+    r = await client.patch(f"/docs/{doc}", headers=_h(t),
+                           json={"fields_changed": {"line_items": {"old": [line], "new": []}}})
+    assert r.status_code == 200, r.text
+
+    # Fresh read: the deletion stuck (before the fix, the line reappeared here).
+    assert (await client.get(f"/docs/{doc}", headers=_h(t))).json().get("line_items") == []
+
+
+@pytest.mark.asyncio
+async def test_finalize_blocked_when_empty(client):
+    t = await _register(client)
+    doc = (await client.post("/docs", headers=_h(t), json={
+        "doc_type": "invoice", "line_items": []})).json()["id"]
+    r = await client.post(f"/docs/{doc}/finalize", headers=_h(t))
+    assert r.status_code == 422
+    assert "at least one line" in r.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_send_blocked_when_empty(client):
+    t = await _register(client)
+    doc = (await client.post("/docs", headers=_h(t), json={
+        "doc_type": "invoice", "line_items": []})).json()["id"]
+    r = await client.post(f"/docs/{doc}/send", headers=_h(t), json={"sent_to": "buyer@x.test"})
+    assert r.status_code == 422
+    assert "at least one line" in r.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_finalize_guard_applies_to_all_issue_types(client):
+    """The >=1-line rule is not invoice-specific - it guards every issue-type doc."""
+    t = await _register(client)
+    for dt in ("invoice", "quotation", "purchase_order", "credit_note"):
+        doc = (await client.post("/docs", headers=_h(t), json={
+            "doc_type": dt, "line_items": []})).json()["id"]
+        r = await client.post(f"/docs/{doc}/finalize", headers=_h(t))
+        assert r.status_code == 422, f"{dt}: {r.status_code} {r.text}"
+
+
+@pytest.mark.asyncio
+async def test_finalize_succeeds_with_a_line(client):
+    """Regression: the guard must not block the normal path - a doc with a line finalizes."""
+    t = await _register(client)
+    item = (await client.post("/items", headers=_h(t), json={
+        "sku": "OK-1", "name": "Widget", "quantity": 5, "sell_by": "piece"})).json()["id"]
+    doc = (await client.post("/docs", headers=_h(t), json={"doc_type": "invoice", "line_items": [
+        {"entity_id": item, "sku": "OK-1", "name": "Widget", "quantity": 1, "unit_price": 10,
+         "sell_by": "piece"}], "total": 10})).json()["id"]
+    assert (await client.post(f"/docs/{doc}/finalize", headers=_h(t))).status_code == 200

--- a/electron/package.json
+++ b/electron/package.json
@@ -182,7 +182,7 @@
       "provider": "github",
       "owner": "celerp",
       "repo": "celerp",
-      "releaseType": "release"
+      "releaseType": "draft"
     }
   },
   "jest": {

--- a/tests/test_browser/test_supplemental_coverage.py
+++ b/tests/test_browser/test_supplemental_coverage.py
@@ -181,7 +181,7 @@ def test_doc_payment_recording(page, ui_server, api):
     r = api.post("/docs", json={
         "doc_type": "invoice",
         "contact_name": f"Pay Test Co {_unique('PAY')}",
-        "lines": [{"description": "Service", "quantity": 1, "unit_price": 100.0}],
+        "line_items": [{"description": "Service", "quantity": 1, "unit_price": 100.0}],
     })
     assert r.status_code in {200, 201}, f"POST /docs failed: {r.text}"
     doc_id = r.json().get("id", "")

--- a/tests/test_electron_build_config.py
+++ b/tests/test_electron_build_config.py
@@ -362,7 +362,10 @@ def test_build_yml_delete_checks_http_status():
     yml = (Path(__file__).parent.parent / ".github" / "workflows" / "build.yml").read_text()
     clear_idx = yml.find("Clear existing release assets")
     assert clear_idx != -1, "Asset-clearing step not found in build.yml"
-    step_block = yml[clear_idx: clear_idx + 1500]
+    # Scan to the end of this step (the next `- name:` or EOF) rather than a fixed-size
+    # window - the delete loop sits near the end of the step and a short slice misses it.
+    next_step = yml.find("\n      - name:", clear_idx + 1)
+    step_block = yml[clear_idx: next_step if next_step != -1 else len(yml)]
     assert "%{http_code}" in step_block, (
         "build.yml DELETE step does not capture HTTP status code. "
         "Use curl -w '%{http_code}' and fail on >= 500."

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -280,7 +280,8 @@ class TestManagerRequiredDocOps:
     async def _create_draft_doc(self, client, headers: dict) -> str:
         r = await client.post(
             "/docs",
-            json={"doc_type": "invoice", "contact_name": "Client", "line_items": []},
+            json={"doc_type": "invoice", "contact_name": "Client",
+                  "line_items": [{"description": "Item", "quantity": 1, "unit_price": 100, "line_total": 100}]},
             headers=headers,
         )
         assert r.status_code == 200, r.text

--- a/tests/test_routers/test_contacts_bulk.py
+++ b/tests/test_routers/test_contacts_bulk.py
@@ -52,6 +52,7 @@ async def _invoice(client, tok, contact_id: str) -> str:
         "doc_type": "invoice",
         "contact_id": contact_id,
         "contact_name": "Test",
+        "line_items": [{"description": "Service", "quantity": 1, "unit_price": 100}],
         "total": 100,
         "issue_date": "2026-01-01",
         "due_date": "2026-02-01",

--- a/tests/test_routers/test_coverage_final.py
+++ b/tests/test_routers/test_coverage_final.py
@@ -132,7 +132,7 @@ async def test_reports_ap_aging_all_buckets(client):
         r = await client.post("/docs", headers=_h(tok), json={
             "doc_type": "purchase_order",
             "contact_id": supplier_id,
-            "line_items": [],
+            "line_items": [{"description": "Item", "quantity": 1, "unit_price": 100.0, "line_total": 100.0}],
             "subtotal": 100.0,
             "tax": 0,
             "total": 100.0,

--- a/tests/test_routers/test_coverage_gaps.py
+++ b/tests/test_routers/test_coverage_gaps.py
@@ -29,7 +29,9 @@ def _h(tok: str) -> dict:
 
 
 async def _doc(client, tok, doc_type="invoice", total=100, **extra):
-    body = {"doc_type": doc_type, "contact_id": "c:1", "line_items": [], "subtotal": total, "tax": 0, "total": total}
+    body = {"doc_type": doc_type, "contact_id": "c:1",
+            "line_items": [{"description": "Item", "quantity": 1, "unit_price": total, "line_total": total}],
+            "subtotal": total, "tax": 0, "total": total}
     body.update(extra)
     r = await client.post("/docs", headers=_h(tok), json=body)
     assert r.status_code == 200, r.text
@@ -248,7 +250,8 @@ async def test_reports_ar_aging_all_buckets(client):
 
     # Invoice with future due_date → current bucket (days_overdue <= 0)
     r = await client.post("/docs", headers=_h(tok), json={
-        "doc_type": "invoice", "contact_id": "c:1", "line_items": [],
+        "doc_type": "invoice", "contact_id": "c:1",
+        "line_items": [{"description": "Item", "quantity": 1, "unit_price": 100, "line_total": 100}],
         "subtotal": 100, "tax": 0, "total": 100, "due_date": "2099-12-31",
     })
     assert r.status_code == 200
@@ -256,7 +259,8 @@ async def test_reports_ar_aging_all_buckets(client):
 
     # Invoice with invalid due_date → ValueError path, falls back to today
     r = await client.post("/docs", headers=_h(tok), json={
-        "doc_type": "invoice", "contact_id": "c:2", "line_items": [],
+        "doc_type": "invoice", "contact_id": "c:2",
+        "line_items": [{"description": "Item", "quantity": 1, "unit_price": 50, "line_total": 50}],
         "subtotal": 50, "tax": 0, "total": 50, "due_date": "not-a-date",
     })
     assert r.status_code == 200
@@ -264,7 +268,8 @@ async def test_reports_ar_aging_all_buckets(client):
 
     # Invoice with very old due_date → d90plus bucket
     r = await client.post("/docs", headers=_h(tok), json={
-        "doc_type": "invoice", "contact_id": "c:3", "line_items": [],
+        "doc_type": "invoice", "contact_id": "c:3",
+        "line_items": [{"description": "Item", "quantity": 1, "unit_price": 200, "line_total": 200}],
         "subtotal": 200, "tax": 0, "total": 200, "due_date": "2000-01-01",
     })
     assert r.status_code == 200
@@ -297,7 +302,8 @@ async def test_reports_ap_aging_all_buckets(client):
 
     # PO with very old due_date → d90plus bucket
     r = await client.post("/docs", headers=_h(tok), json={
-        "doc_type": "purchase_order", "contact_id": "s:1", "line_items": [],
+        "doc_type": "purchase_order", "contact_id": "s:1",
+        "line_items": [{"description": "Item", "quantity": 1, "unit_price": 300, "line_total": 300}],
         "subtotal": 300, "tax": 0, "total": 300, "due_date": "2000-01-01",
     })
     assert r.status_code == 200
@@ -305,7 +311,8 @@ async def test_reports_ap_aging_all_buckets(client):
 
     # PO with invalid due_date → ValueError path
     r = await client.post("/docs", headers=_h(tok), json={
-        "doc_type": "purchase_order", "contact_id": "s:2", "line_items": [],
+        "doc_type": "purchase_order", "contact_id": "s:2",
+        "line_items": [{"description": "Item", "quantity": 1, "unit_price": 100, "line_total": 100}],
         "subtotal": 100, "tax": 0, "total": 100, "due_date": "bad-date",
     })
     assert r.status_code == 200
@@ -313,7 +320,8 @@ async def test_reports_ap_aging_all_buckets(client):
 
     # PO with future date → current bucket
     r = await client.post("/docs", headers=_h(tok), json={
-        "doc_type": "purchase_order", "contact_id": "s:3", "line_items": [],
+        "doc_type": "purchase_order", "contact_id": "s:3",
+        "line_items": [{"description": "Item", "quantity": 1, "unit_price": 150, "line_total": 150}],
         "subtotal": 150, "tax": 0, "total": 150, "due_date": "2099-12-31",
     })
     assert r.status_code == 200

--- a/tests/test_routers/test_doc_workflows.py
+++ b/tests/test_routers/test_doc_workflows.py
@@ -1113,17 +1113,19 @@ async def test_receive_return_fails_loudly_when_no_data_resolvable(client, sessi
     token = await _register(client)
     h = _h(token)
 
-    # Unlinked CN (no original_doc_id), no inventory, no invoice fallback
+    # Unlinked CN (no original_doc_id), no inventory, no invoice fallback. It carries an
+    # unrelated free-text line (so it can be finalized) that does NOT match the SKU we
+    # later try to return - leaving nothing to resolve GHOST-SKU from.
     cn = await client.post("/docs", headers=h, json={
         "doc_type": "credit_note",
-        "line_items": [],  # no line items - nothing to resolve from
-        "subtotal": 0, "tax": 0, "total": 0,
+        "line_items": [{"sku": "UNRELATED-SKU", "description": "Adjustment", "quantity": 1, "unit_price": 10}],
+        "subtotal": 10, "tax": 0, "total": 10,
     })
     assert cn.status_code == 200
     cn_id = cn.json()["id"]
-    await client.post(f"/docs/{cn_id}/finalize", headers=h)
+    assert (await client.post(f"/docs/{cn_id}/finalize", headers=h)).status_code == 200
 
-    # SKU has no sold record and no line item on the CN - must fail loudly
+    # SKU has no sold record and no matching line item on the CN - must fail loudly
     r = await client.post(f"/docs/{cn_id}/receive-return", headers=h, json={"items": [{"sku": "GHOST-SKU", "quantity": 1}]})
     assert r.status_code == 422, r.text
     assert "name" in r.json()["detail"] or "sell_by" in r.json()["detail"]

--- a/tests/test_routers/test_doctor.py
+++ b/tests/test_routers/test_doctor.py
@@ -28,6 +28,8 @@ def _h(token: str) -> dict:
 async def _create_invoice(client, token, *, total=1000, tax=70, status="draft") -> str:
     r = await client.post("/docs", headers=_h(token), json={
         "doc_type": "invoice", "contact_name": "Test",
+        "line_items": [{"description": "Item", "quantity": 1,
+                        "unit_price": total - tax, "line_total": total - tax}],
         "subtotal": total - tax, "tax": tax, "total": total, "status": status,
     })
     assert r.status_code == 200

--- a/tests/test_routers/test_final_gaps.py
+++ b/tests/test_routers/test_final_gaps.py
@@ -34,8 +34,12 @@ def _h(tok: str) -> dict:
 
 
 async def _doc(client, tok, **kw) -> str:
-    defaults = {"doc_type": "invoice", "contact_id": "c1", "line_items": [], "subtotal": 10, "tax": 0, "total": 10}
-    r = await client.post("/docs", headers=_h(tok), json={**defaults, **kw})
+    merged = {"doc_type": "invoice", "contact_id": "c1", "subtotal": 10, "tax": 0, "total": 10, **kw}
+    # Default a single line (amount = subtotal) so the doc can be finalized; callers
+    # that need an empty/custom set pass line_items explicitly.
+    merged.setdefault("line_items", [{"description": "Item", "quantity": 1,
+                                      "unit_price": merged["subtotal"], "line_total": merged["subtotal"]}])
+    r = await client.post("/docs", headers=_h(tok), json=merged)
     assert r.status_code == 200, r.text
     return r.json()["id"]
 

--- a/tests/test_routers/test_sprint4.py
+++ b/tests/test_routers/test_sprint4.py
@@ -33,7 +33,15 @@ def _h(token: str) -> dict:
 
 
 async def _create_invoice(client, token: str, **kw) -> str:
-    data = {"doc_type": "invoice", **kw}
+    # Default to a single line (amount = total) so the doc can be finalized/sent - a
+    # zero-line doc can no longer be issued. Callers testing blank docs pass line_items=[].
+    total = kw.get("total", 100)
+    data = {
+        "doc_type": "invoice",
+        "line_items": [{"description": "Item", "quantity": 1, "unit_price": total, "line_total": total}],
+        "total": total,
+        **kw,
+    }
     r = await client.post("/docs", headers=_h(token), json=data)
     assert r.status_code == 200
     return r.json()["id"]
@@ -58,7 +66,7 @@ async def test_create_blank_invoice_via_api(client):
 async def test_blank_invoice_is_retrievable(client):
     """A blank invoice has draft status and no line items."""
     token = await _register(client)
-    eid = await _create_invoice(client, token, status="draft")
+    eid = await _create_invoice(client, token, status="draft", line_items=[])
     doc = (await client.get(f"/docs/{eid}", headers=_h(token))).json()
     assert doc["status"] == "draft"
     assert doc.get("line_items", []) == []

--- a/ui/routes/documents.py
+++ b/ui/routes/documents.py
@@ -5938,6 +5938,9 @@ def _doc_detail(doc: dict, locations: list | None = None, ledger: list | None = 
             Script(f"""
 const _CELERP_EID = {repr(entity_id)};
 const _CELERP_BASE = {'"/lists/"' if is_list else '"/docs/"'};
+// Did this document render with any line items? Drives whether emptying the table
+// persists (deleting the last line must stick) vs. a blank never-used doc (skip).
+let _celerpHadLines = {'true' if line_items else 'false'};
 const _CELERP_TAXES = {_json.dumps(_taxes_list)};
 const _CELERP_DEFAULT_TAX = {repr(_default_tax_value)};
 /* Currency precision: amounts use _CELERP_CDP decimals, unit prices may use up to _CELERP_RDP. */
@@ -6378,6 +6381,7 @@ function _celerpEditTaxLabel(key, rate, labelEl) {{
     input.select();
 }}
 function celerpAddLine() {{
+    _celerpHadLines = true;  // once a line exists, emptying the table later must persist
     const tpl = document.getElementById('line-row-tpl').content.cloneNode(true);
     const row = tpl.querySelector('tr') || tpl.children[0];
     if (row) {{
@@ -6673,7 +6677,9 @@ function _celerpCollectLines() {{
 }}
 async function _celerpPersist() {{
     const lines = _celerpCollectLines();
-    if (!lines.length) return;
+    // Persist even when empty if the doc had lines - deleting the last line must stick.
+    // Skip only a blank doc that never had any lines (avoids a spurious empty save).
+    if (!lines.length && !_celerpHadLines) return;
     const subtotal = lines.reduce((s, l) => s + l.line_total, 0);
     const grossTax = lines.reduce((s, l) => s + l.line_total * (l.tax_rate / 100), 0);
     // Apply the header discount to the taxable base; tax scales by the same ratio (see


### PR DESCRIPTION
## Problem
The website links `https://github.com/celerp/celerp/releases/latest/download/<asset>`. electron-builder published each platform **straight to a non-draft release** (`releaseType: release`), so during the multi-minute parallel matrix builds the assets went live one at a time - and `latest/download/<asset>` **404'd** for any platform not yet uploaded. Worse, when a platform job **fails**, a *partial* release stays live.

That's exactly what happened on **v1.2.4**: the macOS job failed at notarization (Apple "agreement missing/expired" 403), so the release went live with Windows + Linux but **`Celerp-mac.dmg` 404s**.

## Fix (tag releases only; dev builds unchanged)
- **`electron/package.json`**: `releaseType: release` -> **`draft`** - electron-builder uploads assets to a *draft* release.
- **`build.yml`: new `publish-release` job** - `needs: [build]`, runs only on `success()` for `v*` tags, and flips the release to **published + latest** (`make_latest`) once **every** platform build has succeeded. If any platform fails, it's skipped and the release stays a draft.
- **`build.yml`: `prepare-release`** also reverts an existing release to draft on a **retag**, so a rebuild of an existing tag drops out of "latest" too.

**Result:** while a build is running - or if a platform fails - `/releases/latest` keeps serving the **previous complete release**. No 404 window, and no partial release ever goes live.

## Release-failure alerting (new)
A failed platform build now leaves the release as a draft - correct, but **silent**: GitHub's default failure email only reaches whoever pushed the tag, if their settings allow it. With the draft logic above, one platform failing (e.g. macOS notarization / an expired Apple agreement) blocks **every** platform from shipping, so a loud signal matters more.
- **`build.yml`: new `notify-release-failure` job** - `failure()` on `v*` tags. Opens (or comments on) a team-visible `release-failure` issue stating the release is stuck as a draft and won't ship until fixed. No new secrets (uses `GITHUB_TOKEN`).
- Not included: a scheduled macOS canary (would catch Apple breakage *between* releases, not just at release time) - deferred.

## Also in this PR: invoice line-delete bugfix (#153)
**Bug:** deleting the only line of a document removed it from the page but never persisted (the line reappeared on refresh), with no error. Root cause: the line autosave bailed early on an empty collection (`if (!lines.length) return` in `_celerpPersist`), so "all lines cleared" was never POSTed.

**Fix (Allow emptying a draft, block issuing an empty doc):**
- **`ui/routes/documents.py`**: track whether the doc rendered with lines (`_celerpHadLines`, set true on add); persist `line_items: []` when an emptied doc had lines, while still skipping a never-used blank doc. Deleting the last line now sticks.
- **`celerp-docs/routes.py`**: `finalize` and `send` now 422 with a clear message when a document has no line items - enforced at the API layer so every caller is covered, for all issue-type docs. A zero-line draft is allowed; you just can't issue it.
- Adds `test_line_delete_persist.py` and updates the tests that had created line-less docs and issued them (they only passed before because finalize used to accept an empty doc).

## Validation
- `build.yml` YAML + `package.json` JSON validated; jobs now: `prepare-release, setup-matrix, build, publish-release, notify-release-failure`.
- Dev builds (`develop`/`bugfix`) use the separate `--publish never` + softprops `dev-latest` path and are unaffected.
- Full CI green (unit + browser shards).
