### PR TITLE
feat(nav): "Change password" link in the user menu

### DIFF
--- a/ui/components/shell.py
+++ b/ui/components/shell.py
@@ -1128,6 +1128,11 @@ def _topbar(companies: list[dict], lang: str = "en", user_email: str | None = No
                         cls="user-menu__item",
                     ),
                     A(
+                        "🔑 " + t("nav.change_password", lang, default="Change password"),
+                        href="/settings/general?tab=password",
+                        cls="user-menu__item",
+                    ),
+                    A(
                         "⎋ " + t("nav.logout", lang),
                         href="/logout",
                         cls="user-menu__item user-menu__item--logout",

--- a/ui/locales/ar.json
+++ b/ui/locales/ar.json
@@ -848,6 +848,7 @@
   "nav.labels": "الملصقات",
   "nav.lists": "القوائم",
   "nav.lists_quotations": "القوائم / عروض الأسعار",
+  "nav.change_password": "تغيير كلمة المرور",
   "nav.logout": "تسجيل الخروج",
   "nav.report_bug": "الإبلاغ عن خطأ",
   "nav.suggest_feature": "اقتراح ميزة",

--- a/ui/locales/de.json
+++ b/ui/locales/de.json
@@ -848,6 +848,7 @@
   "nav.labels": "Etiketten",
   "nav.lists": "Listen",
   "nav.lists_quotations": "Listen / Angebote",
+  "nav.change_password": "Passwort ändern",
   "nav.logout": "Abmelden",
   "nav.report_bug": "Fehler melden",
   "nav.suggest_feature": "Funktion vorschlagen",

--- a/ui/locales/en.json
+++ b/ui/locales/en.json
@@ -849,6 +849,7 @@
   "nav.labels": "Labels",
   "nav.lists": "Lists",
   "nav.lists_quotations": "Lists / Quotations",
+  "nav.change_password": "Change password",
   "nav.logout": "Logout",
   "nav.report_bug": "Report a bug",
   "nav.suggest_feature": "Suggest a feature",

--- a/ui/locales/es.json
+++ b/ui/locales/es.json
@@ -848,6 +848,7 @@
   "nav.labels": "Etiquetas",
   "nav.lists": "Liza",
   "nav.lists_quotations": "Listas / Cotizaciones",
+  "nav.change_password": "Cambiar contraseña",
   "nav.logout": "Cerrar sesión",
   "nav.report_bug": "Reportar un error",
   "nav.suggest_feature": "Sugerir una función",

--- a/ui/locales/fr.json
+++ b/ui/locales/fr.json
@@ -848,6 +848,7 @@
   "nav.labels": "Étiquettes",
   "nav.lists": "Listes",
   "nav.lists_quotations": "Listes / Devis",
+  "nav.change_password": "Changer le mot de passe",
   "nav.logout": "Déconnexion",
   "nav.report_bug": "Signaler un bug",
   "nav.suggest_feature": "Suggérer une fonctionnalité",

--- a/ui/locales/id.json
+++ b/ui/locales/id.json
@@ -848,6 +848,7 @@
   "nav.labels": "Label",
   "nav.lists": "Daftar",
   "nav.lists_quotations": "Daftar / Penawaran",
+  "nav.change_password": "Ubah kata sandi",
   "nav.logout": "Keluar",
   "nav.report_bug": "Laporkan bug",
   "nav.suggest_feature": "Sarankan fitur",

--- a/ui/locales/it.json
+++ b/ui/locales/it.json
@@ -848,6 +848,7 @@
   "nav.labels": "Etichette",
   "nav.lists": "Liste",
   "nav.lists_quotations": "Liste / Preventivi",
+  "nav.change_password": "Cambia password",
   "nav.logout": "Esci",
   "nav.report_bug": "Segnala un bug",
   "nav.suggest_feature": "Suggerisci una funzione",

--- a/ui/locales/ja.json
+++ b/ui/locales/ja.json
@@ -848,6 +848,7 @@
   "nav.labels": "ラベル",
   "nav.lists": "リスト",
   "nav.lists_quotations": "リスト・見積",
+  "nav.change_password": "パスワードを変更",
   "nav.logout": "ログアウト",
   "nav.report_bug": "バグを報告",
   "nav.suggest_feature": "機能を提案",

--- a/ui/locales/pt.json
+++ b/ui/locales/pt.json
@@ -848,6 +848,7 @@
   "nav.labels": "Etiquetas",
   "nav.lists": "Listas",
   "nav.lists_quotations": "Listas / Cotações",
+  "nav.change_password": "Alterar senha",
   "nav.logout": "Sair",
   "nav.report_bug": "Reportar bug",
   "nav.suggest_feature": "Sugerir um recurso",

--- a/ui/locales/th.json
+++ b/ui/locales/th.json
@@ -848,6 +848,7 @@
   "nav.labels": "ป้ายกำกับ",
   "nav.lists": "รายการ",
   "nav.lists_quotations": "รายการ / ใบเสนอราคา",
+  "nav.change_password": "เปลี่ยนรหัสผ่าน",
   "nav.logout": "ออกจากระบบ",
   "nav.report_bug": "รายงานข้อผิดพลาด",
   "nav.suggest_feature": "แนะนำฟีเจอร์",

--- a/ui/locales/vi.json
+++ b/ui/locales/vi.json
@@ -848,6 +848,7 @@
   "nav.labels": "Nhãn",
   "nav.lists": "Danh sách",
   "nav.lists_quotations": "Danh sách / Báo giá",
+  "nav.change_password": "Đổi mật khẩu",
   "nav.logout": "Đăng xuất",
   "nav.report_bug": "Báo lỗi",
   "nav.suggest_feature": "Đề xuất tính năng",


### PR DESCRIPTION
## Summary

Adds a **Change password** link to the user menu (the email dropdown in the top bar), above Logout.

**So that** users can reach the password change page without hunting through settings.

It points to the existing page — `/settings/general?tab=password` (Settings → General → Change password) — no new backend. Translated across all 11 locales (`nav.change_password`), matching the sibling nav items.

Verified: rendered topbar contains the link with the correct href, ordered above Logout; stars-UI/menu test green; app imports clean.