### PR TITLE
fix(relay,auth): keep sessions alive while active through the relay + active idle logout

### DIFF
--- a/celerp/config.py
+++ b/celerp/config.py
@@ -20,6 +20,9 @@ class Settings(BaseSettings):
     jwt_algorithm: str = "HS256"
     access_token_expire_minutes: int = 15
     refresh_token_expire_days: int = 30
+    # Log the UI out after this many minutes of no user interaction (client-side idle timer).
+    # Uniform across direct and relay access; set to 0 to disable.
+    idle_logout_minutes: int = 15
     # Set to "true" to allow the default JWT secret (CI only).
     allow_insecure_jwt: str = "false"
     # Logging level for both API and UI processes. Override with LOG_LEVEL env var.

--- a/celerp/gateway/client.py
+++ b/celerp/gateway/client.py
@@ -298,7 +298,7 @@ class GatewayClient:
                 "payload": {
                     "id": request_id,
                     "status": 200,
-                    "headers": {"content-type": "text/event-stream", "cache-control": "no-cache"},
+                    "headers": [["content-type", "text/event-stream"], ["cache-control", "no-cache"]],
                     "body_b64": base64.b64encode(b"data: {}\n\n").decode(),
                 },
             })
@@ -326,12 +326,16 @@ class GatewayClient:
                     content=body,
                 )
             resp_body_b64 = base64.b64encode(resp.content).decode() if resp.content else ""
-            # Filter hop-by-hop headers from response
-            _skip = {"transfer-encoding", "connection", "keep-alive"}
-            resp_headers = {
-                k: v for k, v in resp.headers.items()
+            # Serialize as an ORDERED LIST of pairs (not a dict): a response can carry several
+            # Set-Cookie headers (login/refresh emit access_token + refresh_token), and a dict would
+            # collapse them into one comma-joined value the browser can't parse — so the refresh
+            # cookie never reaches the browser and the session dies at the access token's hard cap.
+            # multi_items() keeps each header separate. Drop content-length; the relay recomputes it.
+            _skip = {"transfer-encoding", "connection", "keep-alive", "content-length"}
+            resp_headers = [
+                [k, v] for k, v in resp.headers.multi_items()
                 if k.lower() not in _skip
-            }
+            ]
             await self._send(self._ws, {
                 "type": "http.response",
                 "payload": {
@@ -348,7 +352,7 @@ class GatewayClient:
                 "payload": {
                     "id": request_id,
                     "status": 502,
-                    "headers": {"content-type": "text/plain"},
+                    "headers": [["content-type", "text/plain"]],
                     "body_b64": base64.b64encode(
                         f"Local app error: {type(exc).__name__}: {exc}".encode()
                     ).decode(),

--- a/tests/test_gateway/test_client.py
+++ b/tests/test_gateway/test_client.py
@@ -13,6 +13,7 @@ import os
 
 os.environ.setdefault("ALLOW_INSECURE_JWT", "true")
 
+import httpx
 import pytest
 
 from celerp.gateway.client import GatewayClient
@@ -363,7 +364,7 @@ async def test_proxy_routes_everything_to_ui_server(client, monkeypatch, path):
     class FakeResp:
         status_code = 200
         content = b"ok"
-        headers = {}
+        headers = httpx.Headers()
 
     class FakeClient:
         def __init__(self, *a, **k):
@@ -389,3 +390,52 @@ async def test_proxy_routes_everything_to_ui_server(client, monkeypatch, path):
     })
     assert "127.0.0.1:8080" in captured["url"], captured
     assert "127.0.0.1:8000" not in captured["url"], captured
+
+
+@pytest.mark.asyncio
+async def test_proxy_response_preserves_multiple_set_cookie(client, monkeypatch):
+    """A proxied response must serialize headers as an ordered list of pairs so multiple Set-Cookie
+    headers (login/refresh emit access_token + refresh_token) survive. A dict would collapse them
+    into one comma-joined value the browser can't parse, dropping the refresh cookie over the relay."""
+    sent = []
+
+    class FakeResp:
+        status_code = 200
+        content = b"<html></html>"
+        headers = httpx.Headers([
+            ("content-type", "text/html"),
+            ("content-length", "13"),
+            ("set-cookie", "access_token=AAA; Path=/; HttpOnly"),
+            ("set-cookie", "refresh_token=RRR; Path=/; HttpOnly"),
+        ])
+
+    class FakeClient:
+        def __init__(self, *a, **k):
+            pass
+        async def __aenter__(self):
+            return self
+        async def __aexit__(self, *a):
+            return False
+        async def request(self, method, url, headers=None, content=None):
+            return FakeResp()
+
+    monkeypatch.setattr("httpx.AsyncClient", FakeClient)
+
+    async def fake_send(ws, msg):
+        sent.append(msg)
+    monkeypatch.setattr(client.__class__, "_send", staticmethod(fake_send))
+    client._ws = object()
+
+    await client._handle_proxy_request({
+        "id": "r1", "method": "GET", "path": "/x",
+        "query": "", "headers": {}, "body_b64": "",
+    })
+
+    headers = sent[-1]["payload"]["headers"]
+    assert isinstance(headers, list), f"headers must be a list of pairs, got {type(headers)}"
+    cookies = [v for k, v in headers if k.lower() == "set-cookie"]
+    assert len(cookies) == 2, f"both Set-Cookie headers must survive, got: {cookies}"
+    assert any("access_token=AAA" in c for c in cookies)
+    assert any("refresh_token=RRR" in c for c in cookies)
+    # content-length is dropped so the relay recomputes it from the (decoded) body.
+    assert not any(k.lower() == "content-length" for k, _ in headers)

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -187,6 +187,31 @@ class TestAuthRouting:
         assert "/login" in r.headers.get("location", "")
 
     @pytest.mark.asyncio
+    async def test_htmx_unauthenticated_gets_hx_redirect(self, ui_client):
+        """An HTMX request to a protected route without a session must return HX-Redirect (a real
+        navigation) instead of a 302 the browser would swap inline as a broken fragment. This is the
+        active-logout path so on-page actions don't fail silently when the session ends."""
+        r = await ui_client.get("/", headers={"HX-Request": "true"})
+        assert r.status_code == 200
+        assert r.headers.get("HX-Redirect", "").startswith("/login")
+
+    @pytest.mark.asyncio
+    async def test_login_idle_reason_shows_message(self, ui_client):
+        """/login?reason=idle (where the inactivity timer sends the browser) explains the logout."""
+        with patch("ui.routes.auth.bootstrap_status", new=AsyncMock(return_value=True)):
+            r = await ui_client.get("/login?reason=idle")
+        assert r.status_code == 200
+        assert b"inactivity" in r.content.lower()
+
+    def test_idle_logout_js_wired_with_config(self):
+        """The inactivity timer is rendered with the configured minutes and logs out on timeout."""
+        from ui.components.shell import _IDLE_LOGOUT_JS
+        from celerp.config import settings
+        assert "/logout?reason=idle" in _IDLE_LOGOUT_JS
+        assert "addEventListener" in _IDLE_LOGOUT_JS
+        assert f"{int(settings.idle_logout_minutes)} * 60000" in _IDLE_LOGOUT_JS
+
+    @pytest.mark.asyncio
     async def test_login_page_renders(self, ui_client):
         """GET /login → returns HTML login form."""
         with patch("ui.routes.auth.bootstrap_status", new=AsyncMock(return_value=True)):

--- a/ui/app.py
+++ b/ui/app.py
@@ -67,6 +67,10 @@ def _auth_guard(req: Request):
         return None
     if req.cookies.get(COOKIE_NAME):
         return None
+    # An HTMX request follows a 302 and swaps the login page into the fragment (a silent, broken
+    # in-page failure). HX-Redirect makes the browser do a real navigation instead.
+    if req.headers.get("hx-request"):
+        return Response(status_code=200, headers={"HX-Redirect": "/login?reason=expired"})
     return RedirectResponse("/login", status_code=302)
 
 
@@ -267,11 +271,12 @@ from ui.api_client import APIError as _APIError
 from starlette.responses import RedirectResponse as _RR
 
 
-def _401_redirect(detail: str) -> _RR:
+def _401_redirect(detail: str, request: Request | None = None):
     """Build a /login redirect from a 401 detail string.
 
     detail may be bare 'Session expired' or 'Session expired|<ip>' (force-login).
-    Any other detail is treated as a generic expiry.
+    Any other detail is treated as a generic expiry. For an HTMX request, return HX-Redirect so the
+    browser navigates instead of swapping the login page into the fragment that fired the request.
     """
     if detail.startswith("Session expired"):
         parts = detail.split("|", 1)
@@ -279,18 +284,21 @@ def _401_redirect(detail: str) -> _RR:
         params = f"reason=evicted&by={ip}" if ip else "reason=evicted"
     else:
         params = "reason=expired"
-    return _RR(f"/login?{params}", status_code=302)
+    url = f"/login?{params}"
+    if request is not None and request.headers.get("hx-request"):
+        return Response(status_code=200, headers={"HX-Redirect": url})
+    return _RR(url, status_code=302)
 
 
-async def ui_401_handler(request: Request, exc) -> _RR:
+async def ui_401_handler(request: Request, exc):
     """Redirect HTTPException 401s to /login."""
-    return _401_redirect(getattr(exc, "detail", "") or "")
+    return _401_redirect(getattr(exc, "detail", "") or "", request)
 
 
-async def ui_api_error_handler(request: Request, exc: _APIError) -> _RR:
+async def ui_api_error_handler(request: Request, exc: _APIError):
     """Redirect APIError 401s (API → UI proxy calls) to /login."""
     if exc.status == 401:
-        return _401_redirect(str(exc.detail or ""))
+        return _401_redirect(str(exc.detail or ""), request)
     # re-raise non-401 APIErrors as 500 so the existing 500 handler formats them
     raise exc
 

--- a/ui/components/shell.py
+++ b/ui/components/shell.py
@@ -13,6 +13,7 @@ from fasthtml.common import *
 from ui.config import COOKIE_NAME, get_role
 from ui.i18n import t, get_lang
 from celerp.services.auth import ROLE_LEVELS
+from celerp.config import settings as _app_settings
 
 # Cache-bust static assets by hashing app.css content
 def _css_version() -> str:
@@ -43,6 +44,24 @@ def _available_locales() -> list[tuple[str, str]]:
     return [(c, _LOCALE_LABELS.get(c, c.upper())) for c in codes]
 
 _LOCALES = _available_locales()
+
+# Idle auto-logout: after N minutes with no user interaction, send the browser to /logout. Uniform
+# across direct and relay access (no token-TTL surgery), and it implements "15 minutes of inactivity"
+# directly. An active user's interactions keep resetting the timer; set idle_logout_minutes=0 to disable.
+_IDLE_LOGOUT_JS = ("""
+(function(){
+  var IDLE_MS = __IDLE_MIN__ * 60000;
+  if (IDLE_MS <= 0) return;
+  var t;
+  function out(){ window.location.href = '/logout?reason=idle'; }
+  function reset(){ clearTimeout(t); t = setTimeout(out, IDLE_MS); }
+  ['mousemove','mousedown','keydown','touchstart','scroll','wheel'].forEach(function(ev){
+    document.addEventListener(ev, reset, {passive:true});
+  });
+  document.addEventListener('htmx:afterRequest', reset);
+  reset();
+})();
+""").replace("__IDLE_MIN__", str(int(_app_settings.idle_logout_minutes)))
 
 # Minimal client-side JS: Esc to cancel edit, row menu toggle, close menus on outside click, searchable combobox
 _CLIENT_JS = """
@@ -918,6 +937,7 @@ def base_shell(*content, title: str = "Celerp", nav_active: str = "", companies:
         Link(rel="stylesheet", href=f"/static/app.css?v={_CSS_VER}"),
         Script(src="/static/htmx.min.js"),
         Script(_CLIENT_JS),
+        Script(_IDLE_LOGOUT_JS),
         Script(_HEALTH_BANNER_JS),
         Script(_BACKUP_BANNER_JS),
         Script(_NOTIFICATION_JS),

--- a/ui/routes/auth.py
+++ b/ui/routes/auth.py
@@ -83,6 +83,8 @@ def setup_routes(app):
             )
         elif reason == "expired":
             notice = flash("Your session expired. Please sign in again.", kind="warning")
+        elif reason == "idle":
+            notice = flash("You were signed out after a period of inactivity. Please sign in again.", kind="warning")
         else:
             notice = ""
         resp = auth_shell(_login_form(notice=notice), title="Sign in - Celerp")
@@ -346,11 +348,13 @@ def setup_routes(app):
 
     @app.get("/logout")
     async def logout_get(request: Request):
-        """GET fallback for no-JS clients. Clears tokens and redirects."""
+        """GET fallback for no-JS clients and the idle-timer. Clears tokens and redirects."""
         token = request.cookies.get(COOKIE_NAME)
         if token:
             await api_logout(token)
-        resp = RedirectResponse("/login", status_code=302)
+        reason = request.query_params.get("reason", "")
+        dest = f"/login?reason={reason}" if reason else "/login"
+        resp = RedirectResponse(dest, status_code=302)
         _clear_tokens(resp)
         return resp
 


### PR DESCRIPTION
Fixes the relay session drop (#182), plus a uniform inactivity logout and active logout surfacing.

## Problem
Through the relay, the session dropped roughly every 15 minutes regardless of activity, kicking users out mid-task.

## Root cause
The HTTP-over-WebSocket proxy serialized a response's headers as a dict. Login and token refresh each emit two Set-Cookie headers (access_token + refresh_token); a dict collapses them into one comma-joined value a browser cannot parse, so the refresh-token cookie never reached the browser. Without it the existing sliding-refresh middleware could not run, and the access token died at its 15-minute hard cap regardless of activity. (Localhost keeps the two headers separate, which is why only the relay path broke.)

## Changes
- `gateway/client.py`: serialize proxied response headers as an ordered list of pairs so every Set-Cookie survives (content-length dropped; the relay recomputes it).
- Uniform inactivity logout: a small client-side idle timer (`idle_logout_minutes`, default 15, `0` disables) navigates to `/logout` after no user interaction. Transport-agnostic and implements "15 minutes of inactivity" directly, with no token-TTL surgery.
- Active logout: an HTMX request on an expired/evicted session (or a 401 mid-action, e.g. eviction over the relay where SSE is suppressed) returns `HX-Redirect` so the browser navigates to `/login` instead of swapping the login page into the fragment and failing silently.

## Tests
- gateway: a proxied response preserves both Set-Cookie headers as a list of pairs.
- ui: HTMX-unauthenticated returns HX-Redirect; `/login?reason=idle` shows the inactivity message; the idle timer is wired with the configured minutes.
- 47 auth/gateway tests pass.
