### PR TITLE
fix(merge): dropdown → "mixed", numeric conflicts → no value (never sum/invent)

### DIFF
--- a/default_modules/celerp-inventory/celerp_inventory/routes.py
+++ b/default_modules/celerp-inventory/celerp_inventory/routes.py
@@ -1920,6 +1920,11 @@ async def transform_item(entity_id: str, payload: TransformBody, company_id=Depe
     return {"child_id": child_eid, "child_sku": payload.child_sku, "parent_sku": parent.state.get("sku", "")}
 
 
+# Sentinel stored on a merged item when sources disagree on a dropdown (select) field — merging
+# must never sum or create a new option for those.
+_MERGE_MIXED_VALUE = "mixed"
+
+
 @router.post("/merge")
 async def merge_items(payload: MergeBody, company_id=Depends(get_current_company_id), user=Depends(get_current_user), session: AsyncSession = Depends(get_session)) -> dict:
     if len(payload.source_entity_ids) < 2:
@@ -2005,6 +2010,13 @@ async def merge_items(payload: MergeBody, company_id=Depends(get_current_company
         all_attr_keys.update((p.state.get("attributes") or {}).keys())
     all_attr_keys -= _EXPIRY_ATTR_KEYS
 
+    # Dropdown (select) fields for the merged category: a merge must NEVER sum these or invent a
+    # new option. Same value across sources → that value; any disagreement → the "mixed" sentinel.
+    from celerp.services.field_schema import get_effective_field_schema
+    _merge_category = (next(iter(categories), "") or "").strip() or None
+    _schema = await get_effective_field_schema(session, company_id, category=_merge_category)
+    _dropdown_keys = {f["key"] for f in _schema if f.get("type") == "select"}
+
     resolved_attrs: dict = {}
     unresolved_conflicts: list[str] = []
     for key in all_attr_keys:
@@ -2015,10 +2027,14 @@ async def merge_items(payload: MergeBody, company_id=Depends(get_current_company
         if len(unique_str_vals) == 1:
             # No conflict — carry forward the original typed value.
             resolved_attrs[key] = raw_values[0]
+        elif key in _dropdown_keys:
+            # Dropdown field: never sum and never invent an option — differing sources collapse
+            # to the system "mixed" sentinel (issue: merge must not create new dropdown values).
+            resolved_attrs[key] = _MERGE_MIXED_VALUE
         elif all(_is_numeric(v) for v in unique_str_vals):
-            # Numeric conflict — sum. Store as number to preserve type through round-trips.
-            total = sum(float(v) for v in str_values)
-            resolved_attrs[key] = int(total) if total == int(total) else total
+            # Numeric conflict — summing invents a meaningless value (size 1 + 2 ≠ 3; 18K + 14K ≠ 32K).
+            # The correct value is unknowable, so the merged item carries NO value for it.
+            continue  # omit the key → no value
         else:
             # String conflict — require user resolution.
             if payload.resolved_attributes and key in payload.resolved_attributes:

--- a/tests/test_routers/test_items.py
+++ b/tests/test_routers/test_items.py
@@ -1610,12 +1610,14 @@ async def test_merge_then_split_does_not_500(client):
 
 @pytest.mark.asyncio
 async def test_merge_numeric_attrs_stored_as_numbers(client):
-    """After merge, numeric attributes (pieces) must be stored as numbers, not strings."""
+    """An AGREEING numeric attribute carries through after merge as a number, not a string.
+    (Conflicting numeric attributes get no value — see test_merge_dropdown_fields_use_value_or_mixed_never_sum.)
+    """
     token = await _token(client)
     h = {"Authorization": f"Bearer {token}"}
     loc = (await client.post("/companies/me/locations", json={"name": "WH-MNA", "type": "warehouse"}, headers=h)).json()
     r1 = await client.post("/items", json={"sku": "MNA-A", "name": "Item A", "quantity": 8.0, "sell_by": "carat", "location_id": loc["id"], "attributes": {"pieces": 8}}, headers=h)
-    r2 = await client.post("/items", json={"sku": "MNA-B", "name": "Item B", "quantity": 12.0, "sell_by": "carat", "location_id": loc["id"], "attributes": {"pieces": 12}}, headers=h)
+    r2 = await client.post("/items", json={"sku": "MNA-B", "name": "Item B", "quantity": 12.0, "sell_by": "carat", "location_id": loc["id"], "attributes": {"pieces": 8}}, headers=h)
     assert r1.status_code == 200
     assert r2.status_code == 200
     id1, id2 = r1.json()["id"], r2.json()["id"]
@@ -1623,9 +1625,11 @@ async def test_merge_numeric_attrs_stored_as_numbers(client):
     assert mr.status_code == 200, mr.text
     merged_id = mr.json()["id"]
     item = (await client.get(f"/items/{merged_id}", headers=h)).json()
-    pieces_val = (item.get("attributes") or {}).get("pieces") or item.get("pieces")
+    pieces_val = (item.get("attributes") or {}).get("pieces")
+    if pieces_val is None:
+        pieces_val = item.get("pieces")
     assert isinstance(pieces_val, (int, float)), f"pieces should be numeric, got {type(pieces_val)}: {pieces_val!r}"
-    assert int(float(pieces_val)) == 20
+    assert int(float(pieces_val)) == 8
 
 
 # ---------------------------------------------------------------------------
@@ -2469,3 +2473,48 @@ async def test_recipe_backed_cost_reads_at_standard_not_lot_total(client):
         f"valuation Cost must value the ring at standard (gold 80 + ring 800), "
         f"got delta {float(val['cost_total']) - base_cost}"
     )
+
+
+@pytest.mark.asyncio
+async def test_merge_dropdown_fields_use_value_or_mixed_never_sum(client):
+    """Merging must never sum or invent a value for dropdown (select) fields. Identical values
+    carry forward; any disagreement collapses to the system 'mixed'. Regression: numeric-option
+    dropdowns were summed into invalid new values (e.g. size 1 + size 2 -> 3)."""
+    token = await _token(client)
+    h = {"Authorization": f"Bearer {token}"}
+    # Category with a string dropdown (grade) and a NUMERIC-option dropdown (size).
+    r = await client.patch("/companies/me", headers=h, json={"settings": {"category_schemas": {"DD": [
+        {"key": "grade", "label": "Grade", "type": "select", "options": ["A", "B", "C"], "editable": True, "required": False},
+        {"key": "size", "label": "Size", "type": "select", "options": ["1", "2", "3"], "editable": True, "required": False},
+    ]}}})
+    assert r.status_code == 200, r.text
+
+    def _attr(item, key):
+        return (item.get("attributes") or {}).get(key, item.get(key))
+
+    async def _mk(sku, attrs):
+        rr = await client.post("/items", json={"sku": sku, "name": sku, "quantity": 1, "sell_by": "piece",
+                                               "category": "DD", "attributes": attrs}, headers=h)
+        assert rr.status_code == 200, rr.text
+        return rr.json()["id"]
+
+    # Differing dropdowns -> "mixed"; numeric dropdown must NOT sum.
+    a = await _mk("DD-A", {"grade": "A", "size": "1", "carats": "5"})
+    b = await _mk("DD-B", {"grade": "B", "size": "2", "carats": "3"})
+    rm = await client.post("/items/merge", json={"source_entity_ids": [a, b], "target_sku_from": a}, headers=h)
+    assert rm.status_code == 200, rm.text
+    merged = (await client.get(f"/items/{rm.json()['id']}", headers=h)).json()
+    assert _attr(merged, "grade") == "mixed"
+    assert _attr(merged, "size") == "mixed", f"numeric dropdown was summed/invented: {_attr(merged, 'size')!r}"
+    # A conflicting non-dropdown numeric attribute (carats) gets NO value — never summed.
+    assert _attr(merged, "carats") in (None, ""), f"numeric attr was summed/kept: {_attr(merged, 'carats')!r}"
+
+    # Identical values carry through (dropdown or numeric); only conflicts are cleared/mixed.
+    c = await _mk("DD-C", {"grade": "A", "size": "2", "carats": "5"})
+    d = await _mk("DD-D", {"grade": "A", "size": "2", "carats": "5"})
+    rm2 = await client.post("/items/merge", json={"source_entity_ids": [c, d], "target_sku_from": c}, headers=h)
+    assert rm2.status_code == 200, rm2.text
+    merged2 = (await client.get(f"/items/{rm2.json()['id']}", headers=h)).json()
+    assert _attr(merged2, "grade") == "A"
+    assert _attr(merged2, "size") == "2"
+    assert float(_attr(merged2, "carats")) == 5.0  # agreeing numeric still carries


### PR DESCRIPTION
## The bug

Merging items resolved conflicting attribute values by **summing anything numeric** — which invents meaningless values: a numeric `Size` dropdown `1 + 2 → 3`, gold purity `18K + 14K → 32K`, two `5mm + 6mm` stones → `11mm`. Summing is only correct for the handful of *extensive* (additive) attributes; for everything else (dimensions, grades, purities, years, identifiers, per-unit values) it silently corrupts data.

## New rule — a merge never invents a value
- **Dropdown (`select`) conflict → `"mixed"`** sentinel. Stored as the value only; **never added to the field's option list**, so no new option is ever created.
- **Any other numeric conflict → no value** — the merged item simply carries nothing for that field (the correct number is unknowable; don't guess).
- **Agreeing values carry through** unchanged (keeping their original type). **Text conflicts** still go through explicit user resolution (unchanged).
- **Top-level extensive quantities** (`quantity`, net `weight`, `cost_total`) **still sum** — those are genuinely additive and are exactly what a merge combines.
