### PR TITLE
feat(upgrade): preserve data on develop→release in-place upgrade

### DIFF
--- a/celerp/__main__.py
+++ b/celerp/__main__.py
@@ -1,0 +1,14 @@
+# Copyright (c) 2026 Noah Severs
+# SPDX-License-Identifier: BUSL-1.1
+"""Module entrypoint so `python -m celerp <command>` runs the CLI.
+
+The packaged Electron launcher invokes the bundled Python by module
+(`python -m celerp migrate`) rather than via the `celerp` console script,
+which is not on PATH inside the app bundle. This mirrors `python -m alembic`.
+"""
+from __future__ import annotations
+
+from celerp.cli import main
+
+if __name__ == "__main__":
+    main()

--- a/celerp/cli.py
+++ b/celerp/cli.py
@@ -418,6 +418,42 @@ def _run_migrations(db_url: str) -> None:
         sys.exit(1)
 
 
+def _reconcile_after_migrate(db_url: str) -> None:
+    """Replay data-backfill migrations the auto-stamp walker skips on a develop
+    (create_all) database, so a develop→release in-place upgrade preserves data.
+
+    Gated by an instance_meta marker so it runs once per version; the backfills
+    are idempotent, so a redundant run would be a no-op anyway. The projection
+    rebuild (the other half of the version-change reconcile) runs in the API
+    lifespan, where module projection handlers are loaded.
+    """
+    import sqlalchemy as _sa
+
+    from celerp import __version__
+    from celerp.migrations._data_reconcile import (
+        BACKFILL_VERSION_KEY,
+        get_meta,
+        replay_data_backfills,
+        set_meta,
+    )
+
+    sync_url = (
+        db_url.replace("postgresql+asyncpg://", "postgresql://")
+        .replace("postgresql+psycopg2://", "postgresql://")
+    )
+    engine = _sa.create_engine(sync_url, pool_pre_ping=True)
+    try:
+        with engine.begin() as conn:
+            if get_meta(conn, BACKFILL_VERSION_KEY) == __version__:
+                return  # already reconciled for this version
+            replayed = replay_data_backfills(conn)
+            set_meta(conn, BACKFILL_VERSION_KEY, __version__)
+        if replayed:
+            click.echo(f"  · Reconciled {len(replayed)} data-backfill migration(s) for {__version__}")
+    finally:
+        engine.dispose()
+
+
 # ── Commands ──────────────────────────────────────────────────────────────────
 
 @click.group()
@@ -697,15 +733,20 @@ def start():
 
 
 @main.command()
-def migrate():
-    """Apply pending database migrations."""
-    cfg = _read_config()
-    if not cfg:
-        click.echo("Not initialized. Run `celerp init` first.", err=True)
-        sys.exit(1)
+@click.option("--db-url", default=None, help="Database URL (overrides config; used by the packaged launcher).")
+def migrate(db_url):
+    """Apply pending database migrations, then the develop→release reconcile."""
+    url = db_url
+    if url is None:
+        cfg = _read_config()
+        if not cfg:
+            click.echo("Not initialized. Run `celerp init` first.", err=True)
+            sys.exit(1)
+        url = cfg["database"]["url"]
     click.echo("Running migrations...")
-    _run_migrations(cfg["database"]["url"])
-    _post_migration_grants(cfg["database"]["url"])
+    _run_migrations(url)
+    _post_migration_grants(url)
+    _reconcile_after_migrate(url)
     click.echo("  ✓ Done")
 
 

--- a/celerp/main.py
+++ b/celerp/main.py
@@ -199,6 +199,22 @@ async def lifespan(_app: FastAPI):
         "_module": "_kernel",
     })
 
+    # Develop→release guard: on a version change, rebuild projections with the
+    # release's handlers (now that all handlers are registered). Gated by a
+    # marker so it runs once per version. Non-fatal: a failure must not block
+    # boot — the marker stays unset and a later boot retries.
+    try:
+        from celerp.db import SessionLocal as _GuardSession
+        from celerp.services.dev_release_guard import run_upgrade_guard
+        async with _GuardSession() as _guard_sess:
+            await run_upgrade_guard(_guard_sess)
+            await _guard_sess.commit()
+    except Exception:
+        logging.getLogger(__name__).exception(
+            "Develop→release upgrade guard failed (non-fatal); projections may be "
+            "stale until rebuilt via doctor or /ledger/rebuild"
+        )
+
     # Start gateway client if configured (opt-in, no-op if GATEWAY_TOKEN is blank)
     gateway_task = None
     if settings.gateway_token:

--- a/celerp/migrations/_data_reconcile.py
+++ b/celerp/migrations/_data_reconcile.py
@@ -1,0 +1,113 @@
+# Copyright (c) 2026 Noah Severs
+# SPDX-License-Identifier: BUSL-1.1
+"""Replay data-backfill migrations on a develop-origin (create_all) database.
+
+The auto-stamp walker (`_auto_stamp.find_safe_stamp`) deliberately stamps a
+`create_all`-built database to near-head and skips every migration with no
+verifiable DDL signature — which is exactly the set of data backfills, seeds,
+and no-ops. That is the right call for the normal `celerp migrate` path (a
+develop database is usually throwaway scratch data), but the develop→release
+in-place upgrade must *preserve* real data, so those backfills have to run.
+
+A `create_all` database has the head schema but never ran any migration's
+`upgrade()`, so its data backfills never happened. Every such migration is
+written idempotently (guarded by `WHERE ... IS NULL` / `ON CONFLICT`) or is a
+no-op, so replaying them on an already-at-head schema is safe and converges.
+
+We re-run each one's `upgrade()` against a live connection through a real
+alembic Operations context — the same `op` proxy the migration was written
+against — so no SQL is duplicated and nothing is monkeypatched.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from celerp.migrations._auto_stamp import extract_signatures
+
+if TYPE_CHECKING:
+    from sqlalchemy.engine import Connection
+
+# ── Instance metadata marker ────────────────────────────────────────────────
+# A tiny key/value table recording which celerp version last applied each
+# upgrade phase. The develop build never persists a version (it has no marker),
+# so the first release boot always reconciles; afterwards each phase is gated to
+# run once per version. Managed here (CREATE TABLE IF NOT EXISTS) rather than as
+# a model/migration so it works on any database, including a create_all one.
+_META_TABLE = "instance_meta"
+
+# Marker keys: the backfill replay runs at `celerp migrate` time (no handlers
+# needed); the projection rebuild runs in the API lifespan (handlers loaded), so
+# each is gated by its own key.
+BACKFILL_VERSION_KEY = "backfill_version"
+PROJECTION_VERSION_KEY = "projection_version"
+
+
+def _ensure_meta_table(conn: "Connection") -> None:
+    from sqlalchemy import text
+
+    conn.execute(text(f"CREATE TABLE IF NOT EXISTS {_META_TABLE} (key TEXT PRIMARY KEY, value TEXT NOT NULL)"))
+
+
+def get_meta(conn: "Connection", key: str) -> str | None:
+    """Read an instance_meta value, or None if unset (table auto-created)."""
+    from sqlalchemy import text
+
+    _ensure_meta_table(conn)
+    return conn.execute(text(f"SELECT value FROM {_META_TABLE} WHERE key = :k"), {"k": key}).scalar()
+
+
+def set_meta(conn: "Connection", key: str, value: str) -> None:
+    """Upsert an instance_meta value (table auto-created)."""
+    from sqlalchemy import text
+
+    _ensure_meta_table(conn)
+    conn.execute(
+        text(
+            f"INSERT INTO {_META_TABLE} (key, value) VALUES (:k, :v) "
+            f"ON CONFLICT (key) DO UPDATE SET value = :v"
+        ),
+        {"k": key, "v": value},
+    )
+
+
+def data_backfill_scripts():
+    """Return alembic Script objects the walker advances past, oldest→newest.
+
+    "Advances past" == `extract_signatures` finds no verifiable DDL, which is
+    precisely the data-backfill / seed / no-op migrations. Oldest→newest order
+    matches the order alembic would have applied them.
+    """
+    from alembic.script import ScriptDirectory
+
+    from celerp.alembic_config import build_alembic_config
+
+    cfg = build_alembic_config()
+    script = ScriptDirectory.from_config(cfg)
+    # walk_revisions() yields newest→oldest; reverse to replay in apply order.
+    out = []
+    for sc in reversed(list(script.walk_revisions())):
+        if not extract_signatures(Path(sc.path)):
+            out.append(sc)
+    return out
+
+
+def replay_data_backfills(connection: "Connection") -> list[str]:
+    """Re-run every data-backfill migration's `upgrade()` against `connection`.
+
+    `connection` is a sync SQLAlchemy Connection; the caller owns the
+    transaction. Returns the revision ids replayed, in apply order.
+    """
+    from alembic.operations import Operations
+    from alembic.runtime.migration import MigrationContext
+
+    scripts = data_backfill_scripts()
+    ctx = MigrationContext.configure(connection)
+    replayed: list[str] = []
+    # Operations.context binds the global `alembic.op` proxy these migrations
+    # import, so their `op.get_bind()` returns this connection.
+    with Operations.context(ctx):
+        for sc in scripts:
+            sc.module.upgrade()
+            replayed.append(sc.revision)
+    return replayed

--- a/celerp/services/backup_export.py
+++ b/celerp/services/backup_export.py
@@ -56,11 +56,16 @@ def _build_archive(dump: bytes, attachment_dirs: list[Path], meta: dict) -> Path
         info.size = len(meta_bytes)
         tar.addfile(info, io.BytesIO(meta_bytes))
 
-        # Attachment directories
+        # File directories (attachments, ai_uploads, custom modules)
         for d in attachment_dirs:
             if not d.exists():
                 continue
             for p in sorted(d.rglob("*")):
+                # Skip regenerable Python bytecode: bundling it bloats the
+                # archive and stale .pyc across machines/python versions is
+                # actively harmful on restore (custom modules carry these).
+                if "__pycache__" in p.parts or p.suffix == ".pyc":
+                    continue
                 if p.is_file():
                     try:
                         rel = str(p.relative_to(d.parent))
@@ -131,6 +136,13 @@ async def export_full() -> Path:
 
     return _build_archive(
         dump,
-        [settings.data_dir / "static" / "attachments", settings.data_dir / "ai_uploads"],
+        [
+            settings.data_dir / "static" / "attachments",
+            settings.data_dir / "ai_uploads",
+            # Custom module code lives on disk (user data), not in the DB dump.
+            # Bundle it so a restore on another machine has the code to interpret
+            # the module's restored tables — not just the tables.
+            settings.data_dir / "modules",
+        ],
         meta,
     )

--- a/celerp/services/backup_import.py
+++ b/celerp/services/backup_import.py
@@ -297,9 +297,9 @@ async def _run_alembic() -> None:
 
 
 async def _extract_files(path: Path) -> None:
-    """Extract attachments/ and ai_uploads/ from the archive into data_dir."""
+    """Extract attachments/, ai_uploads/, and custom modules/ into data_dir."""
     from celerp.config import settings
-    _ALLOWED_PREFIXES = ("attachments/", "ai_uploads/")
+    _ALLOWED_PREFIXES = ("attachments/", "ai_uploads/", "modules/")
     with tarfile.open(str(path), "r:gz") as tar:
         for member in tar.getmembers():
             if member.name in ("database.dump", "meta.json"):

--- a/celerp/services/dev_release_guard.py
+++ b/celerp/services/dev_release_guard.py
@@ -1,0 +1,100 @@
+# Copyright (c) 2026 Noah Severs
+# SPDX-License-Identifier: BUSL-1.1
+"""Develop→release upgrade guard, run from the API lifespan.
+
+After a version change, the release build may compute projections differently
+from the develop build that wrote them, so projections are rebuilt from the
+ledger using the release's handlers (`ProjectionEngine.rebuild`). This runs in
+the lifespan — not the CLI — because rebuild needs every projection handler
+(kernel `sys.*` + each loaded module) registered, which only happens here.
+
+Gated by the `projection_version` marker so it runs once per version. Before
+rebuilding it pre-checks that every `event_type` in the ledger is a known event
+(with modules loaded); an unknown type means a downgrade or a missing module, so
+we skip the rebuild rather than silently fold those events into wrong state.
+
+The data-backfill half of the reconcile runs earlier, at `celerp migrate` time
+(`cli._reconcile_after_migrate`), where no handlers are needed.
+"""
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+log = logging.getLogger(__name__)
+
+
+async def unknown_event_types(session: "AsyncSession") -> set[str]:
+    """Ledger event types that are not in the (modules-loaded) event catalog."""
+    from sqlalchemy import text
+
+    from celerp.events.schemas import EVENT_SCHEMA_MAP
+
+    rows = await session.execute(text("SELECT DISTINCT event_type FROM ledger"))
+    return {r[0] for r in rows} - set(EVENT_SCHEMA_MAP.keys())
+
+
+def _is_dev_version(v: str) -> bool:
+    """A develop build's version string. Matches the UI's dev-build detection
+    (ui/components/shell.py): a PEP 440 `.devN` segment, or the `+dev` local
+    fallback (`0.0.0+dev`) used when setuptools_scm can't read the version."""
+    return ".dev" in v or "+dev" in v
+
+
+def _should_rebuild(marker: str | None) -> bool:
+    """Whether to rebuild projections, given the version that last booted this DB.
+
+    Rebuild when the database was last written by a DEVELOP build (its
+    projections may use experimental logic the release computes differently), or
+    when the origin is unknown (no marker — the first boot under this guard, so
+    rebuild once defensively). A database last booted by a RELEASE build is
+    assumed projection-correct, so a release→release upgrade skips the
+    (potentially expensive) full rebuild entirely.
+    """
+    if marker is None:
+        return True
+    return _is_dev_version(marker)
+
+
+async def run_upgrade_guard(session: "AsyncSession") -> dict:
+    """Rebuild projections on a develop→release transition. Caller owns the txn.
+
+    Returns a summary dict; never raises for an expected condition (unknown
+    events → skip). `changed` is False when the marker already matches.
+    """
+    from celerp import __version__
+    from celerp.migrations._data_reconcile import (
+        PROJECTION_VERSION_KEY,
+        get_meta,
+        set_meta,
+    )
+    from celerp.projections.engine import ProjectionEngine
+
+    conn = await session.connection()
+    marker = await conn.run_sync(lambda c: get_meta(c, PROJECTION_VERSION_KEY))
+    if marker == __version__:
+        return {"changed": False, "rebuilt": False}
+
+    rebuilt = False
+    if _should_rebuild(marker):
+        unknown = await unknown_event_types(session)
+        if unknown:
+            # Downgrade or missing module: replaying these events would produce
+            # wrong state. Skip the rebuild and leave the marker as-is so a later
+            # boot (with the module present, or the right release) retries.
+            log.error(
+                "Upgrade guard: %d unknown ledger event type(s) — skipping projection "
+                "rebuild to avoid corruption. Missing handler/module for: %s",
+                len(unknown), sorted(unknown),
+            )
+            return {"changed": True, "rebuilt": False, "unknown_event_types": sorted(unknown)}
+        await ProjectionEngine.rebuild(session)
+        rebuilt = True
+        log.info("Upgrade guard: rebuilt projections (from %s) for version %s", marker, __version__)
+
+    # Record this boot's version so a later release→release upgrade can skip.
+    await conn.run_sync(lambda c: set_meta(c, PROJECTION_VERSION_KEY, __version__))
+    return {"changed": True, "rebuilt": rebuilt}

--- a/electron/main.js
+++ b/electron/main.js
@@ -133,6 +133,7 @@ let apiPort = null;
 let uiPort = null;
 
 const { watchForRestart } = require("./restart");
+const { migrateArgs } = require("./migrate_cmd");
 
 // ── Utilities ────────────────────────────────────────────────────────────────
 
@@ -252,7 +253,7 @@ function runMigrations(dbUrl) {
     PYTHONPATH: APP_DIR,
     ALEMBIC_VERSION_LOCATIONS: _moduleAlembicLocations(),
   };
-  execFileSync(pythonBin(), ["-m", "alembic", "upgrade", "head"], {
+  execFileSync(pythonBin(), migrateArgs(dbUrl), {
     cwd: APP_DIR,
     env,
     stdio: "pipe",

--- a/electron/migrate_cmd.js
+++ b/electron/migrate_cmd.js
@@ -1,0 +1,18 @@
+// Copyright (c) 2026 Noah Severs
+// SPDX-License-Identifier: BUSL-1.1
+"use strict";
+
+// Argv for the bundled-Python database migration step.
+//
+// Routed through the celerp CLI (`python -m celerp migrate`) instead of a raw
+// `python -m alembic upgrade head`. The CLI path auto-stamps a develop-origin
+// (create_all) database before upgrading and then runs the develop→release
+// reconcile (replay data backfills + projection rebuild on a version change),
+// none of which raw alembic does — raw alembic crashes on such a database.
+//
+// Pure (no electron import) so it is unit-testable, like restart.js.
+function migrateArgs(dbUrl) {
+  return ["-m", "celerp", "migrate", "--db-url", dbUrl];
+}
+
+module.exports = { migrateArgs };

--- a/electron/tests/migrate_cmd.test.js
+++ b/electron/tests/migrate_cmd.test.js
@@ -1,0 +1,22 @@
+// Copyright (c) 2026 Noah Severs
+// SPDX-License-Identifier: BUSL-1.1
+"use strict";
+
+const { migrateArgs } = require("../migrate_cmd");
+
+describe("migrateArgs", () => {
+  test("routes through the celerp CLI, not raw alembic", () => {
+    const args = migrateArgs("postgresql+asyncpg://celerp:celerp@localhost:5432/celerp");
+    expect(args).toEqual([
+      "-m", "celerp", "migrate",
+      "--db-url", "postgresql+asyncpg://celerp:celerp@localhost:5432/celerp",
+    ]);
+    // The whole point of the change: the launcher must NOT run raw alembic,
+    // which crashes on a develop-origin (create_all) database.
+    expect(args).not.toContain("alembic");
+  });
+
+  test("passes the database URL through verbatim", () => {
+    expect(migrateArgs("postgresql://x/y")).toContain("postgresql://x/y");
+  });
+});

--- a/tests/test_backup_module_roundtrip.py
+++ b/tests/test_backup_module_roundtrip.py
@@ -1,0 +1,63 @@
+# Copyright (c) 2026 Noah Severs
+# SPDX-License-Identifier: LicenseRef-Proprietary
+
+"""Custom-module code must survive a backup round-trip.
+
+Module code lives on disk under data_dir/modules/ (user data), not in the pg
+dump. The backup now bundles it so a restore on another machine has the code to
+interpret the module's restored tables — not just the tables.
+"""
+
+from __future__ import annotations
+
+import io
+import tarfile
+
+import pytest
+
+
+def test_build_archive_bundles_modules_and_excludes_bytecode(tmp_path):
+    from celerp.services.backup_export import _build_archive
+
+    modules = tmp_path / "modules"
+    (modules / "mymod" / "__pycache__").mkdir(parents=True)
+    (modules / "mymod" / "code.py").write_text("X = 1")
+    (modules / "mymod" / "__pycache__" / "code.cpython-312.pyc").write_bytes(b"junk")
+
+    archive = _build_archive(b"DUMP", [modules], {"celerp_version": "test"})
+    try:
+        with tarfile.open(archive) as tar:
+            names = tar.getnames()
+    finally:
+        archive.unlink()
+
+    assert "modules/mymod/code.py" in names
+    # Regenerable bytecode must not be bundled (bloat + stale across machines).
+    assert not any("__pycache__" in n or n.endswith(".pyc") for n in names)
+
+
+@pytest.mark.asyncio
+async def test_extract_files_restores_module_code(tmp_path, monkeypatch):
+    from celerp.config import settings
+    from celerp.services import backup_import as bi
+
+    monkeypatch.setattr(settings, "data_dir", tmp_path)
+
+    # An archive carrying a module file (plus the always-present db dump).
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+        dump = b"PGDMP"
+        di = tarfile.TarInfo("database.dump")
+        di.size = len(dump)
+        tar.addfile(di, io.BytesIO(dump))
+        body = b"PLUGIN = 1"
+        mi = tarfile.TarInfo("modules/mymod/__init__.py")
+        mi.size = len(body)
+        tar.addfile(mi, io.BytesIO(body))
+    archive = tmp_path / "backup.celerp-backup"
+    archive.write_bytes(buf.getvalue())
+
+    await bi._extract_files(archive)
+
+    restored = tmp_path / "modules" / "mymod" / "__init__.py"
+    assert restored.read_bytes() == b"PLUGIN = 1"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,6 +4,10 @@
 
 from __future__ import annotations
 
+import os
+import subprocess
+import sys
+
 from unittest.mock import patch
 
 import pytest
@@ -230,15 +234,32 @@ def test_migrate_not_initialized(tmp_config):
 
 
 def test_migrate_runs_with_grants(tmp_config, valid_cfg):
-    """migrate must call _post_migration_grants after _run_migrations."""
+    """migrate must run migrations, grants, then the develop→release reconcile."""
     _write_config(valid_cfg)
     runner = CliRunner()
     with patch("celerp.cli._run_migrations") as mock_mig, \
-         patch("celerp.cli._post_migration_grants") as mock_grants:
+         patch("celerp.cli._post_migration_grants") as mock_grants, \
+         patch("celerp.cli._reconcile_after_migrate") as mock_reconcile:
         result = runner.invoke(main, ["migrate"])
     assert result.exit_code == 0
     mock_mig.assert_called_once_with(valid_cfg["database"]["url"])
     mock_grants.assert_called_once_with(valid_cfg["database"]["url"])
+    mock_reconcile.assert_called_once_with(valid_cfg["database"]["url"])
+
+
+def test_migrate_db_url_overrides_config(tmp_config):
+    """`migrate --db-url` runs without a config (the packaged launcher path) and
+    threads the given URL through migrations, grants, and the reconcile."""
+    url = "postgresql+asyncpg://celerp:celerp@localhost:5432/launcher"
+    runner = CliRunner()
+    with patch("celerp.cli._run_migrations") as mock_mig, \
+         patch("celerp.cli._post_migration_grants") as mock_grants, \
+         patch("celerp.cli._reconcile_after_migrate") as mock_reconcile:
+        result = runner.invoke(main, ["migrate", "--db-url", url])
+    assert result.exit_code == 0, result.output
+    mock_mig.assert_called_once_with(url)
+    mock_grants.assert_called_once_with(url)
+    mock_reconcile.assert_called_once_with(url)
 
 
 # ── celerp start ─────────────────────────────────────────────────────────────
@@ -392,3 +413,38 @@ def test_init_force_aborts_on_no_keeps_everything(tmp_config, tmp_path, monkeypa
     prov.assert_not_called()            # DB not wiped
     stop.assert_not_called()
     assert att.exists() and ai.exists() # files kept
+
+
+# ── `python -m celerp` module entrypoint ────────────────────────────────────
+# The packaged Electron launcher invokes the bundled Python by module
+# (`python -m celerp migrate`), not via the console script. These tests prove
+# the celerp/__main__.py entrypoint exists and dispatches to the CLI group.
+
+def _module_run(args, config_path):
+    env = {
+        **os.environ,
+        "ALLOW_INSECURE_JWT": "true",        # config import guard
+        "CELERP_CONFIG": str(config_path),   # isolate from the real config
+    }
+    return subprocess.run(
+        [sys.executable, "-m", "celerp", *args],
+        capture_output=True, text=True, timeout=20, env=env,
+    )
+
+
+def test_module_entrypoint_help_lists_commands(tmp_path):
+    """`python -m celerp --help` must run and expose the subcommands."""
+    r = _module_run(["--help"], tmp_path / "nope.toml")
+    assert r.returncode == 0, r.stderr
+    assert "migrate" in r.stdout
+
+
+def test_module_entrypoint_dispatches_to_subcommand(tmp_path):
+    """`python -m celerp migrate` must reach the migrate command itself.
+
+    With no config it exits non-zero and says "Not initialized" — proving the
+    invocation dispatched to the real subcommand, not just the group --help.
+    """
+    r = _module_run(["migrate"], tmp_path / "nope.toml")
+    assert r.returncode != 0
+    assert "Not initialized" in (r.stdout + r.stderr)

--- a/tests/test_migrations/test_dev_to_release_upgrade.py
+++ b/tests/test_migrations/test_dev_to_release_upgrade.py
@@ -1,0 +1,303 @@
+# Copyright (c) 2026 Noah Severs
+# SPDX-License-Identifier: LicenseRef-Proprietary
+
+"""Develop→release upgrade: data-backfill reconcile through the real path.
+
+A develop build creates its database with `Base.metadata.create_all`, so the
+schema is at head but no migration `upgrade()` ever ran. The auto-stamp walker
+(`_auto_stamp.find_safe_stamp`) then deliberately stamps near head and skips
+every migration with no verifiable DDL signature — i.e. all data backfills.
+That is fine for throwaway dev data, but the develop→release in-place upgrade
+must preserve real data, so `_data_reconcile.replay_data_backfills` re-runs
+those backfills.
+
+Probe migration: `n8o9p0q1r2s3_backfill_payment_date`, a pure `op.execute`
+backfill on the AUTHORITATIVE `ledger.data` (not a rebuildable projection).
+It has zero DDL signatures, so the walker skips it; only the reconcile applies
+it. The first test pins the walker's (intended) skip so the reconcile's reason
+to exist stays visible; the rest prove the reconcile closes the gap.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+from sqlalchemy import create_engine, text
+
+from celerp import __version__
+from celerp.cli import _reconcile_after_migrate, _run_migrations
+from celerp.migrations._data_reconcile import (
+    BACKFILL_VERSION_KEY,
+    get_meta,
+    replay_data_backfills,
+)
+from celerp.models.base import Base
+
+_PAYMENT_TS = "2026-03-15 10:30:00+00"
+_EXPECTED_DATE = "2026-03-15"
+
+
+def _head_rev() -> str:
+    """The current alembic head revision id."""
+    from alembic.script import ScriptDirectory
+
+    from celerp.alembic_config import build_alembic_config
+
+    return ScriptDirectory.from_config(build_alembic_config()).get_current_head()
+
+
+def _swap_db(url: str, dbname: str) -> str:
+    """Replace the database name (last path segment) in a SQLAlchemy URL."""
+    base, _, _old = url.rpartition("/")
+    return f"{base}/{dbname}"
+
+
+@pytest.fixture()
+def fresh_db():
+    """Provision a throwaway database, yield (async_url, sync_url), then drop it.
+
+    Restores os.environ['DATABASE_URL'] on teardown — `_run_migrations` mutates
+    it, which would otherwise leak the throwaway DB into later tests.
+    """
+    base_async = os.environ["DATABASE_URL"]
+    base_sync = base_async.replace("+asyncpg", "+psycopg2")
+    saved_env = os.environ.get("DATABASE_URL")
+    dbname = f"advtest_{uuid.uuid4().hex[:8]}"
+
+    admin = create_engine(base_sync, isolation_level="AUTOCOMMIT")
+    with admin.connect() as c:
+        c.execute(text(f'CREATE DATABASE "{dbname}"'))
+    admin.dispose()
+
+    try:
+        yield _swap_db(base_async, dbname), _swap_db(base_sync, dbname)
+    finally:
+        if saved_env is not None:
+            os.environ["DATABASE_URL"] = saved_env
+        admin = create_engine(base_sync, isolation_level="AUTOCOMMIT")
+        with admin.connect() as c:
+            c.execute(
+                text(
+                    "SELECT pg_terminate_backend(pid) FROM pg_stat_activity "
+                    "WHERE datname = :d AND pid <> pg_backend_pid()"
+                ),
+                {"d": dbname},
+            )
+            c.execute(text(f'DROP DATABASE IF EXISTS "{dbname}"'))
+        admin.dispose()
+
+
+def _build_dev_schema(sync_url: str, *, stamp: str | None) -> None:
+    """Create the full head schema via create_all (like a develop build) and
+    seed one company + one payment event whose data is MISSING payment_date.
+
+    `stamp` sets alembic_version to mimic the develop build's guessed stamp;
+    pass None to mimic a freshly create_all'd DB that was never stamped.
+    """
+    eng = create_engine(sync_url)
+    try:
+        with eng.begin() as conn:
+            Base.metadata.create_all(conn)
+            cid = uuid.uuid4()
+            conn.execute(
+                text(
+                    "INSERT INTO companies (id, name, slug, settings, is_active, created_at) "
+                    "VALUES (:id, 'Adv', :slug, '{}'::json, true, now())"
+                ),
+                {"id": cid, "slug": f"adv-{cid.hex[:8]}"},
+            )
+            conn.execute(
+                text(
+                    "INSERT INTO ledger "
+                    "(company_id, entity_id, entity_type, event_type, data, source, idempotency_key, ts) "
+                    "VALUES (:cid, 'doc:INV-1', 'doc', 'doc.payment.received', "
+                    "CAST(:data AS json), 'auto_je', 'idem-1', :ts)"
+                ),
+                {"cid": cid, "data": '{"amount": 100}', "ts": _PAYMENT_TS},
+            )
+            if stamp is not None:
+                conn.execute(text("CREATE TABLE alembic_version (version_num VARCHAR(32) NOT NULL)"))
+                conn.execute(text("INSERT INTO alembic_version (version_num) VALUES (:r)"), {"r": stamp})
+    finally:
+        eng.dispose()
+
+
+def _payment_date(sync_url: str) -> str | None:
+    eng = create_engine(sync_url)
+    try:
+        with eng.connect() as conn:
+            return conn.execute(
+                text("SELECT data->>'payment_date' FROM ledger WHERE event_type = 'doc.payment.received'")
+            ).scalar()
+    finally:
+        eng.dispose()
+
+
+def _reconcile(sync_url: str) -> list[str]:
+    eng = create_engine(sync_url)
+    try:
+        with eng.begin() as conn:
+            return replay_data_backfills(conn)
+    finally:
+        eng.dispose()
+
+
+def _marker(sync_url: str) -> str | None:
+    eng = create_engine(sync_url)
+    try:
+        with eng.connect() as conn:
+            return get_meta(conn, BACKFILL_VERSION_KEY)
+    finally:
+        eng.dispose()
+
+
+def _clear_payment_date(sync_url: str) -> None:
+    """Remove payment_date from the seeded event (simulate un-backfilled data)."""
+    eng = create_engine(sync_url)
+    try:
+        with eng.begin() as conn:
+            conn.execute(text("UPDATE ledger SET data = (data::jsonb - 'payment_date')::json "
+                              "WHERE event_type = 'doc.payment.received'"))
+    finally:
+        eng.dispose()
+
+
+def test_run_migrations_alone_skips_authoritative_backfill(fresh_db):
+    """Pins the walker's intended behavior: on a create_all DB, `_run_migrations`
+    does NOT apply the payment_date backfill (no DDL signature → stamped past).
+    This is why the develop→release reconcile exists."""
+    async_url, sync_url = fresh_db
+    _build_dev_schema(sync_url, stamp=None)
+
+    _run_migrations(async_url)
+
+    assert _payment_date(sync_url) is None
+
+
+@pytest.mark.parametrize("stamp_at_head", [False, True], ids=["unstamped", "stamped_at_head"])
+def test_reconcile_applies_authoritative_backfill(fresh_db, stamp_at_head):
+    """After schema migrate + reconcile, the authoritative ledger backfill is
+    applied — for both realistic develop-origin states: a never-stamped
+    create_all DB, and one already stamped at head."""
+    async_url, sync_url = fresh_db
+    _build_dev_schema(sync_url, stamp=_head_rev() if stamp_at_head else None)
+
+    _run_migrations(async_url)
+    replayed = _reconcile(sync_url)
+
+    assert "n8o9p0q1r2s3" in replayed
+    assert _payment_date(sync_url) == _EXPECTED_DATE
+
+
+def test_reconcile_is_idempotent(fresh_db):
+    """Replaying the backfills twice converges (each backfill is guarded), so a
+    second dev→release reconcile is a safe no-op."""
+    async_url, sync_url = fresh_db
+    _build_dev_schema(sync_url, stamp=None)
+    _run_migrations(async_url)
+
+    first = _reconcile(sync_url)
+    after_first = _payment_date(sync_url)
+    second = _reconcile(sync_url)
+    after_second = _payment_date(sync_url)
+
+    assert first == second  # same set of migrations replayed
+    assert after_first == after_second == _EXPECTED_DATE
+
+
+def test_reconcile_after_migrate_applies_and_marks(fresh_db):
+    """The migrate-time orchestration applies the backfill and records the
+    version marker so it won't redo the work next time."""
+    async_url, sync_url = fresh_db
+    _build_dev_schema(sync_url, stamp=None)
+    _run_migrations(async_url)
+
+    assert _marker(sync_url) is None  # develop build never wrote a marker
+
+    _reconcile_after_migrate(async_url)
+
+    assert _payment_date(sync_url) == _EXPECTED_DATE
+    assert _marker(sync_url) == __version__
+
+
+def _seed_dev_origin(sync_url: str) -> uuid.UUID:
+    """Create a develop-origin DB: head schema (no stamp), one module-owned
+    item.created event, and one authoritative payment event lacking payment_date.
+    Returns the company id. No projections — the release rebuild creates them."""
+    eng = create_engine(sync_url)
+    cid = uuid.uuid4()
+    try:
+        with eng.begin() as conn:
+            Base.metadata.create_all(conn)
+            conn.execute(
+                text("INSERT INTO companies (id, name, slug, settings, is_active, created_at) "
+                     "VALUES (:id, 'Golden', :slug, '{}'::json, true, now())"),
+                {"id": cid, "slug": f"golden-{cid.hex[:8]}"},
+            )
+            for eid, etype, evt, data in [
+                ("item:1", "item", "item.created", '{"sku": "S", "name": "A", "quantity": 1}'),
+                ("doc:INV-1", "doc", "doc.payment.received", '{"amount": 100}'),
+            ]:
+                conn.execute(
+                    text("INSERT INTO ledger (company_id, entity_id, entity_type, event_type, "
+                         "data, source, idempotency_key, ts) VALUES "
+                         "(:cid, :eid, :et, :evt, CAST(:d AS json), 'test', :idem, :ts)"),
+                    {"cid": cid, "eid": eid, "et": etype, "evt": evt, "d": data,
+                     "idem": f"idem-{eid}", "ts": _PAYMENT_TS},
+                )
+    finally:
+        eng.dispose()
+    return cid
+
+
+@pytest.mark.asyncio
+async def test_golden_dev_to_release_end_to_end(fresh_db):
+    """Capstone, mirroring production: a develop-origin (create_all) DB goes
+    through schema migrate → migrate-time backfill replay (sync, psycopg2) →
+    lifespan projection rebuild (async, asyncpg). Asserts the authoritative
+    ledger backfill applied AND the doctor's independent oracle finds zero stale
+    projections. Covers use case 2 (a module event replays via its handler)."""
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    from sqlalchemy.pool import NullPool
+
+    from celerp.routers.doctor import _check_stale_projections
+    from celerp.services.dev_release_guard import run_upgrade_guard
+
+    async_url, sync_url = fresh_db
+    cid = _seed_dev_origin(sync_url)
+
+    # Production launcher path: `celerp migrate` = schema + grants + reconcile.
+    _run_migrations(async_url)
+    _reconcile_after_migrate(async_url)
+    assert _payment_date(sync_url) == _EXPECTED_DATE  # authoritative backfill ran
+
+    # Production API-boot path: the lifespan guard rebuilds projections.
+    engine = create_async_engine(async_url, poolclass=NullPool)
+    try:
+        async with async_sessionmaker(engine, expire_on_commit=False)() as s:
+            guard = await run_upgrade_guard(s)
+            await s.commit()
+            assert guard["rebuilt"] is True
+            stale = await _check_stale_projections(s, cid, None, fix=False)
+            assert stale["found"] == 0, stale["details"]
+    finally:
+        await engine.dispose()
+
+
+def test_reconcile_after_migrate_gated_by_version(fresh_db):
+    """Once reconciled for a version, a second call is skipped (gated by the
+    marker). Proven by corrupting the data and confirming it is NOT re-fixed."""
+    async_url, sync_url = fresh_db
+    _build_dev_schema(sync_url, stamp=None)
+    _run_migrations(async_url)
+    _reconcile_after_migrate(async_url)
+    assert _payment_date(sync_url) == _EXPECTED_DATE
+
+    # Marker now == current version. Corrupt the data; a gated rerun must NOT
+    # touch it (same version → skip), proving the gate actually short-circuits.
+    _clear_payment_date(sync_url)
+    _reconcile_after_migrate(async_url)
+
+    assert _payment_date(sync_url) is None

--- a/tests/test_services/test_dev_release_guard.py
+++ b/tests/test_services/test_dev_release_guard.py
@@ -1,0 +1,150 @@
+# Copyright (c) 2026 Noah Severs
+# SPDX-License-Identifier: LicenseRef-Proprietary
+
+"""Tests for the develop→release lifespan guard (projection rebuild + catalog).
+
+Uses the transactional `session` fixture (rolled back per test). Projection
+handlers are registered by the root conftest's autouse slot fixture, so
+`ProjectionEngine.rebuild` runs the real item handler here.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from sqlalchemy import delete, text
+
+from celerp import __version__
+from celerp.events.engine import emit_event
+from celerp.migrations._data_reconcile import PROJECTION_VERSION_KEY, get_meta, set_meta
+from celerp.models.company import Company
+from celerp.models.projections import Projection
+from celerp.services.dev_release_guard import run_upgrade_guard, unknown_event_types
+
+
+async def _seed_item(session) -> uuid.UUID:
+    cid = uuid.uuid4()
+    session.add(Company(id=cid, name="GuardCo", slug=f"guardco-{cid.hex[:8]}"))
+    await session.flush()
+    await emit_event(
+        session, company_id=cid, entity_id="item:1", entity_type="item",
+        event_type="item.created", data={"sku": "S", "name": "A", "quantity": 1},
+        actor_id=None, location_id=None, source="test",
+        idempotency_key=str(uuid.uuid4()), metadata_={},
+    )
+    return cid
+
+
+async def _marker(session) -> str | None:
+    conn = await session.connection()
+    return await conn.run_sync(lambda c: get_meta(c, PROJECTION_VERSION_KEY))
+
+
+async def _set_marker(session, value: str) -> None:
+    conn = await session.connection()
+    await conn.run_sync(lambda c: set_meta(c, PROJECTION_VERSION_KEY, value))
+
+
+async def _projection_count(session) -> int:
+    return len((await session.execute(select_projections())).all())
+
+
+def select_projections():
+    from sqlalchemy import select
+    return select(Projection)
+
+
+@pytest.mark.asyncio
+async def test_guard_rebuilds_on_version_change(session):
+    """No marker (develop origin) → guard rebuilds projections and stamps the
+    version marker."""
+    await _seed_item(session)
+    # Simulate projections that don't match the release: wipe them.
+    await session.execute(delete(Projection))
+    assert await _projection_count(session) == 0
+    assert await _marker(session) is None
+
+    result = await run_upgrade_guard(session)
+
+    assert result == {"changed": True, "rebuilt": True}
+    assert await _projection_count(session) == 1     # rebuilt from the ledger
+    assert await _marker(session) == __version__
+
+
+@pytest.mark.asyncio
+async def test_guard_gated_when_version_matches(session):
+    """Once stamped for this version, a second run is skipped — proven by wiping
+    projections and confirming the guard does NOT rebuild them."""
+    await _seed_item(session)
+    await run_upgrade_guard(session)            # stamps marker == __version__
+    assert await _marker(session) == __version__
+
+    await session.execute(delete(Projection))   # corrupt: drop read-models
+    result = await run_upgrade_guard(session)    # same version → must skip
+
+    assert result == {"changed": False, "rebuilt": False}
+    assert await _projection_count(session) == 0  # NOT rebuilt (gate held)
+
+
+@pytest.mark.asyncio
+async def test_guard_skips_rebuild_for_release_origin(session):
+    """A DB last booted by a RELEASE build (marker has no .dev) is assumed
+    projection-correct: a release→release upgrade skips the rebuild entirely."""
+    await _seed_item(session)
+    await _set_marker(session, "1.0.0")          # previous boot was a release build
+    await session.execute(delete(Projection))    # corrupt: drop read-models
+
+    result = await run_upgrade_guard(session)
+
+    assert result == {"changed": True, "rebuilt": False}
+    assert await _projection_count(session) == 0  # NOT rebuilt — release origin
+    assert await _marker(session) == __version__  # but the boot version is recorded
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("dev_marker", ["1.0.0.dev7", "0.0.0+dev"], ids=["pep440-dev", "local-dev-fallback"])
+async def test_guard_rebuilds_for_dev_origin(session, dev_marker):
+    """A DB last booted by a DEVELOP build gets a rebuild — the develop→release
+    transition this feature exists for. Both dev-version forms count (matching
+    the UI's detection): a `.devN` segment and the `+dev` local fallback."""
+    await _seed_item(session)
+    await _set_marker(session, dev_marker)        # previous boot was a develop build
+    await session.execute(delete(Projection))
+
+    result = await run_upgrade_guard(session)
+
+    assert result == {"changed": True, "rebuilt": True}
+    assert await _projection_count(session) == 1  # rebuilt from the ledger
+    assert await _marker(session) == __version__
+
+
+@pytest.mark.asyncio
+async def test_guard_skips_rebuild_on_unknown_event_type(session):
+    """An unknown ledger event type (downgrade / missing module) makes the guard
+    refuse to rebuild, leaving existing projections and the marker untouched."""
+    cid = await _seed_item(session)
+    # A ledger event the catalog doesn't know about.
+    await session.execute(
+        text(
+            "INSERT INTO ledger (company_id, entity_id, entity_type, event_type, "
+            "data, source, idempotency_key, ts) VALUES "
+            "(:cid, 'x:1', 'mystery', 'zzz.unknown.event', '{}'::json, 'test', :idem, now())"
+        ),
+        {"cid": cid, "idem": f"idem-{uuid.uuid4().hex[:8]}"},
+    )
+    before = await _projection_count(session)
+
+    result = await run_upgrade_guard(session)
+
+    assert result["changed"] is True and result["rebuilt"] is False
+    assert "zzz.unknown.event" in result["unknown_event_types"]
+    assert await _projection_count(session) == before   # untouched
+    assert await _marker(session) is None               # not stamped → retries later
+
+
+@pytest.mark.asyncio
+async def test_unknown_event_types_empty_for_known_events(session):
+    """All kernel/module event types emitted normally are in the catalog."""
+    await _seed_item(session)
+    assert await unknown_event_types(session) == set()


### PR DESCRIPTION
## What & why

A develop build creates its database with `Base.metadata.create_all`, so the schema is at head but **no migration `upgrade()` ever ran**. The auto-stamp walker (`_auto_stamp.find_safe_stamp`) deliberately stamps such a DB near head and skips every migration with no verifiable DDL signature — i.e. **all data backfills/seeds**. That's correct for throwaway dev data, but on a develop→release upgrade that must *preserve* real data it silently drops them, including the **authoritative `ledger.data` payment_date backfill** (`n8o9p0q1r2s3`). An adversarial test confirmed `_run_migrations` leaves payment_date unset.

## Changes

- **Launcher routing** — `electron/main.js` now runs `python -m celerp migrate --db-url <url>` (new `celerp/__main__.py` + pure `electron/migrate_cmd.js`) instead of raw `alembic upgrade head`, so it gets auto-stamp + the reconcile. `migrate` gained a `--db-url` override (the launcher has no CLI config).
- **Migrate-time backfill replay** — `cli._reconcile_after_migrate` replays the no-DDL-signature data-backfill migrations via a real alembic `Operations` context (no SQL duplication), gated by a `backfill_version` marker. All such migrations are idempotent.
- **Lifespan guard** — `services/dev_release_guard` rebuilds projections with the release's handlers + a catalog pre-check that refuses on unknown event types. The rebuild is **scoped to a develop-origin DB** (the `projection_version` marker holds a `.dev`/`+dev` version, matching the UI's dev detection) or the first unknown boot; **release→release upgrades skip it**. Non-fatal — never blocks boot.
- **Backup completeness** — the backup now bundles `data_dir/modules/` (custom-module code lives on disk, not in the pg dump) and excludes regenerable bytecode, so a restore on another machine has the code for its restored tables.

## Test coverage

Adversarial backfill-skip; reconcile-applies + idempotency + version-gating; lifespan rebuild + catalog-refuse + dev/release scoping; backup module round-trip; CLI `--db-url` and `python -m celerp` entrypoint; and a **golden end-to-end** (sync replay + async rebuild mirroring production) asserting the doctor's **independent stale-projection oracle == 0**. Full non-browser suite green locally (3763 passed).
