### PR TITLE
feat(stars): tiered gold/silver/bronze star labels (Stargazer)

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/ideas.yml
+++ b/.github/DISCUSSION_TEMPLATE/ideas.yml
@@ -75,4 +75,4 @@ body:
       value: >
         Thanks for the idea! If Celerp is useful to you, a ⭐ on
         [GitHub](https://github.com/celerp/celerp) genuinely helps others find it - and early
-        supporters can claim a founding-supporter badge.
+        stargazers can claim a star badge.

--- a/.github/workflows/founder-label.yml
+++ b/.github/workflows/founder-label.yml
@@ -1,10 +1,11 @@
-name: Founder recognition
+name: Stargazer recognition
 
-# Recognise verified, public-opt-in founding/early supporters wherever they engage:
-# issues, pull requests, and discussions. One gold label per thread - no comments
-# (discrete-but-meaningful, mirrors the in-app gold star). Uses the ephemeral,
-# repo-scoped GITHUB_TOKEN (no GitHub App, no CLA-app change - stars plan §0.8/0.14)
-# and the relay's read-only founder-status lookup.
+# Recognise a verified stargazer wherever they engage - issues, pull requests, and
+# discussions - with one small star label per thread (no comment), gold / silver /
+# bronze by tier. The names are the :star: / :star2: / :sparkles: shortcodes, which
+# GitHub renders as ⭐ / 🌟 / ✨ in the chip; the meaning rides in the label description,
+# shown on hover. Uses the ephemeral repo-scoped GITHUB_TOKEN (no GitHub App, no CLA-app
+# change - stars plan §0.8/0.14) and the relay's read-only founder-status lookup.
 #
 # pull_request_target runs in BASE context (has the token): we ONLY read the author
 # login + apply a label. We never check out or execute PR code.
@@ -23,10 +24,10 @@ permissions:
   discussions: write
 
 jobs:
-  recognise-founder:
+  recognise-stargazer:
     runs-on: ubuntu-latest
     steps:
-      - name: Label founders (issues / PRs / discussions)
+      - name: Label stargazers (issues / PRs / discussions)
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
@@ -49,20 +50,24 @@ jobs:
           esac
           [ -n "$AUTHOR" ] || { echo "no author on event; skipping."; exit 0; }
 
-          # 2. One read-only founder-status lookup (relay is authoritative; opted-in only).
+          # 2. One read-only founder-status lookup (relay is authoritative).
           status="$(curl -fsS "https://relay.celerp.com/github/founder-status?login=${AUTHOR}" || echo '{}')"
           if [ "$(echo "$status" | jq -r '.founder // false')" != "true" ]; then
-            echo "$AUTHOR is not a public founder; nothing to do."
+            echo "$AUTHOR is not a verified stargazer; nothing to do."
             exit 0
           fi
+
           tier="$(echo "$status" | jq -r '.tier // "supporter"')"
 
-          # 3. One tier -> label map.
-          if [ "$tier" = "founding" ]; then
-            LABEL="founding-supporter"; COLOR="d4af37"; DESC="Verified founding supporter of Celerp"
-          else
-            LABEL="supporter";          COLOR="c9b458"; DESC="Verified Celerp supporter"
-          fi
+          # 3. Tier -> a gold / silver / bronze star (rendered from the :star: shortcode
+          #    family). The star IS the mark; its meaning rides in the description, shown
+          #    on hover. Copy uses "Stargazer" (GitHub's word for someone who starred the
+          #    repo) - precise, and never misreadable as a company founder.
+          case "$tier" in
+            founding) LABEL=":star:";     COLOR="d4af37"; DESC="First Stargazers" ;;
+            early)    LABEL=":star2:";    COLOR="c0c0c0"; DESC="Early Stargazer" ;;
+            *)        LABEL=":sparkles:"; COLOR="cd7f32"; DESC="Stargazer" ;;
+          esac
           gh label create "$LABEL" --repo "$REPO" --color "$COLOR" --description "$DESC" --force || true
 
           # 4. Apply. Issues/PRs share the REST issues-labels endpoint; discussions are
@@ -78,4 +83,4 @@ jobs:
               -f query='mutation($id:ID!,$lbl:ID!){addLabelsToLabelable(input:{labelableId:$id,labelIds:[$lbl]}){clientMutationId}}' \
               -F id="$TARGET" -F lbl="$label_id"
           fi
-          echo "Recognised founder $AUTHOR ($tier) on $KIND -> $LABEL"
+          echo "Recognised stargazer $AUTHOR ($tier) on $KIND -> $LABEL"

--- a/celerp/cli.py
+++ b/celerp/cli.py
@@ -549,7 +549,7 @@ def init(db_url, api_port, ui_port, cloud_token, force):
     from celerp.gateway.state import build_handoff_url as _handoff
     if _settings.star_cta_enabled:
         click.echo(
-            "New and independent - founding supporters are how other teams find us.\n"
+            "New and independent - early stargazers are how other teams find us.\n"
             f"  Back us early: {_handoff('/github', medium='cli')}\n"
         )
 

--- a/celerp/services/supporter_badge.py
+++ b/celerp/services/supporter_badge.py
@@ -33,11 +33,13 @@ def _claims(cred: str) -> dict:
 
 
 def label_for(tier: str, ordinal: int) -> str:
+    # "Stargazer" (GitHub's word for someone who starred the repo) - precise and never
+    # misreadable as a company founder. The top cohort carries its ordinal in parens.
     if tier == "founding":
-        return f"Founding Supporter #{ordinal}"
+        return f"First Stargazers (#{ordinal})"
     if tier == "early":
-        return "Early Supporter"
-    return "Supporter"
+        return "Early Stargazer"
+    return "Stargazer"
 
 
 async def claim(session: AsyncSession, user_id: uuid.UUID, cred: str) -> SupporterBadge:

--- a/tests/test_routers/test_supporter_badge.py
+++ b/tests/test_routers/test_supporter_badge.py
@@ -42,7 +42,7 @@ async def test_claim_then_get(client):
     assert r.status_code == 200
     badge = r.json()["badge"]
     assert badge["tier"] == "founding" and badge["ordinal"] == 8
-    assert badge["label"] == "Founding Supporter #8"
+    assert badge["label"] == "First Stargazers (#8)"
     assert badge["github_login"] == "alice"
 
     g = await client.get("/stars/badge", headers=_h(token))

--- a/ui/components/shell.py
+++ b/ui/components/shell.py
@@ -788,7 +788,7 @@ _STAR_CTA_JS = """
     var el = document.getElementById('supporter-badge');
     if (!el || !d || !d.badge) return;
     el.textContent = '\\u2605';            // just the gold star
-    el.title = d.badge.label;              // tooltip: e.g. "Founding Supporter #1"
+    el.title = d.badge.label;              // tooltip: e.g. "First Stargazers (#1)"
     el.style.display = '';
   }).catch(function(){});
 })();

--- a/ui/routes/dashboard.py
+++ b/ui/routes/dashboard.py
@@ -608,7 +608,7 @@ def setup_routes(app):
             values.pop("margin_pct_sub", None)
         return base_shell(
             page_header(t("page.dashboard", lang)),
-            # Founding-supporter ask shown where setup actually lands (admin only;
+            # Stargazer/supporter ask shown where setup actually lands (admin only;
             # hidden in neutral/dismissed). Self-hides once dismissed install-wide.
             *([star_supporter_card("dashboard")] if _ROLE_LEVELS.get(role, 0) >= _ROLE_LEVELS["admin"] else []),
             _kpi_grid(cfg, values, role=role),


### PR DESCRIPTION
## What
Founder/star recognition stays on **issues, PRs, and discussions**, but the label is now a small **tiered star** with non-misleading copy.

| Tier | Star (shortcode -> renders) | Pill colour | Mouseover |
|------|------------------------------|------------|-----------|
| founding | `:star:` -> ⭐ | gold `#d4af37` | **First Stargazers** |
| early | `:star2:` -> 🌟 | silver `#c0c0c0` | **Early Stargazer** |
| supporter | `:sparkles:` -> ✨ | bronze `#cd7f32` | **Stargazer** |

The label name is the emoji shortcode, which GitHub renders as the emoji in the chip (verified on the live labels page). The meaning rides in the label **description** (hover). In-app/wall/SVG show the personal ordinal: **First Stargazers (#N)**.