### PR TITLE
fix(merge): custom attributes collapse to "Mixed", not dropped

### DIFF
--- a/celerp/services/field_schema.py
+++ b/celerp/services/field_schema.py
@@ -13,6 +13,11 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from celerp.models.company import Company
 
+# Reserved system value for a field whose sources disagreed and cannot be reconciled (e.g. a merge
+# of items holding different values for a dropdown or custom attribute). There is ONE canonical form,
+# "Mixed", stored and displayed verbatim — no separate lowercase sentinel vs capitalized label.
+MIXED_VALUE = "Mixed"
+
 # Default price lists (used when company has none configured)
 _DEFAULT_PRICE_LISTS: list[dict] = [
     {"name": "Wholesale"},

--- a/default_modules/celerp-inventory/celerp_inventory/routes.py
+++ b/default_modules/celerp-inventory/celerp_inventory/routes.py
@@ -1911,10 +1911,6 @@ async def transform_item(entity_id: str, payload: TransformBody, company_id=Depe
     return {"child_id": child_eid, "child_sku": payload.child_sku, "parent_sku": parent.state.get("sku", "")}
 
 
-# Sentinel stored on a merged item when sources disagree on a dropdown (select) field — merging
-# must never sum or create a new option for those.
-_MERGE_MIXED_VALUE = "mixed"
-
 
 @router.post("/merge")
 async def merge_items(payload: MergeBody, company_id=Depends(get_current_company_id), user=Depends(get_current_user), session: AsyncSession = Depends(get_session)) -> dict:
@@ -1986,13 +1982,6 @@ async def merge_items(payload: MergeBody, company_id=Depends(get_current_company
     earliest_expiry = expiry_dates[0] if expiry_dates else None
 
     # Resolve attributes: collect all keys across sources.
-    def _is_numeric(val: str) -> bool:
-        try:
-            float(val)
-            return True
-        except (TypeError, ValueError):
-            return False
-
     # Expiry-related attributes are handled separately (earliest wins); exclude from conflict resolution.
     _EXPIRY_ATTR_KEYS = frozenset({"expiry_date", "warranty_exp", "expires_at"})
 
@@ -2001,15 +1990,19 @@ async def merge_items(payload: MergeBody, company_id=Depends(get_current_company
         all_attr_keys.update((p.state.get("attributes") or {}).keys())
     all_attr_keys -= _EXPIRY_ATTR_KEYS
 
-    # Dropdown (select) fields for the merged category: a merge must NEVER sum these or invent a
-    # new option. Same value across sources → that value; any disagreement → the "mixed" sentinel.
-    from celerp.services.field_schema import get_effective_field_schema
+    # Classify the merged category's fields by their SCHEMA type, not by the shape of their values.
+    # A merge must NEVER sum a field or invent a value. Only genuinely numeric-typed fields
+    # (number/money/rate) drop to no-value; every other conflicting field collapses to the "Mixed"
+    # system value. Keying off the value shape (as before) misclassified custom attributes whose
+    # values merely look numeric (free fields, or selects with numeric options) and silently dropped
+    # them instead of showing "Mixed".
+    from celerp.services.field_schema import get_effective_field_schema, MIXED_VALUE
     _merge_category = (next(iter(categories), "") or "").strip() or None
     _schema = await get_effective_field_schema(session, company_id, category=_merge_category)
-    _dropdown_keys = {f["key"] for f in _schema if f.get("type") == "select"}
+    _dropdown_keys = {f["key"] for f in _schema if f.get("type") in ("select", "status")}
+    _numeric_keys = {f["key"] for f in _schema if f.get("type") in ("number", "money", "rate")}
 
     resolved_attrs: dict = {}
-    unresolved_conflicts: list[str] = []
     for key in all_attr_keys:
         # Collect raw attribute values (preserve original type for numeric fields)
         raw_values = [(p.state.get("attributes") or {}).get(key) for p in source_projections if key in (p.state.get("attributes") or {})]
@@ -2020,24 +2013,21 @@ async def merge_items(payload: MergeBody, company_id=Depends(get_current_company
             resolved_attrs[key] = raw_values[0]
         elif key in _dropdown_keys:
             # Dropdown field: never sum and never invent an option — differing sources collapse
-            # to the system "mixed" sentinel (issue: merge must not create new dropdown values).
-            resolved_attrs[key] = _MERGE_MIXED_VALUE
-        elif all(_is_numeric(v) for v in unique_str_vals):
-            # Numeric conflict — summing invents a meaningless value (size 1 + 2 ≠ 3; 18K + 14K ≠ 32K).
-            # The correct value is unknowable, so the merged item carries NO value for it.
+            # to the system "Mixed" value (issue: merge must not create new dropdown values).
+            resolved_attrs[key] = MIXED_VALUE
+        elif key in _numeric_keys:
+            # Numeric-typed field — summing invents a meaningless value (size 1 + 2 ≠ 3; 18K + 14K ≠ 32K),
+            # and a numeric cell cannot render the "Mixed" label. The correct value is unknowable, so
+            # the merged item carries NO value for it.
             continue  # omit the key → no value
         else:
-            # String conflict — require user resolution.
+            # Any other conflicting field (custom/free attribute, text, etc.) collapses to the "Mixed"
+            # system value so the conflict stays visible instead of silently vanishing. An explicit
+            # user override via resolved_attributes still wins.
             if payload.resolved_attributes and key in payload.resolved_attributes:
                 resolved_attrs[key] = str(payload.resolved_attributes[key])
             else:
-                unresolved_conflicts.append(key)
-
-    if unresolved_conflicts:
-        raise HTTPException(
-            status_code=422,
-            detail=f"Attribute conflicts require resolution via resolved_attributes: {sorted(unresolved_conflicts)}.",
-        )
+                resolved_attrs[key] = MIXED_VALUE
 
     # Apply user overrides.
     resulting_qty = payload.resulting_quantity if payload.resulting_quantity is not None else total_qty

--- a/tests/test_inventory_table_helpers.py
+++ b/tests/test_inventory_table_helpers.py
@@ -384,17 +384,17 @@ class TestPerPageSelector:
 
 
 class TestMixedSelectSystemValue:
-    """#178: 'mixed' is a reserved system value for select fields (e.g. a merge of items whose
-    select attribute differed). It must render as a selectable 'Mixed' rather than matching no
-    option and showing empty — and without being added to the field's configured options."""
+    """#178: 'Mixed' is the reserved system value for a field whose sources disagreed (e.g. a merge
+    of items whose select attribute differed). It must render as a selectable 'Mixed' rather than
+    matching no option and showing empty — and without being added to the configured options."""
 
     def test_editable_select_renders_mixed_as_selected_option(self):
         from ui.components.table import editable_cell
         from fasthtml.common import to_xml
-        html = to_xml(editable_cell("item:1", "stone_type", "mixed", cell_type="select",
+        html = to_xml(editable_cell("item:1", "stone_type", "Mixed", cell_type="select",
                                     options=["Alexandrite", "Amethyst"]))
-        assert "Mixed" in html, "stored 'mixed' must render as a 'Mixed' option, not empty"
-        assert 'value="mixed"' in html and "selected" in html
+        assert "Mixed" in html, "stored 'Mixed' must render as a 'Mixed' option, not empty"
+        assert 'value="Mixed"' in html and "selected" in html
 
     def test_editable_select_normal_value_has_no_injected_mixed(self):
         from ui.components.table import editable_cell
@@ -406,12 +406,21 @@ class TestMixedSelectSystemValue:
     def test_display_select_shows_mixed_label(self):
         from ui.components.table import display_cell
         from fasthtml.common import to_xml
-        html = to_xml(display_cell("item:1", "stone_type", "mixed", cell_type="select",
+        html = to_xml(display_cell("item:1", "stone_type", "Mixed", cell_type="select",
                                    options=["Alexandrite", "Amethyst"]))
         assert "Mixed" in html
 
     def test_options_helper_idempotent_when_already_present(self):
         from ui.components.table import _options_with_mixed
         # already has a Mixed option → not duplicated
-        opts = [("a", "A"), ("mixed", "Mixed")]
-        assert _options_with_mixed(opts, "mixed") == opts
+        opts = [("a", "A"), ("Mixed", "Mixed")]
+        assert _options_with_mixed(opts, "Mixed") == opts
+
+    def test_display_custom_text_attr_shows_mixed_label(self):
+        # A conflicting custom/free attribute (no select schema) carries the 'Mixed' sentinel after a
+        # merge and must read "Mixed", not the raw value — not only dropdown cells. A legacy lowercase
+        # value normalizes to the one canonical "Mixed" too (no separate 'mixed' vs 'Mixed').
+        from ui.components.table import display_cell
+        from fasthtml.common import to_xml
+        html = to_xml(display_cell("item:1", "carats", "mixed", cell_type="text"))
+        assert ">Mixed<" in html, "custom text attr must render the canonical 'Mixed'"

--- a/tests/test_routers/test_items.py
+++ b/tests/test_routers/test_items.py
@@ -2478,14 +2478,16 @@ async def test_recipe_backed_cost_reads_at_standard_not_lot_total(client):
 @pytest.mark.asyncio
 async def test_merge_dropdown_fields_use_value_or_mixed_never_sum(client):
     """Merging must never sum or invent a value for dropdown (select) fields. Identical values
-    carry forward; any disagreement collapses to the system 'mixed'. Regression: numeric-option
+    carry forward; any disagreement collapses to the system 'Mixed'. Regression: numeric-option
     dropdowns were summed into invalid new values (e.g. size 1 + size 2 -> 3)."""
     token = await _token(client)
     h = {"Authorization": f"Bearer {token}"}
-    # Category with a string dropdown (grade) and a NUMERIC-option dropdown (size).
+    # Category with a string dropdown (grade), a NUMERIC-option dropdown (size), and a genuine
+    # numeric-TYPED field (weight_ct). 'carats' is left undefined -> a free/custom attribute.
     r = await client.patch("/companies/me", headers=h, json={"settings": {"category_schemas": {"DD": [
         {"key": "grade", "label": "Grade", "type": "select", "options": ["A", "B", "C"], "editable": True, "required": False},
         {"key": "size", "label": "Size", "type": "select", "options": ["1", "2", "3"], "editable": True, "required": False},
+        {"key": "weight_ct", "label": "Weight (ct)", "type": "number", "editable": True, "required": False},
     ]}}})
     assert r.status_code == 200, r.text
 
@@ -2498,26 +2500,29 @@ async def test_merge_dropdown_fields_use_value_or_mixed_never_sum(client):
         assert rr.status_code == 200, rr.text
         return rr.json()["id"]
 
-    # Differing dropdowns -> "mixed"; numeric dropdown must NOT sum.
-    a = await _mk("DD-A", {"grade": "A", "size": "1", "carats": "5"})
-    b = await _mk("DD-B", {"grade": "B", "size": "2", "carats": "3"})
+    # Differing dropdowns -> "Mixed"; numeric dropdown must NOT sum.
+    a = await _mk("DD-A", {"grade": "A", "size": "1", "weight_ct": "5", "carats": "5"})
+    b = await _mk("DD-B", {"grade": "B", "size": "2", "weight_ct": "3", "carats": "3"})
     rm = await client.post("/items/merge", json={"source_entity_ids": [a, b], "target_sku_from": a}, headers=h)
     assert rm.status_code == 200, rm.text
     merged = (await client.get(f"/items/{rm.json()['id']}", headers=h)).json()
-    assert _attr(merged, "grade") == "mixed"
-    assert _attr(merged, "size") == "mixed", f"numeric dropdown was summed/invented: {_attr(merged, 'size')!r}"
-    # A conflicting non-dropdown numeric attribute (carats) gets NO value — never summed.
-    assert _attr(merged, "carats") in (None, ""), f"numeric attr was summed/kept: {_attr(merged, 'carats')!r}"
+    assert _attr(merged, "grade") == "Mixed"
+    assert _attr(merged, "size") == "Mixed", f"numeric dropdown was summed/invented: {_attr(merged, 'size')!r}"
+    # A conflicting numeric-TYPED field (weight_ct) gets NO value — never summed, can't render "Mixed".
+    assert _attr(merged, "weight_ct") in (None, ""), f"numeric field was summed/kept: {_attr(merged, 'weight_ct')!r}"
+    # A conflicting CUSTOM/free attribute (carats) collapses to the system "Mixed" — never dropped.
+    assert _attr(merged, "carats") == "Mixed", f"custom attr was dropped instead of Mixed: {_attr(merged, 'carats')!r}"
 
-    # Identical values carry through (dropdown or numeric); only conflicts are cleared/mixed.
-    c = await _mk("DD-C", {"grade": "A", "size": "2", "carats": "5"})
-    d = await _mk("DD-D", {"grade": "A", "size": "2", "carats": "5"})
+    # Identical values carry through (dropdown, numeric, or custom); only conflicts are cleared/mixed.
+    c = await _mk("DD-C", {"grade": "A", "size": "2", "weight_ct": "5", "carats": "5"})
+    d = await _mk("DD-D", {"grade": "A", "size": "2", "weight_ct": "5", "carats": "5"})
     rm2 = await client.post("/items/merge", json={"source_entity_ids": [c, d], "target_sku_from": c}, headers=h)
     assert rm2.status_code == 200, rm2.text
     merged2 = (await client.get(f"/items/{rm2.json()['id']}", headers=h)).json()
     assert _attr(merged2, "grade") == "A"
     assert _attr(merged2, "size") == "2"
-    assert float(_attr(merged2, "carats")) == 5.0  # agreeing numeric still carries
+    assert float(_attr(merged2, "weight_ct")) == 5.0  # agreeing numeric still carries
+    assert str(_attr(merged2, "carats")) == "5"       # agreeing custom attr still carries
 
 
 @pytest.mark.asyncio

--- a/ui/components/table.py
+++ b/ui/components/table.py
@@ -7,6 +7,7 @@ import re
 
 from fasthtml.common import *
 from ui.i18n import t, get_lang
+from celerp.services.field_schema import MIXED_VALUE
 
 # Canonical empty-value placeholder (rule k)
 EMPTY = "--"
@@ -736,28 +737,24 @@ def purchase_display_cell(
     )
 
 
-# "mixed" is a reserved SYSTEM value for select fields — e.g. a merge of items whose select
-# attribute differed. It is never stored in a field's configured options, but a select holding it
-# must still render (as "Mixed") and count as a real value, instead of matching no option and
-# showing empty. These helpers make that work without polluting the admin-configured option list.
-MIXED_SELECT_VALUE = "mixed"
-_MIXED_SELECT_LABEL = "Mixed"
-
-
+# MIXED_VALUE ("Mixed") is the reserved SYSTEM value for a field whose sources disagreed — e.g. a
+# merge of items whose dropdown or custom attribute differed. It is never part of a field's configured
+# options, but a select holding it must still render and count as a real value instead of matching no
+# option and showing empty. These helpers make that work without polluting the configured option list.
 def _is_mixed(value) -> bool:
-    return str(value or "").strip().lower() == MIXED_SELECT_VALUE
+    return str(value or "").strip().casefold() == MIXED_VALUE.casefold()
 
 
 def _options_with_mixed(options: list, value) -> list:
-    """Append a ('mixed', 'Mixed') option when the cell value is the reserved 'mixed' sentinel and
-    the field's options don't already include it — so a merged select renders as Mixed, not empty."""
+    """Append a ('Mixed', 'Mixed') option when the cell value is the reserved 'Mixed' sentinel and the
+    field's options don't already include it — so a merged select renders as Mixed, not empty."""
     if not _is_mixed(value):
         return options
     def _opt_val(o):
         return o[0] if isinstance(o, tuple) else o
-    if any(str(_opt_val(o)).strip().lower() == MIXED_SELECT_VALUE for o in options):
+    if any(_is_mixed(_opt_val(o)) for o in options):
         return options
-    return list(options) + [(MIXED_SELECT_VALUE, _MIXED_SELECT_LABEL)]
+    return list(options) + [(MIXED_VALUE, MIXED_VALUE)]
 
 
 def editable_cell(
@@ -950,9 +947,10 @@ def display_cell(
               ``/api/items/{entity_id}/field/{field}/edit`` pattern.
     label_map: optional {slug: display_name} dict - if set, display_val shows the mapped name."""
     display_value = label_map.get(value, value) if label_map and value is not None else value
-    # Show the reserved 'mixed' select sentinel as "Mixed" (not the raw lowercase value or empty).
-    if cell_type in ("select", "status") and _is_mixed(value):
-        display_value = _MIXED_SELECT_LABEL
+    # Normalize the reserved conflict sentinel to the canonical "Mixed" for any cell that can carry it
+    # (dropdowns AND custom/free attributes left after a merge), so legacy/any-case values read alike.
+    if _is_mixed(value):
+        display_value = MIXED_VALUE
     inner = _display_val(display_value, cell_type, currency)
     _edit = edit_url or f"/api/items/{entity_id}/field/{field}/edit"
     _safe_id = entity_id.replace(":", "-")

--- a/ui/routes/inventory.py
+++ b/ui/routes/inventory.py
@@ -2704,28 +2704,15 @@ function celerpPrintLabel(entityId, templateId) {
             except APIError as e:
                 return Div(P(str(e.detail), cls="flash flash--error"), id="bulk-action-result")
         total_qty = sum(float(it.get("quantity", 0) or 0) for it in items)
-        _CORE_KEYS = _CORE_ITEM_COLS | {"id", "is_expired", "children",
-                                         "child_skus", "merged_into", "reserved_quantity",
-                                         "tax_codes", "unit", "expires_at", "total_cost",
-                                         "entity_id"}
-        def _extract_attrs(it: dict) -> dict:
-            return {k: v for k, v in it.items() if k not in _CORE_KEYS and not k.endswith("_price") and v is not None}
-        item_attrs = [_extract_attrs(it) for it in items]
-        all_attr_keys: set[str] = set()
-        for attrs in item_attrs:
-            all_attr_keys.update(attrs.keys())
-        resolved_attrs: dict = {}
-        for key in all_attr_keys:
-            vals = [str(attrs[key]) for attrs in item_attrs if key in attrs]
-            unique = set(vals)
-            resolved_attrs[key] = vals[0] if len(unique) == 1 else "mixed"
+        # Attribute conflict resolution lives entirely in the merge endpoint (schema-aware: dropdowns
+        # and custom attributes collapse to the "Mixed" system value, numeric fields drop). The UI
+        # must not duplicate that logic.
         try:
             result = await api.merge_items(
                 token,
                 source_entity_ids=entity_ids,
                 target_sku_from=target_sku_from,
                 resulting_quantity=total_qty,
-                resolved_attributes=resolved_attrs or None,
             )
         except APIError as e:
             # Surface merge failures (e.g. a weight-unit mismatch) as the standard lower-right toast.


### PR DESCRIPTION
## Problem
Merging items silently dropped custom (non-system) attributes whose values merely looked numeric (a free attribute, or a dropdown with numeric options). System dropdowns survived; custom attributes vanished.

## Root cause
Conflict resolution classified attributes by the **shape of their values** (`all(_is_numeric(...))`), not by the field's **schema type**. Any custom attribute with number-like values fell into the numeric "drop" branch.

## Fix
- Classify by schema type: only `number`/`money`/`rate` fields drop to no-value; dropdowns (`select`/`status`) and every other conflicting field (custom/free, text) collapse to the "Mixed" system value.
- Unify the conflict sentinel to one canonical `"Mixed"` (`MIXED_VALUE`, defined once in `field_schema.py`), stored and displayed verbatim. No more separate lowercase value vs capitalized label.
- Conflict resolution now lives solely in the merge endpoint; the bulk-merge UI no longer duplicates it.
- Remove the dead "require resolution" 422 path.

## Tests
- `test_merge_dropdown_fields_use_value_or_mixed_never_sum` extended: a genuine numeric-typed field drops; a custom/free attribute collapses to "Mixed".
- `TestMixedSelectSystemValue` updated to the canonical "Mixed" plus a case-insensitive normalization case.
- 28 merge/table tests pass.