### PR TITLE
fix(docs): no-op ghost activity row (#155) + history pager total count (#154)

### DIFF
--- a/default_modules/celerp-docs/celerp_docs/routes.py
+++ b/default_modules/celerp-docs/celerp_docs/routes.py
@@ -825,13 +825,20 @@ async def patch_doc(entity_id: str, payload: DocPatch, company_id: str = Depends
         if field in _MONEY_FIELDS and value is not None:
             return to_stored_float(round_money(value, _currency))
         return value
+    # Keep only fields that actually changed (old != new). A re-select/blur that resets a
+    # field to its current value must emit no event - otherwise it records an empty
+    # `doc.updated` that renders as a ghost activity row (#155).
+    effective = {}
+    for k, change in payload.fields_changed.items():
+        old = _round_field(k, change.get("old") if change.get("old") is not None else row.state.get(k))
+        new = _round_field(k, change.get("new"))
+        if old != new:
+            effective[k] = {"old": old, "new": new}
+    if not effective:
+        return {"event_id": None}
     entry = await emit_event(
         session, company_id=company_id, entity_id=entity_id, entity_type="doc", event_type="doc.updated",
-        data={"fields_changed": {
-            k: {"old": _round_field(k, change.get("old") if change.get("old") is not None else row.state.get(k)),
-                "new": _round_field(k, change.get("new"))}
-            for k, change in payload.fields_changed.items()
-        }, "idempotency_key": payload.idempotency_key},
+        data={"fields_changed": effective, "idempotency_key": payload.idempotency_key},
         actor_id=user.id, location_id=None, source="api",
         idempotency_key=payload.idempotency_key or str(uuid.uuid4()), metadata_={},
     )

--- a/tests/test_routers/test_sprint4.py
+++ b/tests/test_routers/test_sprint4.py
@@ -117,6 +117,27 @@ async def test_patch_doc_line_items(client):
 
 
 @pytest.mark.asyncio
+async def test_patch_noop_emits_no_event(client):
+    """A no-op edit (new == current value) must not emit doc.updated - otherwise it
+    records an empty 'ghost' activity row (#155)."""
+    token = await _register(client)
+    eid = await _create_invoice(client, token)
+    # A real change emits an event.
+    r1 = await client.patch(f"/docs/{eid}", headers=_h(token),
+                            json={"fields_changed": {"customer_note": {"old": None, "new": "hello"}}})
+    assert r1.status_code == 200 and r1.json()["event_id"] is not None
+    # Re-setting the field to its current value (client omits old; server resolves it from
+    # state) changes nothing -> no event.
+    r2 = await client.patch(f"/docs/{eid}", headers=_h(token),
+                            json={"fields_changed": {"customer_note": {"old": None, "new": "hello"}}})
+    assert r2.status_code == 200 and r2.json()["event_id"] is None
+    # An actual change after that still emits.
+    r3 = await client.patch(f"/docs/{eid}", headers=_h(token),
+                            json={"fields_changed": {"customer_note": {"old": "hello", "new": "world"}}})
+    assert r3.status_code == 200 and r3.json()["event_id"] is not None
+
+
+@pytest.mark.asyncio
 async def test_patch_doc_updates_totals(client):
     """Patching subtotal/tax/total stores them in projection."""
     token = await _register(client)

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -13787,3 +13787,17 @@ async def test_bulk_attach_result_has_status_filters(ui_client):
     assert 'data-filter="ok"' in html
     assert 'data-filter="unmatched"' in html
     assert 'data-filter="error"' not in html  # no errors in this batch → no Errors pill
+
+
+def test_compact_pages_shows_full_count_and_last():
+    """#154: the doc-history pager must surface the real page count and a reachable last
+    page, not just current ±1. (None marks an ellipsis gap.)"""
+    from ui.routes.documents import _compact_pages
+    assert _compact_pages(1, 1) == [1]
+    assert _compact_pages(1, 2) == [1, 2]
+    assert _compact_pages(1, 3) == [1, 2, 3]            # all pages visible up front
+    assert _compact_pages(2, 3) == [1, 2, 3]
+    assert _compact_pages(1, 10) == [1, 2, None, 10]    # last page reachable from page 1
+    assert _compact_pages(5, 10) == [1, None, 4, 5, 6, None, 10]
+    assert _compact_pages(9, 10) == [1, None, 8, 9, 10]
+    assert _compact_pages(10, 10) == [1, None, 9, 10]

--- a/ui/routes/documents.py
+++ b/ui/routes/documents.py
@@ -323,6 +323,27 @@ def _action_error(msg: str, target_id: str = "action-error"):
     )
 
 
+def _compact_pages(page: int, total_pages: int) -> list[int | None]:
+    """Page numbers to show in a compact pager: first, current +/- 1, last, with `None`
+    marking an ellipsis gap. Drives the doc-history pager so the real page count (and the
+    last page) is reachable up front (#154)."""
+    out: list[int | None] = []
+    if page > 2:
+        out.append(1)
+    if page > 3:
+        out.append(None)
+    if page > 1:
+        out.append(page - 1)
+    out.append(page)
+    if page < total_pages:
+        out.append(page + 1)
+    if page < total_pages - 2:
+        out.append(None)
+    if page < total_pages - 1:
+        out.append(total_pages)
+    return out
+
+
 def _render_receive_return_section(doc: dict):
     """Receive Returns button - shown on credit notes when celerp-inventory is installed.
 
@@ -3343,12 +3364,12 @@ celerpUpdateBulkAlloc();
             per_page = _DEFAULT_PER_PAGE
         offset = (page - 1) * per_page
         try:
-            resp = await api.list_ledger(token, {"entity_id": entity_id, "limit": per_page + 1, "offset": offset, "resolve": "true"})
-            items = resp.get("items", []) if isinstance(resp, dict) else []
+            resp = await api.list_ledger(token, {"entity_id": entity_id, "limit": per_page, "offset": offset, "resolve": "true"})
+            entries = resp.get("items", []) if isinstance(resp, dict) else []
+            total = int(resp.get("total", len(entries))) if isinstance(resp, dict) else len(entries)
         except Exception:
-            items = []
-        has_next = len(items) > per_page
-        entries = items[:per_page]
+            entries, total = [], 0
+        total_pages = max(1, (total + per_page - 1) // per_page)
         from ui.components.activity import format_timestamp, detail_from_entry, _event_display, _is_uuid
         EMPTY = "--"
         def _row(e: dict):
@@ -3370,19 +3391,12 @@ celerpUpdateBulkAlloc();
                 hx_target=f"#doc-history-{safe_id}",
                 hx_swap="outerHTML",
             )
-        # Build compact page number list: always show first, last, current ±1,
-        # with ellipsis gaps. We don't know total pages without a count query,
-        # so show prev/current/next when known.
-        page_btns = []
-        if page > 2:
-            page_btns.append(_page_btn(1))
-        if page > 3:
-            page_btns.append(Span("…", cls="text-muted"))
-        if page > 1:
-            page_btns.append(_page_btn(page - 1))
-        page_btns.append(_page_btn(page, active=True))
-        if has_next:
-            page_btns.append(_page_btn(page + 1))
+        # Compact page list from the real total: first … current±1 … last, so the full
+        # page count shows up front and the last page is directly reachable (#154).
+        page_btns = [
+            Span("…", cls="text-muted") if p is None else _page_btn(p, active=(p == page))
+            for p in _compact_pages(page, total_pages)
+        ]
         per_page_select = Select(
             *[Option(str(n), value=str(n), selected=(per_page == n)) for n in (10, 20, 50, 100)],
             cls="per-page-select",


### PR DESCRIPTION
Two doc-history bug fixes.

## #155 - Ghost activity row on no-op edits
`patch_doc` emitted `doc.updated` for every field in `fields_changed` with no `old != new` check, so re-setting a field to its current value (e.g. re-selecting the same tax) recorded an empty `--` activity row. Now only changed fields are recorded, and a patch where nothing changed emits no event (returns `event_id: null`).

## #154 - History pager hid the real page count
The doc-history pager used a `+1` peek to learn only whether a next page existed, so it showed current ±1 and never the last page (page 3 was invisible until you clicked page 2). The `/ledger` endpoint already returns `total`; the pager now uses it to compute `total_pages` and render **first … current±1 … last**. The window logic was extracted to a pure, unit-tested `_compact_pages()` helper.

## Tests
- `test_patch_noop_emits_no_event` (real change emits, no-op doesn't, later real change still does).
- `test_compact_pages_shows_full_count_and_last` (full count up front; last page reachable).
- Patch-heavy `test_sprint4` suite re-run green (the `old != new` filter doesn't break existing patch behavior).

Branched off current `main` (PR #152, which carried earlier bugfix work, was already squash-merged).

Fixes #154
Fixes #155
