### PR TITLE
fix(inventory): "mixed" as a reserved system value for select fields (#178)

### DIFF
--- a/tests/test_inventory_table_helpers.py
+++ b/tests/test_inventory_table_helpers.py
@@ -381,3 +381,37 @@ class TestPerPageSelector:
         from fasthtml.common import to_xml
         html = to_xml(_per_page_selector(100, "/inventory", "status=sold"))
         assert "/inventory?per_page=" in html and "status=sold" in html
+
+
+class TestMixedSelectSystemValue:
+    """#178: 'mixed' is a reserved system value for select fields (e.g. a merge of items whose
+    select attribute differed). It must render as a selectable 'Mixed' rather than matching no
+    option and showing empty — and without being added to the field's configured options."""
+
+    def test_editable_select_renders_mixed_as_selected_option(self):
+        from ui.components.table import editable_cell
+        from fasthtml.common import to_xml
+        html = to_xml(editable_cell("item:1", "stone_type", "mixed", cell_type="select",
+                                    options=["Alexandrite", "Amethyst"]))
+        assert "Mixed" in html, "stored 'mixed' must render as a 'Mixed' option, not empty"
+        assert 'value="mixed"' in html and "selected" in html
+
+    def test_editable_select_normal_value_has_no_injected_mixed(self):
+        from ui.components.table import editable_cell
+        from fasthtml.common import to_xml
+        html = to_xml(editable_cell("item:1", "stone_type", "Amethyst", cell_type="select",
+                                    options=["Alexandrite", "Amethyst"]))
+        assert ">Mixed<" not in html, "'Mixed' must not be injected for a normal value"
+
+    def test_display_select_shows_mixed_label(self):
+        from ui.components.table import display_cell
+        from fasthtml.common import to_xml
+        html = to_xml(display_cell("item:1", "stone_type", "mixed", cell_type="select",
+                                   options=["Alexandrite", "Amethyst"]))
+        assert "Mixed" in html
+
+    def test_options_helper_idempotent_when_already_present(self):
+        from ui.components.table import _options_with_mixed
+        # already has a Mixed option → not duplicated
+        opts = [("a", "A"), ("mixed", "Mixed")]
+        assert _options_with_mixed(opts, "mixed") == opts

--- a/ui/components/table.py
+++ b/ui/components/table.py
@@ -736,6 +736,30 @@ def purchase_display_cell(
     )
 
 
+# "mixed" is a reserved SYSTEM value for select fields — e.g. a merge of items whose select
+# attribute differed. It is never stored in a field's configured options, but a select holding it
+# must still render (as "Mixed") and count as a real value, instead of matching no option and
+# showing empty. These helpers make that work without polluting the admin-configured option list.
+MIXED_SELECT_VALUE = "mixed"
+_MIXED_SELECT_LABEL = "Mixed"
+
+
+def _is_mixed(value) -> bool:
+    return str(value or "").strip().lower() == MIXED_SELECT_VALUE
+
+
+def _options_with_mixed(options: list, value) -> list:
+    """Append a ('mixed', 'Mixed') option when the cell value is the reserved 'mixed' sentinel and
+    the field's options don't already include it — so a merged select renders as Mixed, not empty."""
+    if not _is_mixed(value):
+        return options
+    def _opt_val(o):
+        return o[0] if isinstance(o, tuple) else o
+    if any(str(_opt_val(o)).strip().lower() == MIXED_SELECT_VALUE for o in options):
+        return options
+    return list(options) + [(MIXED_SELECT_VALUE, _MIXED_SELECT_LABEL)]
+
+
 def editable_cell(
     entity_id: str,
     field: str,
@@ -781,6 +805,7 @@ def editable_cell(
     )
 
     if cell_type in ("select", "status") and options is not None:
+        options = _options_with_mixed(options, display_val)
         if len(options) > _SEARCHABLE_THRESHOLD or allow_custom:
             # Searchable combobox for large option sets or allow-custom fields
             input_el = Div(
@@ -925,6 +950,9 @@ def display_cell(
               ``/api/items/{entity_id}/field/{field}/edit`` pattern.
     label_map: optional {slug: display_name} dict - if set, display_val shows the mapped name."""
     display_value = label_map.get(value, value) if label_map and value is not None else value
+    # Show the reserved 'mixed' select sentinel as "Mixed" (not the raw lowercase value or empty).
+    if cell_type in ("select", "status") and _is_mixed(value):
+        display_value = _MIXED_SELECT_LABEL
     inner = _display_val(display_value, cell_type, currency)
     _edit = edit_url or f"/api/items/{entity_id}/field/{field}/edit"
     _safe_id = entity_id.replace(":", "-")


### PR DESCRIPTION
## Issue #178

A merge of items whose `select` attribute differed stores the sentinel `"mixed"`. For a select with no "Mixed" option (e.g. **Stone Type**), `"mixed"` matched no `<option>`, so the field rendered **empty** — silently losing the value, and leaving a required field effectively blank.

make "mixed" a reserved *system* value:

Rather than block the merge or write into the admin's configured options, `"mixed"` is now a reserved system value that always renders and counts as a real value, **without being stored in the option list**:

- **`editable_cell`** appends a `(mixed, Mixed)` option when the cell value is the sentinel and it isn't already present, so the select shows **"Mixed"** (selected) instead of empty. Works for both the plain select and the searchable combobox.
- **`display_cell`** shows **"Mixed"** for the sentinel.
- Both the inventory table and the item detail page render through these shared helpers, so the fix covers both surfaces.
- The **field editor is untouched** — `"mixed"` is never injected into the stored options, so nothing round-trips back into the schema (which `GET /me/item-schema` → `PATCH` would otherwise do).

The merge already writes `"mixed"` for differing selects (PR #175), and custom-select saves don't strict-validate against options, so no merges are blocked and required fields are satisfied.

## Tests

Verified fail-without-fix: an editable select holding `"mixed"` renders a *selected* "Mixed" option (not empty); a normal value does **not** inject "Mixed"; display shows "Mixed"; the helper is idempotent when a real "Mixed" option already exists. Table-related suites green (154 passed).

Fixes #178
