### PR TITLE
chore(bug-report): friendlier form + auto-set area from celerp

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -26,18 +26,6 @@ body:
     validations:
       required: true
   - type: dropdown
-    id: install_method
-    attributes:
-      label: Installation method
-      options:
-        - .dmg (macOS)
-        - .exe (Windows)
-        - AppImage (Linux)
-        - pip
-        - Other
-    validations:
-      required: true
-  - type: dropdown
     id: area
     attributes:
       label: Area
@@ -64,25 +52,27 @@ body:
     validations:
       required: false
   - type: textarea
-    id: repro
+    id: current
     attributes:
-      label: Steps to reproduce
-      placeholder: |
-        1. ...
-        2. ...
-        3. ...
+      label: Currently, the system is...
+      description: What is the system doing (that it shouldn't)? In your own words - and if you can, what you did to see it.
+      placeholder: "When I ..., the system ..."
     validations:
       required: true
   - type: textarea
-    id: expected
+    id: should
     attributes:
-      label: Expected behavior
+      label: It should...
+      description: What did you expect to happen instead?
+      placeholder: "It should ..."
     validations:
       required: true
   - type: textarea
-    id: actual
+    id: so_that
     attributes:
-      label: Actual behavior
+      label: So that...
+      description: Why does this matter - what are you trying to get done?
+      placeholder: "...so that I can ..."
     validations:
       required: true
   - type: textarea

--- a/ui/components/shell.py
+++ b/ui/components/shell.py
@@ -922,6 +922,7 @@ def base_shell(*content, title: str = "Celerp", nav_active: str = "", companies:
         Script(_BACKUP_BANNER_JS),
         Script(_NOTIFICATION_JS),
         Script(_USER_MENU_JS),
+        Script(_BUG_LINK_JS),
         Script(_STAR_CTA_JS),
     ]
     if extra_head:
@@ -1115,9 +1116,9 @@ def _topbar(companies: list[dict], lang: str = "en", user_email: str | None = No
                         target="_blank",
                         rel="noopener",
                         cls="user-menu__item",
-                        # Append the current page to the bug form's `page` field at click time
-                        # (server-side URL is cached/page-agnostic; the path is only known client-side).
-                        onclick="this.href=this.dataset.base+'&page='+encodeURIComponent(location.pathname+location.search)",
+                        # Append the current page (and the matching Area) to the bug form at click
+                        # time — the path is only known client-side; see _BUG_LINK_JS.
+                        onclick="this.href=celerpBugUrl(this.dataset.base)",
                         **{"data-base": _bug_report_url()},
                     ),
                     A(
@@ -1153,6 +1154,31 @@ def _topbar(companies: list[dict], lang: str = "en", user_email: str | None = No
 
 # Kernel-level nav entries always present (no module required)
 _KERNEL_NAV: list[dict] = []
+
+_BUG_LINK_JS = """
+(function(){
+  // Build the "Report a bug" URL at click time: prefill the form's `page` field with the
+  // current path, and preselect the `area` dropdown from the route the user is on (the path
+  // is only known client-side). Area values must match the bug form's dropdown options exactly.
+  var AREA_ROUTES = [
+    [/^\\/(inventory|items|lists)/, "Inventory"],
+    [/^\\/docs/, "Invoicing / documents"],
+    [/^\\/manufacturing/, "Manufacturing"],
+    [/^\\/(accounting|finance|payments)/, "Accounting"],
+    [/^\\/(contacts|crm)/, "Contacts / CRM"],
+    [/^\\/(reports|dashboard|history)/, "Reporting"],
+    [/^\\/(settings|setup|onboarding|subscriptions)/, "Setup / admin / permissions"]
+  ];
+  window.celerpBugUrl = function(base) {
+    var path = location.pathname;
+    var url = base + "&page=" + encodeURIComponent(path + location.search);
+    for (var i = 0; i < AREA_ROUTES.length; i++) {
+      if (AREA_ROUTES[i][0].test(path)) { url += "&area=" + encodeURIComponent(AREA_ROUTES[i][1]); break; }
+    }
+    return url;
+  };
+})();
+"""
 
 _USER_MENU_JS = """
 (function(){


### PR DESCRIPTION
## Summary

Makes the bug report form faster and lower-friction.

- **Removed "Installation method"** — it was `required`, blocking users who didn't know it; OS already covers platform.
- **Reframed the boxes** into a problem statement: **"Currently, the system is..."** (was Steps to reproduce — now invites the symptom + light repro), **"It should..."** (was Expected behavior), **"So that..."** (was Actual behavior — the why). Trade-off: no dedicated repro-steps field; we fold light repro into the first box and can ask for exact steps in-thread.
- **Auto-set Area when opened from the app:** the in-app "Report a bug" link now appends `&area=<mapped area>` (next to the existing `&page=`), mapping the current route to the Area dropdown option client-side. GitHub issue forms preselect dropdowns from URL params, same mechanism that already prefills version/os.

### Verify
Form YAML validates; shell imports; rendered link wired to `celerpBugUrl`. **Manual check:** open **Report a bug** from an `/inventory` page → Area should be preselected to **Inventory** (confirms GitHub honors the dropdown param).