### PR TITLE
fix(transform): drop sell price on transform (never carry the pre-transform price)

### DIFF
--- a/default_modules/celerp-inventory/celerp_inventory/routes.py
+++ b/default_modules/celerp-inventory/celerp_inventory/routes.py
@@ -1760,8 +1760,11 @@ async def transform_item(entity_id: str, payload: TransformBody, company_id=Depe
 
     parent_qty = float(parent.state.get("quantity") or 0)
     parent_attrs = dict(parent.state.get("attributes") or {})
-    # Exclude cost fields: child cost is set explicitly from child_cost_total
-    parent_prices = {k: parent.state[k] for k in parent.state if k.endswith("_price") and parent.state[k] is not None and k != "cost_price"}
+    # Sell-price fields (retail/wholesale/custom price-list rates — every *_price except cost).
+    # These are intentionally DROPPED on the child: a transform changes what the item is, so the
+    # pre-transform sell price must not carry over (it would let the user accidentally sell the
+    # transformed goods at the old price). The user sets the new sell price manually before selling.
+    parent_price_keys = {k for k in parent.state if k.endswith("_price") and k != "cost_price"}
     parent_cost_total = float(parent.state.get("cost_total") or 0) or (
         float(parent.state.get("cost_price") or 0) * parent_qty
     )
@@ -1772,7 +1775,8 @@ async def transform_item(entity_id: str, payload: TransformBody, company_id=Depe
     # Copy-all-then-override: inherit every parent field; reset only identity/qty/cost/status.
     # Also override sell_by and category — the purpose of a transform is to change these.
     child_data: dict = {
-        k: v for k, v in parent.state.items() if k not in _CHILD_RESET_FIELDS
+        k: v for k, v in parent.state.items()
+        if k not in _CHILD_RESET_FIELDS and k not in parent_price_keys
     }
     child_data.update({
         "sku": payload.child_sku,
@@ -1828,21 +1832,8 @@ async def transform_item(entity_id: str, payload: TransformBody, company_id=Depe
         metadata_={"reason": "from_transform"},
     )
 
-    # 2. Copy prices
-    for price_type, price_val in parent_prices.items():
-        await emit_event(
-            session,
-            company_id=company_id,
-            entity_id=child_eid,
-            entity_type="item",
-            event_type="item.pricing.set",
-            data={"price_type": price_type, "new_price": price_val},
-            actor_id=user.id,
-            location_id=None,
-            source="api",
-            idempotency_key=str(uuid.uuid4()),
-            metadata_={"reason": "from_transform"},
-        )
+    # 2. Sell prices are intentionally NOT copied — the child starts with no sell price (see the
+    #    parent_price_keys note above). Only cost carries over.
 
     # 2b. Set child cost via item.pricing.set (consistent with split/post_item flows)
     await emit_event(

--- a/tests/test_routers/test_items.py
+++ b/tests/test_routers/test_items.py
@@ -2518,3 +2518,32 @@ async def test_merge_dropdown_fields_use_value_or_mixed_never_sum(client):
     assert _attr(merged2, "grade") == "A"
     assert _attr(merged2, "size") == "2"
     assert float(_attr(merged2, "carats")) == 5.0  # agreeing numeric still carries
+
+
+@pytest.mark.asyncio
+async def test_transform_drops_sell_prices_keeps_cost(client):
+    """A transform must NOT carry the parent's sell prices to the child: selling transformed goods
+    at the pre-transform sell price is unsafe. The child starts with no sell price (the user sets it
+    manually before selling); cost still carries over."""
+    token = await _token(client)
+    h = {"Authorization": f"Bearer {token}"}
+    r = await client.post("/items", json={
+        "sku": "TX-PARENT", "name": "Parent", "quantity": 20, "sell_by": "piece",
+        "retail_price": 38.0, "wholesale_price": 24.0, "cost_total": 260.0,
+    }, headers=h)
+    assert r.status_code == 200, r.text
+    pid = r.json()["id"]
+    parent = (await client.get(f"/items/{pid}", headers=h)).json()
+    assert float(parent.get("retail_price") or 0) == 38.0  # parent really has a sell price
+
+    rt = await client.post(f"/items/{pid}/transform", json={
+        "child_sku": "TX-CHILD", "child_category": "Cut", "child_sell_by": "piece",
+        "child_quantity": 10, "child_cost_total": 260.0,
+    }, headers=h)
+    assert rt.status_code == 200, rt.text
+    child = (await client.get(f"/items/{rt.json()['child_id']}", headers=h)).json()
+    # Sell prices dropped — neither carried verbatim nor rebased.
+    assert not child.get("retail_price"), f"retail_price should be dropped, got {child.get('retail_price')!r}"
+    assert not child.get("wholesale_price"), f"wholesale_price should be dropped, got {child.get('wholesale_price')!r}"
+    # Cost still preserved.
+    assert float(child.get("cost_total") or 0) == 260.0


### PR DESCRIPTION
## Issue #176

Transform carried the parent's **sell price** to the child — and because sell prices are per-unit rates, a quantity change silently shrank the totals (retail €760 → €380, etc.). The issue suggested rebasing to preserve the totals.

## the safer behaviour

**Drop the sell price entirely on transform.** A transform changes *what the item is*, so the pre-transform price is meaningless — and carrying it risks a user accidentally selling transformed goods at the old price. Better to clear it so they set the correct price manually before selling.

## Fix

`transform_item` no longer carries any `*_price` (retail/wholesale/custom price-list rate) to the child — removed from both the inherited fields and the explicit copy step. The child starts with **no sell price**. Unchanged:
- **Cost** still carries over (set explicitly as a total).
- **Split** is untouched — a split child is the same product at the same per-unit price, so its price legitimately carries.

## Test

Verified fail-without-fix: after a transform the child has no retail/wholesale price, and cost is preserved. items + history suites green (147 passed).

Fixes #176