### PR TITLE
fix(backup): surface import failures + pre-check PostgreSQL version

### DIFF
--- a/celerp/services/backup_import.py
+++ b/celerp/services/backup_import.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 import tarfile
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -119,6 +120,27 @@ class ImportMeta:
     enabled_modules: list[str] = field(default_factory=list)
 
 
+def _pg_major(version_text: str | None) -> int | None:
+    """Major PostgreSQL version from a `pg_dump`/`pg_restore --version` string like
+    'pg_dump (PostgreSQL) 17.2 (Ubuntu ...)'. None if unknown/unparseable."""
+    if not version_text:
+        return None
+    m = re.search(r"PostgreSQL\)\s+(\d+)", version_text)
+    return int(m.group(1)) if m else None
+
+
+def _local_pg_restore_major() -> int | None:
+    """Major version of the pg_restore that will run the restore, or None if it can't be
+    determined (in which case the pre-check is skipped — we never block on inability to check)."""
+    import subprocess
+    from celerp.services.backup import _find_pg_tool
+    try:
+        out = subprocess.run([_find_pg_tool("pg_restore"), "--version"], capture_output=True, timeout=5)
+        return _pg_major(out.stdout.decode(errors="replace"))
+    except Exception:
+        return None
+
+
 def validate_archive(path: Path) -> ImportMeta:
     """Check archive structure and read meta.json.
 
@@ -152,6 +174,21 @@ def validate_archive(path: Path) -> ImportMeta:
         company_name=meta_data.get("company_name", "unknown"),
         enabled_modules=list(meta_data.get("enabled_modules") or []),
     )
+
+    # PostgreSQL forward-compatibility: pg_restore cannot read a backup made by a NEWER
+    # pg_dump. Fail early with an actionable message instead of the cryptic
+    # "unsupported version (1.16) in file header" pg_restore emits mid-restore. Only block
+    # when we can affirmatively determine backup_major > local_major; if either version is
+    # unknown we skip the pre-check and let pg_restore decide.
+    backup_major = _pg_major(meta.pg_version)
+    local_major = _local_pg_restore_major()
+    if backup_major is not None and local_major is not None and backup_major > local_major:
+        raise ValueError(
+            f"This backup was created with PostgreSQL {backup_major}, but this system's "
+            f"restore tools are PostgreSQL {local_major}. Install PostgreSQL {backup_major} "
+            f"(client tools, and a matching server) to restore it - pg_restore cannot read a "
+            f"backup from a newer PostgreSQL."
+        )
 
     # Version compatibility check
     try:

--- a/tests/test_backup_import.py
+++ b/tests/test_backup_import.py
@@ -111,6 +111,53 @@ class TestValidateArchiveEnabledModules:
             path.unlink(missing_ok=True)
 
 
+class TestPgVersionPreCheck:
+    """validate_archive must fail early (actionable message) when the backup was made by a
+    newer PostgreSQL than the local pg_restore can read — instead of the cryptic
+    'unsupported version (1.16) in file header' pg_restore emits mid-restore."""
+
+    _PG17 = "pg_dump (PostgreSQL) 17.2 (Ubuntu 17.2-1.pgdg24.04+1)"
+
+    def test_pg_major_parsing(self):
+        from celerp.services.backup_import import _pg_major
+        assert _pg_major(self._PG17) == 17
+        assert _pg_major("pg_restore (PostgreSQL) 16.14 (Ubuntu ...)") == 16
+        assert _pg_major("16") is None      # bare/unrecognized -> unknown (skip check)
+        assert _pg_major("unknown") is None
+        assert _pg_major(None) is None
+
+    def test_blocks_newer_pg_backup_with_actionable_message(self, monkeypatch):
+        from celerp.services import backup_import as bi
+        monkeypatch.setattr(bi, "_local_pg_restore_major", lambda: 16)
+        path = _write_archive_to_tmp(_make_archive(extra_meta={"pg_version": self._PG17}))
+        try:
+            with pytest.raises(ValueError) as ei:
+                bi.validate_archive(path)
+            msg = str(ei.value)
+            assert "PostgreSQL 17" in msg and "PostgreSQL 16" in msg
+        finally:
+            path.unlink(missing_ok=True)
+
+    def test_allows_same_or_older_pg(self, monkeypatch):
+        from celerp.services import backup_import as bi
+        monkeypatch.setattr(bi, "_local_pg_restore_major", lambda: 17)  # local newer than backup
+        path = _write_archive_to_tmp(_make_archive(extra_meta={"pg_version": self._PG17}))
+        try:
+            bi.validate_archive(path)  # must not raise
+        finally:
+            path.unlink(missing_ok=True)
+
+    def test_skips_when_version_unknown(self, monkeypatch):
+        from celerp.services import backup_import as bi
+        monkeypatch.setattr(bi, "_local_pg_restore_major", lambda: 16)
+        # pg_version not in the recognized format -> can't compare -> don't block
+        path = _write_archive_to_tmp(_make_archive(extra_meta={"pg_version": "unknown"}))
+        try:
+            bi.validate_archive(path)  # must not raise
+        finally:
+            path.unlink(missing_ok=True)
+
+
 class TestRunImportEnabledModules:
     """validate_archive must surface enabled_modules so the UI can preflight.
 

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -13093,6 +13093,37 @@ class TestBackupRoutes:
             f"export_backup not called with cookie token. Captured: {captured}"
         )
 
+    @pytest.mark.asyncio
+    async def test_backup_import_relays_failure_not_false_success(self, ui_client):
+        """A failed restore must surface the real error, not a hardcoded "imported".
+
+        Regression: the API signals import failure with a 200 + error-flash body (for the
+        HTMX swap); the UI proxy used to ignore the body and always show success, so a
+        pg_restore version mismatch was reported to the user as a successful import.
+        """
+        import httpx
+        test_token = make_test_token(role="owner")
+        err = ('<div class="flash flash--error" id="backup-flash">'
+               'Import failed: pg_restore failed (exit 1): unsupported version (1.16)</div>')
+        real_cls = httpx.AsyncClient
+
+        def _mock_api_client(*args, **kwargs):
+            # Only the route's API client is built via httpx.AsyncClient; the test client
+            # uses the module-imported AsyncClient name, so it is unaffected by this patch.
+            kwargs["transport"] = httpx.MockTransport(lambda req: httpx.Response(200, text=err))
+            return real_cls(*args, **kwargs)
+
+        with patch("httpx.AsyncClient", _mock_api_client):
+            async with ui_client as c:
+                r = await c.post(
+                    "/backup/import",
+                    files={"file": ("backup.celerp-backup", b"data", "application/octet-stream")},
+                    cookies={"celerp_token": test_token},
+                )
+        assert r.status_code == 200
+        assert "Import failed" in r.text and "flash--error" in r.text
+        assert "flash--success" not in r.text, "failed import was reported as success"
+
 
 class TestUnknownUnitRendererInFixTable:
     """Unit dropdown in fix-table must preserve unrecognised values instead of silently dropping them."""

--- a/ui/routes/settings.py
+++ b/ui/routes/settings.py
@@ -2569,10 +2569,10 @@ def setup_routes(app):
                 content=to_xml(Div(str(exc), cls="flash flash--error", id="backup-flash")),
                 media_type="text/html",
             )
-        return Response(
-            content=to_xml(Div(t("settings.backup_imported", lang), cls="flash flash--success", id="backup-flash")),
-            media_type="text/html",
-        )
+        # The API returns a flash (success OR "Import failed: …") at HTTP 200 for the HTMX
+        # swap. Relay it verbatim instead of assuming success — otherwise a failed restore
+        # (e.g. a pg_restore version mismatch) is reported to the user as "imported".
+        return Response(content=r.text, media_type="text/html")
 
 
 # ── Display cell helpers (click-to-edit pattern) ─────────────────────────


### PR DESCRIPTION
## The bug

A failed backup import was shown to the user as **"imported successfully."** Found while diagnosing a real failure (`pg_restore: error: unsupported version (1.16)` — a PG17 backup restored with PG16 tools).

## Root cause

The API `/backup/import` route signals failure via `_flash(..., "error")` — an **HTTP 200** with an error-flash body (so HTMX swaps it in). The **UI proxy** only checked `r.status_code >= 400`, so on a 200-with-error-flash it skipped the error branch and returned a **hardcoded success** message.

`run_import` itself was correct (returns `ok=False`), and the bootstrap/setup-wizard path was correct (returns 422, wizard checks status). The bug was isolated to the authenticated UI proxy.

## Fix

Relay the API's flash verbatim (success **or** "Import failed: …") instead of assuming success. It already carries the right class + `id="backup-flash"`, so it swaps correctly and the real error reaches the user.

## Test

Regression test (`TestBackupRoutes`) mocks the API returning a 200 error-flash and asserts the UI surfaces the error (`flash--error`, no `flash--success`). `TestBackupRoutes` green.