### PR TITLE
fix(history): per-item tax change shows % and amount

### DIFF
--- a/tests/test_item_history.py
+++ b/tests/test_item_history.py
@@ -383,6 +383,47 @@ def test_derived_doc_totals_suppressed_in_summary():
     assert _fields_changed_summary({"subtotal": {"old": 20, "new": 30}, "total": {"old": 20, "new": 30}}) == ""
 
 
+def test_per_item_tax_change_shows_pct_and_amount():
+    """#156: a per-item tax-rate change names the item, the % change, and the amount -
+    not a bare, item-less document-level 'Tax: 0.00 → 503.44'."""
+    from ui.components.activity import _fields_changed_summary
+    fields = {
+        "line_items": {
+            "old": [{"sku": "DEMO-AUTO-007", "name": "Widget", "quantity": 1,
+                     "unit_price": 7192, "line_total": 7192, "tax_rate": 0}],
+            "new": [{"sku": "DEMO-AUTO-007", "name": "Widget", "quantity": 1,
+                     "unit_price": 7192, "line_total": 7192, "tax_rate": 7}],
+        },
+        # the document-level scalar that today renders as a bare, item-less amount
+        "tax": {"old": 0.0, "new": 503.44},
+        "tax_amount": {"old": 0.0, "new": 503.44},
+    }
+    summary = _fields_changed_summary(fields, "USD")
+    assert "DEMO-AUTO-007 Tax 0% → 7%" in summary  # 7192 × 7% = 503.44
+    assert "503.44" in summary
+    # the bare, item-less document-level tax scalar is suppressed (no "Tax: 0.00 → 503.44")
+    assert "Tax: " not in summary
+
+
+def test_per_item_tax_change_reads_structured_taxes():
+    """Effective rate is read from the structured taxes list (summed), not only legacy tax_rate."""
+    from ui.components.activity import _fields_changed_summary
+    fields = {"line_items": {
+        "old": [{"sku": "A", "name": "A", "line_total": 1000, "taxes": []}],
+        "new": [{"sku": "A", "name": "A", "line_total": 1000,
+                 "taxes": [{"code": "VAT", "rate": 10.0}]}],
+    }}
+    summary = _fields_changed_summary(fields, "USD")
+    assert "A Tax 0% → 10%" in summary
+    assert "100.00" in summary  # 1000 × 10%
+
+
+def test_doc_tax_scalar_kept_when_no_per_item_change():
+    """With no per-line tax change, a document-level tax field still renders unchanged."""
+    from ui.components.activity import _fields_changed_summary
+    assert _fields_changed_summary({"tax": {"old": 0, "new": 50}}, "USD") == "Tax: $0.00 → $50.00"
+
+
 def test_added_line_item_shows_type_qty_price():
     # Auditors need to see what kind of item was added and at what value. Bills/POs carry an
     # explicit receive_as (stock/expense); invoice lines read as Stock (linked catalog item) or

--- a/ui/components/activity.py
+++ b/ui/components/activity.py
@@ -594,6 +594,59 @@ def _discount_change_summary(fields_changed: dict, currency: str | None):
     return ", ".join(parts), _DISCOUNT_CONSUMED
 
 
+def _line_effective_tax(li: dict) -> tuple[float, float]:
+    """(rate_percent, tax_amount) for a line. Reads the legacy per-line ``tax_rate`` or the
+    structured ``taxes`` list (summed rates); amount is ``line_total × rate / 100`` — the same
+    per-line formula list totals are recomputed with (see doc_projections._recalc_list_totals)."""
+    try:
+        rate = float(li.get("tax_rate") or 0)
+        if not rate and isinstance(li.get("taxes"), list):
+            rate = sum(float(tx.get("rate") or 0) for tx in li["taxes"] if isinstance(tx, dict))
+        line_total = float(li.get("line_total") or 0)
+    except (TypeError, ValueError):
+        return 0.0, 0.0
+    return rate, line_total * rate / 100
+
+
+def _line_tax_change_summary(fields_changed: dict, currency: str | None):
+    """Per-item tax-rate changes from a line_items diff, e.g.
+    'DEMO-AUTO-007 Tax 0% → 7% (0.00 → 503.44)'.
+
+    Returns (parts, consumed). When any per-line tax change is shown we consume the
+    document-level ``tax`` scalar so the history doesn't also dump a bare, item-less
+    "Tax: 0.00 → 503.44" for the same change.
+    """
+    change = fields_changed.get("line_items")
+    if not isinstance(change, dict):
+        return [], frozenset()
+    old, new = change.get("old"), change.get("new")
+    if not isinstance(old, list) or not isinstance(new, list):
+        return [], frozenset()
+
+    def _key(li):
+        return li.get("entity_id") or li.get("item_id") or li.get("sku") or li.get("name") or ""
+
+    old_by = {_key(li): li for li in old if isinstance(li, dict)}
+    parts: list[str] = []
+    for li in new:
+        if not isinstance(li, dict):
+            continue
+        prev = old_by.get(_key(li))
+        if prev is None:  # added lines are reported by the line_items add/remove diff
+            continue
+        o_rate, o_amt = _line_effective_tax(prev)
+        n_rate, n_amt = _line_effective_tax(li)
+        if o_rate == n_rate:
+            continue
+        name = li.get("sku") or li.get("name") or ""
+        label = f"{name} " if name else ""
+        parts.append(
+            f"{label}Tax {o_rate:g}% → {n_rate:g}% "
+            f"({fmt_price(o_amt, 'tax', currency)} → {fmt_price(n_amt, 'tax', currency)})"
+        )
+    return parts, (frozenset({"tax"}) if parts else frozenset())
+
+
 def _fields_changed_summary(fields_changed: dict, currency: str | None = None) -> str:
     """Compact summary of field changes from a ledger data dict.
 
@@ -610,11 +663,16 @@ def _fields_changed_summary(fields_changed: dict, currency: str | None = None) -
     # they don't double-render.
     discount_summary, consumed = _discount_change_summary(fields_changed, currency)
 
+    # Per-item tax-rate changes render explicitly (which item, the % and the amount); doing so
+    # consumes the document-level `tax` scalar so the same change isn't also dumped item-less.
+    tax_parts, tax_consumed = _line_tax_change_summary(fields_changed, currency)
+    consumed = consumed | tax_consumed
+
     user_fields = {k: v for k, v in fields_changed.items()
                    if k not in _SYSTEM_FIELDS and k not in _DERIVED_DOC_FIELDS
                    and k not in consumed
                    and k not in {"attachments", "preview_image_id"}}
-    if not user_fields and not discount_summary:
+    if not user_fields and not discount_summary and not tax_parts:
         return ""
 
     # Suppress raw-ID fields when the companion human-readable field is also present.
@@ -736,7 +794,7 @@ def _fields_changed_summary(fields_changed: dict, currency: str | None = None) -
         else:
             scalar_parts.append(label)
 
-    all_parts = ([discount_summary] if discount_summary else []) + scalar_parts + complex_labels
+    all_parts = ([discount_summary] if discount_summary else []) + tax_parts + scalar_parts + complex_labels
     if not all_parts:
         return ""
     suffix = "…" if len(all_parts) > 4 else ""


### PR DESCRIPTION
## Summary

Fixes the invoice/document history so a **per-item tax change** is legible.

**So that** the history clearly shows *which item* a tax change was for, with the tax **%** and the **amount** — instead of a bare, item-less document-level figure.

### Before
The line-items diff only compared quantity and unit price, so a tax-rate change produced no per-line entry — you got only the document-level scalar:
```
Document updated … Tax: 0.00 → 503.44
```
(no item, no percentage, just an absolute amount.)

### After
```
DEMO-AUTO-007 Tax 0% → 7% ($0.00 → $503.44)
```
- Effective rate read from the legacy per-line `tax_rate` **or** the structured `taxes` list (summed rates).
- Amount computed `line_total × rate / 100` — the same per-line formula `doc_projections._recalc_list_totals` uses.
- Showing the per-item change **consumes the document-level `tax` scalar**, so the same edit isn't also dumped item-less.
- A document-level tax change with **no** per-line change still renders as before (fallback unchanged).

Pure history-rendering change in `ui/components/activity.py` — no event/schema changes, no migrations.

## Tests
`tests/test_item_history.py`: the idea's exact example (7% of 7192 = 503.44), the structured-`taxes` path, and that a no-per-item-change doc tax scalar still renders. Broader history/doc suite (item history, doc money/history, file activity, fulfillment, doc workflows) green — **199 passed**.

Addresses discussion #156.
