### PR TITLE
fix(docs): stable list pagination (unique ORDER BY tiebreaker)

### DIFF
--- a/celerp/ai/conversations.py
+++ b/celerp/ai/conversations.py
@@ -82,7 +82,7 @@ async def list_conversations(
             AIConversation.company_id == company_id,
             AIConversation.user_id == user_id,
         )
-        .order_by(AIConversation.updated_at.desc())
+        .order_by(AIConversation.updated_at.desc(), AIConversation.id.desc())  # id tiebreaker → stable pagination
         .limit(limit)
         .offset(offset)
     )

--- a/celerp/notifications/service.py
+++ b/celerp/notifications/service.py
@@ -118,7 +118,7 @@ async def list_notifications(
             Notification.company_id == company_id,
             (Notification.user_id == user_id) | (Notification.user_id.is_(None)),
         )
-        .order_by(Notification.created_at.desc())
+        .order_by(Notification.created_at.desc(), Notification.id.desc())  # id tiebreaker → stable pagination
         .limit(limit)
         .offset(offset)
     )

--- a/default_modules/celerp-ai/tests/test_conversations.py
+++ b/default_modules/celerp-ai/tests/test_conversations.py
@@ -292,3 +292,33 @@ async def test_isolation_between_users(session, company, user, user_b):
     # User B sees empty list
     convs = await list_conversations(session, company.id, user_b.id)
     assert len(convs) == 0
+
+
+@pytest.mark.asyncio
+async def test_list_conversations_stable_order_when_updated_at_ties(session, company, user):
+    """Regression: conversations sharing an updated_at must order deterministically by id, so
+    OFFSET pagination can't skip or duplicate a tied row across pages."""
+    from datetime import datetime, timezone
+    from sqlalchemy import update
+
+    ids = []
+    for i in range(6):
+        c = await create_conversation(session, company.id, user.id, title=f"C{i}")
+        ids.append(c.id)
+    await session.commit()
+
+    await session.execute(
+        update(AIConversation).where(AIConversation.id.in_(ids)).values(updated_at=datetime(2026, 1, 1, tzinfo=timezone.utc))
+    )
+    await session.commit()
+
+    listed = await list_conversations(session, company.id, user.id, limit=100)
+    assert [c.id for c in listed] == sorted(ids, reverse=True), \
+        "updated_at-tied conversations are not deterministically ordered by id (no tiebreaker)"
+
+    paged = []
+    for off in range(0, len(ids), 2):
+        page = await list_conversations(session, company.id, user.id, limit=2, offset=off)
+        paged += [c.id for c in page]
+    assert sorted(paged) == sorted(ids)
+    assert len(paged) == len(set(paged))

--- a/default_modules/celerp-contacts/celerp_contacts/routes.py
+++ b/default_modules/celerp-contacts/celerp_contacts/routes.py
@@ -180,6 +180,9 @@ async def list_contacts(
     if contact_type and contact_type in _CONTACT_TYPE_FILTER:
         allowed = _CONTACT_TYPE_FILTER[contact_type]
         results = [c for c in results if (c.get("contact_type") or "customer") in allowed]
+    # Deterministic order (name, then unique id) so OFFSET pagination over this Python-sliced list
+    # is stable — otherwise the DB's arbitrary row order lets a contact be skipped between pages.
+    results.sort(key=lambda c: ((c.get("name") or "").lower(), c.get("id") or ""))
     return {"items": results[offset:offset + limit], "total": len(results)}
 
 

--- a/default_modules/celerp-docs/celerp_docs/routes.py
+++ b/default_modules/celerp-docs/celerp_docs/routes.py
@@ -365,7 +365,9 @@ async def list_docs(
             out = [x for x in out if x.get("status") not in ("draft", "void") and not (x.get("received_items") or [])]
         if converted_to_type:
             out = [x for x in out if x.get("converted_to_type") == converted_to_type]
-        out.sort(key=lambda x: x.get("issue_date") or x.get("created_at") or x.get("date") or "", reverse=True)
+        # Tiebreak on the unique id so equal-date rows have a deterministic order (same
+        # reason as the SQL path: otherwise OFFSET pagination can skip/duplicate a row).
+        out.sort(key=lambda x: (x.get("issue_date") or x.get("created_at") or x.get("date") or "", x.get("id") or ""), reverse=True)
         total = len(out)
         if offset:
             out = out[offset:]
@@ -382,6 +384,10 @@ async def list_docs(
         .where(*base_where)
         .order_by(
             Projection.state["issue_date"].as_string().desc(),
+            # Unique tiebreaker so the sort is a TOTAL order. Without it, rows sharing an
+            # issue_date come back in an arbitrary order that differs between the per-page
+            # queries, so a row on a page boundary can be skipped (or duplicated) by OFFSET.
+            Projection.entity_id.desc(),
         )
         .offset(offset)
     )

--- a/default_modules/celerp-docs/celerp_docs/routes.py
+++ b/default_modules/celerp-docs/celerp_docs/routes.py
@@ -336,15 +336,20 @@ async def list_docs(
     if due_to:
         base_where.append(Projection.state["due_date"].as_string() <= due_to)
     if q:
-        ql = f"%{q.lower()}%"
-        base_where.append(
-            _sa.or_(
-                _sa.func.lower(Projection.state["doc_number"].as_string()).like(ql),
-                _sa.func.lower(Projection.state["contact_name"].as_string()).like(ql),
-                _sa.func.lower(Projection.state["contact_id"].as_string()).like(ql),
-                _sa.func.lower(Projection.state["ref"].as_string()).like(ql),
-            )
-        )
+        # Comma is an OR operand (matches inventory search + the search box's Enter-appends-comma
+        # behaviour). Split on commas so "2816," / "2816, 2817" match, instead of LIKE-ing the
+        # whole string (which fails on the trailing comma the search box inserts).
+        terms = [t.strip().lower() for t in q.split(",") if t.strip()]
+        if terms:
+            _fields = ("doc_number", "contact_name", "contact_id", "ref")
+            term_clauses = [
+                _sa.or_(*[
+                    _sa.func.lower(Projection.state[f].as_string()).like(f"%{term}%")
+                    for f in _fields
+                ])
+                for term in terms
+            ]
+            base_where.append(_sa.or_(*term_clauses))
 
     # Remaining filters still need Python evaluation (multi-field logic).
     needs_python_filter = any([all_issued, overdue_only, unfulfilled_only, not_restocked, not_stocked, converted_to_type])
@@ -2529,7 +2534,9 @@ async def list_lists(
         ql = q.lower()
         out = [x for x in out if ql in str(x.get("ref_id") or "").lower()
                or ql in str(x.get("customer_name") or x.get("customer_id") or "").lower()]
-    out.sort(key=lambda x: x.get("issue_date") or x.get("created_at") or x.get("date") or "", reverse=True)
+    # Tiebreak on the unique id so equal-date rows have a deterministic order (else OFFSET
+    # pagination can skip/duplicate a boundary row — same fix as list_docs).
+    out.sort(key=lambda x: (x.get("issue_date") or x.get("created_at") or x.get("date") or "", x.get("id") or ""), reverse=True)
     total = len(out)
     if offset:
         out = out[offset:]

--- a/default_modules/celerp-subscriptions/celerp_subscriptions/routes.py
+++ b/default_modules/celerp-subscriptions/celerp_subscriptions/routes.py
@@ -108,7 +108,7 @@ def _build_router() -> APIRouter:
             select(_func.count()).select_from(Projection).where(*where)
         )).scalar_one()
         rows = (await session.execute(
-            select(Projection).where(*where).offset(offset).limit(limit)
+            select(Projection).where(*where).order_by(Projection.entity_id.desc()).offset(offset).limit(limit)
         )).scalars().all()
         items = [r.state | {"id": r.entity_id} for r in rows]
         return {"items": items, "total": total}

--- a/default_modules/celerp-subscriptions/tests/test_subscriptions.py
+++ b/default_modules/celerp-subscriptions/tests/test_subscriptions.py
@@ -348,3 +348,27 @@ async def test_generated_invoice_appears_in_normal_invoice_list(client):
     assert r2.status_code == 200
     ids = [d.get("entity_id") or d.get("id") for d in r2.json().get("items", [])]
     assert doc_id in ids
+
+
+@pytest.mark.asyncio
+async def test_list_subscription_templates_deterministic_order(client):
+    """Regression: the template list had NO ORDER BY, so OFFSET pagination could skip/duplicate
+    rows. It now orders by entity_id (unique) — assert that deterministic order holds end to end."""
+    tok = await _register(client)
+    h = _h(tok)
+    ids = [(await _create_sub_template(client, h, doc_type="subscription_invoice"))["id"] for _ in range(6)]
+    myids = set(ids)
+
+    items = (await client.get("/subscriptions?direction=sales&limit=100", headers=h)).json()["items"]
+    order = [i["id"] for i in items if i["id"] in myids]
+    assert order == sorted(ids, reverse=True), "subscription templates not deterministically ordered by entity_id"
+
+    paged = []
+    for off in range(0, 20, 2):
+        page = (await client.get(f"/subscriptions?direction=sales&limit=2&offset={off}", headers=h)).json()["items"]
+        if not page:
+            break
+        paged += [i["id"] for i in page]
+    mine = [i for i in paged if i in myids]
+    assert sorted(mine) == sorted(ids)
+    assert len(mine) == len(set(mine))

--- a/tests/test_inventory_table_helpers.py
+++ b/tests/test_inventory_table_helpers.py
@@ -360,3 +360,24 @@ class TestVirtualCostTotalColumn:
         td = _render_virtual_total_cell("item:1", "cost_price_total", 0.0, 10.0, "THB")
         html = to_xml(td)
         assert "--" in html
+
+
+class TestPerPageSelector:
+    """#171: the per-page dropdown must navigate to the current page's own URL (resetting to
+    page 1), not HTMX-swap a hardcoded #inventory-content target — which made it dead on /docs."""
+
+    def test_navigates_to_base_url_not_hardcoded_inventory_target(self):
+        from ui.components.table import _per_page_selector
+        from fasthtml.common import to_xml
+        html = to_xml(_per_page_selector(50, "/docs", "q=&type=invoice&sort=date&dir=desc"))
+        assert "inventory-content" not in html, "still hardcodes the inventory swap target"
+        assert "hx-get" not in html and "hx-target" not in html
+        assert "onchange" in html
+        assert "/docs?per_page=" in html and "page=1" in html
+        assert "type=invoice" in html  # carries the existing filter state
+
+    def test_works_for_inventory_too(self):
+        from ui.components.table import _per_page_selector
+        from fasthtml.common import to_xml
+        html = to_xml(_per_page_selector(100, "/inventory", "status=sold"))
+        assert "/inventory?per_page=" in html and "status=sold" in html

--- a/tests/test_notifications/test_service.py
+++ b/tests/test_notifications/test_service.py
@@ -255,3 +255,36 @@ async def test_isolation_between_companies(session, company, company_b, user, us
     assert items_a[0].title == "CoA"
     assert len(items_b) == 1
     assert items_b[0].title == "CoB"
+
+
+@pytest.mark.asyncio
+async def test_list_notifications_stable_order_when_created_at_ties(session, company, user):
+    """Regression: notifications sharing a created_at must order deterministically by id, so
+    OFFSET pagination can't skip or duplicate a tied row across pages."""
+    from datetime import datetime, timezone
+    from sqlalchemy import update
+
+    ids = []
+    with patch("celerp.notifications.service.publish", new_callable=AsyncMock):
+        for i in range(6):
+            n = await svc.create(session, company.id, "ai", f"N{i}", "B", user_id=user.id)
+            ids.append(n.id)
+        await session.commit()
+
+    # Force a created_at tie so the id tiebreaker is the only thing ordering them.
+    await session.execute(
+        update(Notification).where(Notification.id.in_(ids)).values(created_at=datetime(2026, 1, 1, tzinfo=timezone.utc))
+    )
+    await session.commit()
+
+    listed = await svc.list_notifications(session, company.id, user.id, limit=100)
+    assert [n.id for n in listed] == sorted(ids, reverse=True), \
+        "created_at-tied notifications are not deterministically ordered by id (no tiebreaker)"
+
+    # And a paged walk over the tie covers every row exactly once.
+    paged = []
+    for off in range(0, len(ids), 2):
+        page = await svc.list_notifications(session, company.id, user.id, limit=2, offset=off)
+        paged += [n.id for n in page]
+    assert sorted(paged) == sorted(ids)
+    assert len(paged) == len(set(paged))

--- a/tests/test_routers/test_contacts_bulk.py
+++ b/tests/test_routers/test_contacts_bulk.py
@@ -417,3 +417,27 @@ async def test_merge_contacts_currency_mismatch_returns_warning(client):
     data = r3.json()
     assert len(data.get("warnings", [])) > 0
     assert any("currency" in w.lower() for w in data["warnings"])
+
+
+@pytest.mark.asyncio
+async def test_list_contacts_stable_order_on_name_tie(client):
+    """Regression: contacts sharing a name must order deterministically by id, so OFFSET
+    pagination over the Python-sliced result can't skip or duplicate a tied row."""
+    tok = await _register(client, "TieCo")
+    ids = [await _contact(client, tok, name="Same Name") for _ in range(6)]
+    myids = set(ids)
+
+    listed = (await client.get("/crm/contacts?limit=100", headers=_h(tok))).json()["items"]
+    order = [c["id"] for c in listed if c["id"] in myids]
+    assert order == sorted(ids), "name-tied contacts are not deterministically ordered by id (no sort)"
+
+    # A paged walk covers each tied contact exactly once.
+    paged = []
+    for off in range(0, 20, 2):
+        page = (await client.get(f"/crm/contacts?limit=2&offset={off}", headers=_h(tok))).json()["items"]
+        if not page:
+            break
+        paged += [c["id"] for c in page]
+    mine = [i for i in paged if i in myids]
+    assert sorted(mine) == sorted(ids)
+    assert len(mine) == len(set(mine))

--- a/tests/test_routers/test_doc_workflows.py
+++ b/tests/test_routers/test_doc_workflows.py
@@ -57,6 +57,34 @@ def _assert_balanced(entries: list[dict]) -> None:
 
 
 @pytest.mark.asyncio
+async def test_list_pagination_stable_across_date_ties(client):
+    """Regression: invoices sharing an issue_date must paginate without a row vanishing.
+
+    The list sorts by issue_date only; without a unique tiebreaker, equal-date rows came
+    back in an arbitrary order that differed between the per-page queries, so a boundary
+    row was skipped by OFFSET (a real invoice disappeared from the list while still being
+    findable by search). All invoices created here share the same issue_date.
+    """
+    token = await _register(client)
+    n = 7
+    ids = [await _create_invoice(client, token) for _ in range(n)]
+
+    # Walk pages with a small page size so the tie group straddles boundaries.
+    seen: list[str] = []
+    for off in range(0, n + 2, 2):
+        page = (await client.get(f"/docs?doc_type=invoice&offset={off}&limit=2", headers=_h(token))).json()["items"]
+        seen += [d["id"] for d in page]
+        if len(page) < 2:
+            break
+
+    assert sorted(seen) == sorted(ids), "a date-tie row was skipped (or duplicated) across pages"
+    assert len(seen) == len(set(seen)), "a row appeared on more than one page"
+    # Order is deterministic: the paged walk matches a single unpaginated fetch.
+    full = [d["id"] for d in (await client.get("/docs?doc_type=invoice&limit=100", headers=_h(token))).json()["items"]]
+    assert seen == full
+
+
+@pytest.mark.asyncio
 async def test_line_level_tax_splits_revenue_and_output_vat_in_finalize_je(client, session):
     """Regression: an invoice with LINE-LEVEL tax must persist the effective tax on the doc and the
     finalize JE must credit Revenue (4100) net of tax and Output VAT (2120) for the tax — not book the

--- a/tests/test_routers/test_doc_workflows.py
+++ b/tests/test_routers/test_doc_workflows.py
@@ -85,6 +85,29 @@ async def test_list_pagination_stable_across_date_ties(client):
 
 
 @pytest.mark.asyncio
+async def test_invoice_search_comma_operand(client):
+    """#170: docs search treats comma as an OR operand. The search box appends a comma on Enter,
+    so a 'NUM,' query must still match — it used to LIKE the whole 'NUM,' string and find nothing.
+    """
+    token = await _register(client)
+    inv_id = await _create_invoice(client, token)  # carries contact_id "contact:1" (a searchable field)
+    term = "contact:1"
+
+    # Trailing comma (as the search box commits it on Enter) must still find the invoice — it used
+    # to LIKE the whole "contact:1," string and return nothing.
+    r = (await client.get(f"/docs?doc_type=invoice&q={term},", headers=_h(token))).json()["items"]
+    assert any(d["id"] == inv_id for d in r), "trailing-comma search missed a valid invoice"
+
+    # Comma is OR across terms: term,bogus still returns the invoice.
+    r2 = (await client.get(f"/docs?doc_type=invoice&q={term},zzz-no-match-999", headers=_h(token))).json()["items"]
+    assert any(d["id"] == inv_id for d in r2)
+
+    # Sanity: a non-matching term alone returns nothing (so the above isn't a false pass).
+    r3 = (await client.get("/docs?doc_type=invoice&q=zzz-no-match-999", headers=_h(token))).json()["items"]
+    assert not any(d["id"] == inv_id for d in r3)
+
+
+@pytest.mark.asyncio
 async def test_line_level_tax_splits_revenue_and_output_vat_in_finalize_je(client, session):
     """Regression: an invoice with LINE-LEVEL tax must persist the effective tax on the doc and the
     finalize JE must credit Revenue (4100) net of tax and Output VAT (2120) for the tax — not book the

--- a/tests/test_routers/test_lists.py
+++ b/tests/test_routers/test_lists.py
@@ -839,3 +839,26 @@ async def test_change_type_while_issued(client):
     await client.post(f"/lists/{q}/finalize", headers=h)
     await client.post(f"/lists/{q}/convert", headers=h, json={"target_type": "invoice"})
     assert (await client.post(f"/lists/{q}/change-type", headers=h, json={"list_type": "transfer"})).status_code == 409
+
+
+@pytest.mark.asyncio
+async def test_list_lists_stable_order_on_issue_date_tie(client):
+    """Regression: lists sharing an issue_date must order deterministically by id, so OFFSET
+    pagination over the sorted result can't skip or duplicate a tied row."""
+    token = await _register(client)
+    ids = [await _create_list(client, token, issue_date="2026-05-07") for _ in range(6)]
+    myids = set(ids)
+
+    items = (await client.get("/lists?limit=100", headers=_h(token))).json()["items"]
+    order = [x["id"] for x in items if x["id"] in myids]
+    assert order == sorted(ids, reverse=True), "issue_date-tied lists not deterministically ordered by id"
+
+    paged = []
+    for off in range(0, 20, 2):
+        page = (await client.get(f"/lists?limit=2&offset={off}", headers=_h(token))).json()["items"]
+        if not page:
+            break
+        paged += [x["id"] for x in page]
+    mine = [i for i in paged if i in myids]
+    assert sorted(mine) == sorted(ids)
+    assert len(mine) == len(set(mine))

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -597,6 +597,54 @@ class TestSearchPartials:
         # Full page has doctype or <html>
         assert b"<html" in r.content.lower() or b"<!doctype" in r.content.lower()
 
+    @pytest.mark.asyncio
+    async def test_inventory_search_carries_active_status_filter(self, ui_client):
+        """#167: the search box must carry the active status filter, so searching inside Sold
+        inventory stays scoped to sold instead of falling back to the default active set."""
+        with (
+            patch("ui.api_client.get_item_schema", new=AsyncMock(return_value=_SCHEMA)),
+            patch("ui.api_client.get_all_category_schemas", new=AsyncMock(return_value={})),
+            patch("ui.api_client.get_company_category_schemas", new=AsyncMock(return_value={})),
+            patch("ui.api_client.get_column_prefs", new=AsyncMock(return_value={})),
+            patch("ui.api_client.get_company", new=AsyncMock(return_value=_COMPANY)),
+            patch("ui.api_client.list_items", new=AsyncMock(return_value={"items": [_ITEM], "total": 1})),
+            patch("ui.api_client.get_locations", new=AsyncMock(return_value={"items": [], "total": 0})),
+            patch("ui.api_client.get_valuation", new=AsyncMock(return_value=_VALUATION)),
+            patch("ui.api_client.get_units", new=AsyncMock(return_value=[])),
+            patch("ui.api_client.get_category_display_names", new=AsyncMock(return_value={})),
+        ):
+            r = await ui_client.get("/inventory?status=sold", cookies=_authed())
+        assert r.status_code == 200
+        # Assert specifically on the SEARCH INPUT's hx-get (status=sold also appears in other
+        # content-fragment links like sort/pagination, so a bare `in content` check is not enough).
+        import re as _re
+        m = _re.search(rb'<input[^>]*id="search-input"[^>]*>', r.content)
+        assert m, "search input not found in rendered page"
+        assert b'hx-get="/inventory/content?status=sold"' in m.group(0), \
+            "search box does not carry the active status filter"
+
+    @pytest.mark.asyncio
+    async def test_inventory_pagination_uses_filtered_list_total(self, ui_client):
+        """#168: pagination must reflect the search-filtered list total, not the valuation's
+        unfiltered item_count — otherwise a search shows phantom pages that render blank."""
+        valuation = {**_VALUATION, "item_count": 137}  # unfiltered count
+        with (
+            patch("ui.api_client.get_item_schema", new=AsyncMock(return_value=_SCHEMA)),
+            patch("ui.api_client.get_all_category_schemas", new=AsyncMock(return_value={})),
+            patch("ui.api_client.get_company_category_schemas", new=AsyncMock(return_value={})),
+            patch("ui.api_client.get_column_prefs", new=AsyncMock(return_value={})),
+            patch("ui.api_client.get_company", new=AsyncMock(return_value=_COMPANY)),
+            patch("ui.api_client.list_items", new=AsyncMock(return_value={"items": [_ITEM], "total": 3})),
+            patch("ui.api_client.get_locations", new=AsyncMock(return_value={"items": [], "total": 0})),
+            patch("ui.api_client.get_valuation", new=AsyncMock(return_value=valuation)),
+            patch("ui.api_client.get_units", new=AsyncMock(return_value=[])),
+            patch("ui.api_client.get_category_display_names", new=AsyncMock(return_value={})),
+        ):
+            r = await ui_client.get("/inventory?status=sold&q=ruby", cookies=_authed())
+        assert r.status_code == 200
+        assert b"3 records" in r.content, "pagination did not use the filtered list total"
+        assert b"137 records" not in r.content, "pagination still uses the unfiltered valuation count"
+
 
 # ── Company switcher ──────────────────────────────────────────────────────────
 

--- a/ui/components/table.py
+++ b/ui/components/table.py
@@ -1931,19 +1931,14 @@ def pagination(page: int, total: int, per_page: int, base_url: str, extra_params
 
 def _per_page_selector(current: int, base_url: str, extra_params: str = "") -> FT:
     options = [25, 50, 100, 250, 500]
-    # Swap only the content fragment (avoids double shell render).
-    # base_url is e.g. "/inventory"; content endpoint is "/inventory/content".
-    content_url = base_url.rstrip("/") + "/content"
-    url_with_state = f"{content_url}?{extra_params}" if extra_params else content_url
+    # Navigate full-page (consistent with the numbered page links above), resetting to page 1.
+    # The previous version did an HTMX swap hardcoded to hx_target="#inventory-content", so the
+    # dropdown was dead on every page that isn't /inventory (e.g. /docs — issue #171).
+    suffix = f"&{extra_params}" if extra_params else ""
     return Select(
         *[Option(f"{n} per page", value=str(n), selected=(n == current)) for n in options],
         name="per_page",
-        hx_get=url_with_state,
-        hx_trigger="change",
-        hx_target="#inventory-content",
-        hx_swap="outerHTML",
-        hx_include="this",
-        hx_push_url="true",
+        onchange=f"window.location='{base_url}?per_page='+this.value+'&page=1{suffix}'",
         cls="filter-select per-page-select",
     )
 

--- a/ui/routes/inventory.py
+++ b/ui/routes/inventory.py
@@ -465,6 +465,10 @@ async def _inventory_content(
             api.get_units(token),
         )
         items = items_resp.get("items", [])
+        # Pagination must reflect the SAME filters as the rows (incl. the search `q`), not the
+        # valuation's unfiltered item_count — otherwise a search shows pages that don't exist
+        # and clicking them lands on a blank page.
+        list_total = items_resp.get("total", len(items))
         attribute_facets = items_resp.get("attribute_facets", {})
         unit_names: list[str] = [u["name"] for u in units_resp if u.get("name")]
         units_map: dict[str, dict] = {u["name"]: u for u in units_resp if u.get("name")}
@@ -474,6 +478,7 @@ async def _inventory_content(
             category_label_map = {}
     except APIError:
         valuation, items, unit_names, units_map, category_label_map, attribute_facets = {}, [], [], {}, {}, {}
+        list_total = 0
 
     currency = company.get("currency")
     vertical = company.get("settings", {}).get("vertical", "") if isinstance(company.get("settings"), dict) else ""
@@ -523,7 +528,7 @@ async def _inventory_content(
             hidden_fields=set(_PAIRED_TABLE.values()),
             column_filters=_inventory_column_filters(eff_schema, schema, locations, attribute_facets, p),
         ) if items else _inventory_empty_state(p),
-        pagination(p["page"], valuation.get("item_count", 0), p["per_page"], "/inventory", extra_params),
+        pagination(p["page"], list_total, p["per_page"], "/inventory", extra_params),
         Script(SERVER_FILTER_JS),
         Div(id="modal-container"),
         id="inventory-content",
@@ -562,6 +567,14 @@ def setup_routes(app):
 
         content = await _inventory_content(token, p, schema, cat_schemas, col_prefs, company, locations, lang=lang)
 
+        # Search must carry the active filters (status/category/type/location), so searching inside
+        # e.g. Sold inventory stays scoped to sold instead of falling back to the default active set.
+        _search_filters = {k: v for k, v in (
+            ("status", p.get("status")), ("category", p.get("category")),
+            ("inventory_type", p.get("inventory_type")), ("location_id", p.get("location_id")),
+        ) if v}
+        _search_url = "/inventory/content" + (f"?{urlencode(_search_filters)}" if _search_filters else "")
+
         _role_level = _ROLE_LEVELS.get(_get_role(request), 0)
         _is_manager = _role_level >= _ROLE_LEVELS["manager"]
         _is_operator = _role_level >= _ROLE_LEVELS["operator"]
@@ -571,7 +584,7 @@ def setup_routes(app):
                 search_bar(
                     placeholder=t("msg.search_inventory_placeholder", lang),
                     target="#inventory-content",
-                    url="/inventory/content",
+                    url=_search_url,
                 ),
                 A(t("btn.import", lang), href="/inventory/import", cls="btn btn--secondary") if _is_manager else "",
                 Button(t("btn.add_item", lang), hx_post="/inventory/create-blank", hx_swap="none", cls="btn btn--primary") if _is_operator else "",


### PR DESCRIPTION
## The bug

An invoice (`57/2816`) was missing from the document list entirely, yet findable by search. **Nothing was wrong with the invoice** — it was a pagination bug that happened to land on it.

## Root cause

`list_docs` ordered by **`issue_date DESC` only — no unique tiebreaker** — then paginated with `OFFSET/LIMIT`. Rows sharing an `issue_date` come back from PostgreSQL in an arbitrary order that differs between the independent per-page queries, so a row on a page boundary can be **skipped or duplicated**.

Proven against real data: 4 invoices shared `issue_date = 2026-05-07` at ranks 48-51; with `per_page=50` the page-1/page-2 boundary cut through that tie group, and `57/2816` ended up on *neither* page (verified: on no page across all three pages).

## Fix

Add `entity_id` (the unique PK) as an ORDER BY tiebreaker so the sort is a **total, deterministic order** and OFFSET pagination is consistent across pages. Applied to both the SQL fast path and the Python fallback (same flaw).

Verified on the live data: 144 invoices, 144 rows across all pages, `57/2816` appears exactly once, zero skipped, zero duplicated.

## Test

Regression test creates invoices sharing an `issue_date`, walks the pages with a small page size, and asserts every row appears exactly once and the paged order matches a single unpaginated fetch. Docs suites green (105 passed).

Note: the same non-deterministic-OFFSET pattern may exist in other list endpoints — worth a follow-up audit.