### PR TITLE
fix(backup): stream backup download (#158) + init --force purges files (#160)

### DIFF
--- a/celerp/cli.py
+++ b/celerp/cli.py
@@ -430,8 +430,9 @@ def main() -> None:
 @click.option("--api-port", default=None, type=int, help="API server port (default 8000).")
 @click.option("--ui-port", default=None, type=int, help="UI server port (default 8080).")
 @click.option("--cloud-token", default=None, help="Celerp Cloud token (optional).")
-@click.option("--force", is_flag=True, help="Overwrite existing config.")
-def init(db_url, api_port, ui_port, cloud_token, force):
+@click.option("--force", is_flag=True, help="Reconfigure: WIPES the database and all attached files.")
+@click.option("--yes", "-y", "assume_yes", is_flag=True, help="Skip the --force wipe confirmation (non-interactive use).")
+def init(db_url, api_port, ui_port, cloud_token, force, assume_yes):
     """Initialize Celerp: write config and run database migrations."""
     config_path = _config_path()
 
@@ -441,6 +442,21 @@ def init(db_url, api_port, ui_port, cloud_token, force):
         return
 
     if force:
+        # --force is destructive: it drops the database AND removes attached files.
+        # init can run under sudo, so warn (with full paths) and confirm before wiping.
+        from celerp.config import settings
+        _purge_dirs = [
+            settings.data_dir / "static" / "attachments",
+            settings.data_dir / "ai_uploads",
+        ]
+        click.echo("⚠  `init --force` permanently WIPES this instance:")
+        click.echo(f"     - database: {db_url or _DEFAULT_DB_URL}")
+        for _d in _purge_dirs:
+            click.echo(f"     - files:    {_d.resolve()}")
+        click.echo("   Make sure you have a backup.")
+        if not assume_yes and not click.confirm("Continue?", default=False):
+            click.echo("Aborted.")
+            return
         _stop_servers()
 
     enabled_modules: list[str] = []
@@ -469,6 +485,13 @@ def init(db_url, api_port, ui_port, cloud_token, force):
             )
             sys.exit(1)
         click.echo("  ✓ Database ready (fresh)")
+        # Wipe attached files too, so a forced re-init is a truly fresh instance and no
+        # orphaned files remain. Recreated automatically on next boot.
+        import shutil
+        for _d in _purge_dirs:
+            if _d.exists():
+                shutil.rmtree(_d, ignore_errors=True)
+                click.echo(f"  ✓ Removed {_d.resolve()}")
     else:
         # Test DB connection — auto-provision if running as root
         click.echo("Connecting to database...")

--- a/default_modules/celerp-backup/celerp_backup/routes.py
+++ b/default_modules/celerp-backup/celerp_backup/routes.py
@@ -22,6 +22,7 @@ from pathlib import Path
 import httpx
 from fastapi import APIRouter, Depends, File, HTTPException, Request, UploadFile
 from fastapi.responses import FileResponse, Response
+from starlette.background import BackgroundTask
 
 from celerp.db import get_session
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -191,7 +192,10 @@ async def export_local() -> FileResponse:
         path = await export_full()
     except RuntimeError as exc:
         raise HTTPException(status_code=422, detail=str(exc))
-    return FileResponse(path=str(path), filename=path.name, media_type="application/gzip")
+    # export_full writes a temp archive (delete=False); remove it once the response is
+    # sent so multi-GB exports don't pile up in the temp dir.
+    return FileResponse(path=str(path), filename=path.name, media_type="application/gzip",
+                        background=BackgroundTask(path.unlink, missing_ok=True))
 
 
 @router.get("/export/{backup_id}")
@@ -202,7 +206,8 @@ async def export_cloud(backup_id: str) -> FileResponse:
         path = await export_from_cloud(backup_id)
     except RuntimeError as exc:
         raise HTTPException(status_code=422, detail=str(exc))
-    return FileResponse(path=str(path), filename=path.name, media_type="application/gzip")
+    return FileResponse(path=str(path), filename=path.name, media_type="application/gzip",
+                        background=BackgroundTask(path.unlink, missing_ok=True))
 
 
 @router.post("/import")

--- a/tests/test_bootstrap_flow.py
+++ b/tests/test_bootstrap_flow.py
@@ -159,7 +159,7 @@ def test_force_init_as_root_wipes_db_and_regenerates_secret(tmp_config, written_
          patch(_PATCHES["post_grants"]), \
          patch("celerp.cli._needs_ownership_fix", return_value=False), \
          patch(_PATCHES["start"]):
-        result = runner.invoke(main, ["init", "--force"])
+        result = runner.invoke(main, ["init", "--force", "--yes"])
 
     assert result.exit_code == 0, result.output
     mock_stop.assert_called_once()
@@ -185,7 +185,7 @@ def test_force_init_non_root_also_drops_db(tmp_config, written_cfg):
          patch(_PATCHES["post_grants"]), \
          patch("celerp.cli._needs_ownership_fix", return_value=False), \
          patch(_PATCHES["start"]):
-        result = runner.invoke(main, ["init", "--force"])
+        result = runner.invoke(main, ["init", "--force", "--yes"])
 
     assert result.exit_code == 0, result.output
     mock_prov.assert_called_once()
@@ -201,7 +201,7 @@ def test_force_init_provision_failure_exits(tmp_config, written_cfg):
     runner = CliRunner()
     with patch(_PATCHES["stop"]), \
          patch("celerp.cli._provision_db", side_effect=RuntimeError("pg down")):
-        result = runner.invoke(main, ["init", "--force"])
+        result = runner.invoke(main, ["init", "--force", "--yes"])
 
     assert result.exit_code != 0
     assert "DB wipe failed" in result.output

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -136,7 +136,7 @@ def test_init_force_stops_servers_and_regenerates_secret(tmp_config, valid_cfg):
          patch("celerp.cli._stop_servers") as mock_stop, \
          patch("celerp.cli._provision_db"), \
          patch("celerp.cli._needs_ownership_fix", return_value=False):
-        result = runner.invoke(main, ["init", "--force"])
+        result = runner.invoke(main, ["init", "--force", "--yes"])
     assert result.exit_code == 0, result.output
     assert "✓ Celerp initialized" in result.output
     mock_stop.assert_called_once()
@@ -348,3 +348,47 @@ def test_start_exits_without_sentinel(tmp_path):
 
     assert exc.value.code == 1
     assert len([c for c in spawn_calls if _is_api_cmd(c)]) == 1, "No respawn without sentinel"
+
+
+# ── celerp init --force purges files (#160) ──────────────────────────────────
+
+def _seed_data_dir(tmp_path, monkeypatch):
+    """Point settings.data_dir at a temp dir seeded with attachment + ai_upload files."""
+    from celerp.config import settings
+    data_dir = tmp_path / "data"
+    att = data_dir / "static" / "attachments"
+    att.mkdir(parents=True)
+    (att / "img.png").write_bytes(b"x")
+    ai = data_dir / "ai_uploads"
+    ai.mkdir(parents=True)
+    (ai / "doc.pdf").write_bytes(b"y")
+    monkeypatch.setattr(settings, "data_dir", data_dir)
+    return att, ai
+
+
+def test_init_force_yes_wipes_db_and_files(tmp_config, tmp_path, monkeypatch):
+    """--force --yes wipes the DB and removes attachment + ai_uploads dirs (no prompt)."""
+    att, ai = _seed_data_dir(tmp_path, monkeypatch)
+    runner = CliRunner()
+    with patch("celerp.cli._provision_db") as prov, \
+         patch("celerp.cli._stop_servers"), \
+         patch(_INIT_PATCHES["run_migrations"]), \
+         patch(_INIT_PATCHES["post_grants"]), \
+         patch(_INIT_PATCHES["start"]):
+        result = runner.invoke(main, ["init", "--force", "--yes"])
+    assert result.exit_code == 0, result.output
+    prov.assert_called_once()           # DB wiped
+    assert not att.exists() and not ai.exists()   # files removed
+
+
+def test_init_force_aborts_on_no_keeps_everything(tmp_config, tmp_path, monkeypatch):
+    """Without --yes, answering No to the wipe warning aborts: DB and files untouched."""
+    att, ai = _seed_data_dir(tmp_path, monkeypatch)
+    runner = CliRunner()
+    with patch("celerp.cli._provision_db") as prov, \
+         patch("celerp.cli._stop_servers") as stop:
+        result = runner.invoke(main, ["init", "--force"], input="n\n")
+    assert "Aborted" in result.output
+    prov.assert_not_called()            # DB not wiped
+    stop.assert_not_called()
+    assert att.exists() and ai.exists() # files kept

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -13080,7 +13080,14 @@ class TestBackupRoutes:
 
         async def fake_export(token: str):
             captured["token"] = token
-            return (b"fakedata", "application/octet-stream", "attachment; filename=backup.celerp-backup")
+
+            async def _stream():
+                yield b"fakedata"
+
+            return _stream(), {
+                "content-type": "application/octet-stream",
+                "content-disposition": "attachment; filename=backup.celerp-backup",
+            }
 
         with patch.object(_api, "export_backup", fake_export):
             async with ui_client as c:

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -13789,6 +13789,34 @@ async def test_bulk_attach_result_has_status_filters(ui_client):
     assert 'data-filter="error"' not in html  # no errors in this batch → no Errors pill
 
 
+@pytest.mark.asyncio
+async def test_backup_export_streams_with_progress_headers(ui_client):
+    """#158: the backup download streams through (not buffered) and forwards Content-Length
+    + Content-Disposition, so a multi-GB archive doesn't sit in memory and the browser shows
+    a real download progress bar."""
+    chunks = [b"PK\x03\x04", b"x" * 2048, b"tail"]
+    total = sum(len(c) for c in chunks)
+
+    async def _fake_stream():
+        for ch in chunks:
+            yield ch
+
+    async def _fake_export(token):
+        return _fake_stream(), {
+            "content-length": str(total),
+            "content-disposition": "attachment; filename=backup.celerp-backup",
+            "content-type": "application/gzip",
+        }
+
+    with patch("ui.api_client.export_backup", _fake_export):
+        r = await ui_client.get("/backup/export", cookies=_authed())
+    assert r.status_code == 200
+    assert r.content == b"".join(chunks)              # streamed through intact
+    assert r.headers["content-length"] == str(total)  # browser progress bar
+    assert r.headers["content-disposition"] == "attachment; filename=backup.celerp-backup"
+    assert r.headers["content-type"].startswith("application/gzip")
+
+
 def test_compact_pages_shows_full_count_and_last():
     """#154: the doc-history pager must surface the real page count and a reachable last
     page, not just current ±1. (None marks an ellipsis gap.)"""

--- a/ui/api_client.py
+++ b/ui/api_client.py
@@ -2042,18 +2042,50 @@ async def trigger_backup(token: str, backup_type: str = "database") -> None:
         _raise(await c.post("/backup/trigger", params={"type": backup_type}))
 
 
-async def export_backup(token: str) -> tuple[bytes, str, str]:
-    """GET /backup/export — fetch full local backup archive from the API process.
+async def export_backup(token: str):
+    """GET /backup/export, streamed. Returns (chunk_iterator, headers).
 
-    Returns (content_bytes, content_type, content_disposition).
+    The backup archive can be many GB (DB dump + attachments), so we never buffer it in
+    memory: the caller pipes the iterator straight into a StreamingResponse, and the httpx
+    client + response stay open until the iterator is exhausted. The server builds the
+    archive (pg_dump + bundling) before the first byte, so the read timeout is generous;
+    once bytes flow, each chunk just needs to arrive within it. We forward Content-Length
+    so the browser shows a real download progress bar.
     """
-    async with _api_client(token) as c:
-        r = _raise(await c.get("/backup/export"))
-        return (
-            r.content,
-            r.headers.get("content-type", "application/octet-stream"),
-            r.headers.get("content-disposition", "attachment; filename=backup.celerp-backup"),
-        )
+    client = _client(token, timeout=httpx.Timeout(300.0, connect=10.0))
+    try:
+        resp = await client.send(client.build_request("GET", "/backup/export"), stream=True)
+    except httpx.TimeoutException as exc:
+        await client.aclose()
+        raise APIError(504, "Backup timed out — the archive took too long to build.") from exc
+    except httpx.ConnectError as exc:
+        await client.aclose()
+        raise APIError(503, f"Cannot reach API at {API_BASE} — is the server running?") from exc
+    if resp.status_code >= 400:
+        body = await resp.aread()
+        await resp.aclose()
+        await client.aclose()
+        try:
+            import json as _json
+            detail = _json.loads(body).get("detail", body.decode("utf-8", "replace"))
+        except Exception:
+            detail = body.decode("utf-8", "replace")
+        raise APIError(resp.status_code, detail)
+    headers = {
+        k: resp.headers[k]
+        for k in ("content-length", "content-disposition", "content-type")
+        if k in resp.headers
+    }
+
+    async def _iter():
+        try:
+            async for chunk in resp.aiter_bytes():
+                yield chunk
+        finally:
+            await resp.aclose()
+            await client.aclose()
+
+    return _iter(), headers
 
 
 async def export_cloud_backup(token: str, backup_id: str) -> tuple[bytes, str, str]:

--- a/ui/routes/settings.py
+++ b/ui/routes/settings.py
@@ -2456,23 +2456,28 @@ def setup_routes(app):
 
     @app.get("/backup/export")
     async def backup_export(request: Request):
-        """Download full local backup archive (.celerp-backup)."""
+        """Stream the full local backup archive (.celerp-backup) to the browser.
+
+        Streamed (not buffered) so a multi-GB backup never sits in UI memory and isn't
+        bound by the short default timeout; forwarding Content-Length gives the browser a
+        native download progress bar."""
         import ui.api_client as _api
+        from starlette.responses import StreamingResponse
         token = _token(request)
         if not token:
             return RedirectResponse("/login", status_code=302)
         try:
-            content, content_type, content_disp = await _api.export_backup(token)
+            stream, headers = await _api.export_backup(token)
         except _api.APIError as exc:
             from fasthtml.common import Div, to_xml
             return Response(
                 content=to_xml(Div(str(exc.detail), cls="flash flash--error")),
                 media_type="text/html",
             )
-        return Response(
-            content=content,
-            media_type=content_type,
-            headers={"Content-Disposition": content_disp},
+        return StreamingResponse(
+            stream,
+            media_type=headers.get("content-type", "application/octet-stream"),
+            headers={k.title(): v for k, v in headers.items() if k != "content-type"},
         )
 
     @app.get("/backup/export/{backup_id}")


### PR DESCRIPTION
Two backup-related bug fixes.

## #158 - Backup download times out (and buffers GBs in memory)
The UI fetched `/backup/export` with `r.content`, buffering the entire archive (DB dump + attachments, often GBs) in UI-process memory and bound by the **10s default timeout** - so large backups timed out before finishing.

**Thorough fix (done once, not a band-aid):**
- **Stream UI -> browser.** `api_client.export_backup` now opens an httpx *stream* and yields chunks; the settings route pipes them into a `StreamingResponse`. Memory stays flat regardless of backup size; the transfer is no longer capped by a short total timeout (generous read timeout for the build, then chunks flow).
- **Progress indicator (free, native).** We forward `Content-Length`, so the browser's own download manager shows a real progress bar - useful for LAN/remote pulls of a multi-GB file. *(The build phase - pg_dump + bundling - is an inherent wait before the first byte; showing a % for that would need a background-job system, deliberately out of scope.)*
- **Temp-file leak fixed.** `export_local`/`export_cloud` returned a `FileResponse` over a `delete=False` temp archive with no cleanup, leaving a ~GB temp file behind on every export. Added a `BackgroundTask` to unlink it once the response is sent.

The API side already streamed from a temp file (`FileResponse` with `Content-Length`); the breakage and the buffering were entirely on the UI side.

## #160 - `init --force` leaves attached files on disk
`init --force` dropped the database but left `data_dir/static/attachments` and `data_dir/ai_uploads`, so a forced re-init left orphaned files (not "truly fresh").

**Fix:** `--force` now removes those dirs too. Since it's destructive (and can run under `sudo`), it first prints a clear warning with the **full resolved paths** and **confirms** before wiping ("Make sure you have a backup."). A **`--yes`** flag skips the prompt for non-interactive/scripted use. Dirs are recreated on next boot.

## Tests
- `test_backup_export_streams_with_progress_headers` - streams through intact + forwards Content-Length/Disposition.
- `test_init_force_yes_wipes_db_and_files` + `test_init_force_aborts_on_no_keeps_everything`.
- Updated the pre-existing `--force` tests (cli + bootstrap_flow) to pass `--yes` (the proceed path now needs it).

Branched off `main`.

Fixes #158
Fixes #160
