### PR TITLE
fix(cli): add --no-start to `celerp init` for headless/service installs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,8 +39,9 @@ Trademarks are not licensed by any code license; see `legal/TRADEMARK.md`.
 ## CLI commands (pip install)
 
 ```bash
-celerp init       # first-time setup (connects DB, runs migrations, writes config)
-celerp start      # launches API + UI
+celerp init             # first-time setup: DB + migrations + config, then launches the servers
+celerp init --no-start  # same setup, but exit WITHOUT launching (service-managed/headless)
+celerp start            # launch API + UI (e.g. from systemd, after `init --no-start`)
 celerp migrate    # apply pending migrations after an upgrade
 celerp status     # show config, DB connection, migration state
 celerp demo       # seed demo data
@@ -56,8 +57,42 @@ celerp upgrade    # pip install --upgrade celerp + migrate
 | `--ui-port` | `8080` | UI server port |
 | `--cloud-token` | _(empty)_ | Celerp Cloud token (optional) |
 | `--force` | off | Overwrite existing config |
+| `--yes` / `-y` | off | Skip the `--force` wipe confirmation (non-interactive) |
+| `--no-start` | off | Set up, then exit WITHOUT launching servers (service-managed/headless) |
 
 To change ports after init, edit `~/.config/celerp/config.toml` directly.
+
+### Run as a service (systemd)
+
+`celerp init` launches the servers and blocks (good for the one-command desktop
+flow). For a headless box where a process manager owns the lifecycle, set up with
+`--no-start` and let systemd run `celerp start`:
+
+```bash
+# First boot: provision DB + migrations + config, then exit (do not block).
+sudo celerp init --no-start \
+  --db-url "postgresql+asyncpg://celerp:<password>@localhost:5432/celerp" \
+  --api-port 8000 --ui-port 8080
+```
+
+```ini
+# /etc/systemd/system/celerp.service
+[Unit]
+Description=Celerp
+After=network.target postgresql.service
+
+[Service]
+ExecStart=/usr/local/bin/celerp start
+Restart=on-failure
+User=celerp
+
+[Install]
+WantedBy=multi-user.target
+```
+
+```bash
+sudo systemctl enable --now celerp
+```
 
 ## Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -43,12 +43,15 @@ Or install via pip:
 
 ```bash
 pip install celerp
-celerp init
-celerp start
+celerp init        # sets up the database and launches Celerp
 ```
 
 Open **http://localhost:8080**. Done.
 Your office can securely access the system at your IP address :8080.
+
+Running headless or under a process manager? Use `celerp init --no-start` to set up
+without launching, then have your service run `celerp start` — see
+[Run as a service (systemd)](CONTRIBUTING.md#run-as-a-service-systemd).
 
 ---
 

--- a/celerp/cli.py
+++ b/celerp/cli.py
@@ -432,7 +432,13 @@ def main() -> None:
 @click.option("--cloud-token", default=None, help="Celerp Cloud token (optional).")
 @click.option("--force", is_flag=True, help="Reconfigure: WIPES the database and all attached files.")
 @click.option("--yes", "-y", "assume_yes", is_flag=True, help="Skip the --force wipe confirmation (non-interactive use).")
-def init(db_url, api_port, ui_port, cloud_token, force, assume_yes):
+@click.option(
+    "--no-start", "no_start", is_flag=True,
+    help="Provision the database, run migrations, and write config, then exit "
+         "WITHOUT launching the servers. For service-managed/headless installs "
+         "where a process manager (e.g. systemd) runs `celerp start`.",
+)
+def init(db_url, api_port, ui_port, cloud_token, force, assume_yes, no_start):
     """Initialize Celerp: write config and run database migrations."""
     config_path = _config_path()
 
@@ -576,6 +582,9 @@ def init(db_url, api_port, ui_port, cloud_token, force, assume_yes):
             f"  Back us early: {_handoff('/github', medium='cli')}\n"
         )
 
+    if no_start:
+        click.echo("Setup complete. Start the servers with: celerp start")
+        return
     _start(cfg)
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -72,6 +72,51 @@ def test_init_defaults(tmp_config):
     assert len(cfg["auth"]["jwt_secret"]) == 64  # secrets.token_hex(32)
 
 
+def test_init_no_start_skips_server_launch(tmp_config):
+    """--no-start provisions + migrates + writes config, then exits without
+    launching servers (headless/service-managed installs)."""
+    runner = CliRunner()
+    with patch(_INIT_PATCHES["test_db"], return_value=None), \
+         patch(_INIT_PATCHES["run_migrations"]), \
+         patch(_INIT_PATCHES["post_grants"]), \
+         patch(_INIT_PATCHES["start"]) as mock_start:
+        result = runner.invoke(main, ["init", "--no-start"])
+    assert result.exit_code == 0, result.output
+    mock_start.assert_not_called()                      # nothing launched
+    assert tmp_config.exists()                          # config written
+    assert "celerp start" in result.output              # tells the user what to run next
+
+
+def test_init_without_no_start_launches_servers(tmp_config):
+    """Regression guard for the desktop one-command UX: no flag → _start runs."""
+    runner = CliRunner()
+    with patch(_INIT_PATCHES["test_db"], return_value=None), \
+         patch(_INIT_PATCHES["run_migrations"]), \
+         patch(_INIT_PATCHES["post_grants"]), \
+         patch(_INIT_PATCHES["start"]) as mock_start:
+        result = runner.invoke(main, ["init"])
+    assert result.exit_code == 0, result.output
+    mock_start.assert_called_once()
+
+
+def test_init_force_no_start_skips_launch(tmp_config, valid_cfg):
+    """--no-start also applies on the --force path: it still stops/wipes/re-provisions,
+    then exits without launching."""
+    _write_config(valid_cfg)
+    runner = CliRunner()
+    with patch(_INIT_PATCHES["run_migrations"]), \
+         patch(_INIT_PATCHES["post_grants"]), \
+         patch(_INIT_PATCHES["start"]) as mock_start, \
+         patch("celerp.cli._stop_servers") as mock_stop, \
+         patch("celerp.cli._provision_db") as mock_prov, \
+         patch("celerp.cli._needs_ownership_fix", return_value=False):
+        result = runner.invoke(main, ["init", "--force", "--yes", "--no-start"])
+    assert result.exit_code == 0, result.output
+    mock_stop.assert_called_once()        # force still stopped servers
+    mock_prov.assert_called_once()        # force still re-provisioned
+    mock_start.assert_not_called()        # but did not launch
+
+
 def test_init_shows_star_cta_line(tmp_config):
     runner = CliRunner()
     with patch(_INIT_PATCHES["test_db"], return_value=None), \


### PR DESCRIPTION
## Problem

`celerp init` ends by calling `_start(cfg)`, which launches the API+UI servers and **blocks until they exit**. So `init` can't be used non-interactively: a first-boot/cloud-init script that runs `celerp init` never returns and the provisioner hangs (our DigitalOcean 1-Click droplet fails its image scan). It also contradicts the documented self-host flow (`celerp init` → systemd `celerp start`), which can't work while `init` blocks.

## Change

Add an opt-in **`--no-start`** flag to `celerp init`: provision the DB, run migrations, write config, then **exit 0 without launching servers**. Purely additive and non-breaking — no flag means the same init-and-run behavior, so the one-command desktop UX is preserved.

- Works on the normal path **and** the `--force` path (force still stops/wipes/re-provisions first, just skips the launch).
- The "Already initialized" early return and the as-root auto-provision logic are untouched.

```bash
celerp init --no-start --db-url "postgresql+asyncpg://celerp:<pw>@localhost:5432/celerp" --api-port 8000 --ui-port 8080
```
provisions + migrates + writes config, then exits 0 binding no port; systemd then runs `celerp start`.

## Tests

- `--no-start` → `_start` not called, exit 0, config written (normal and `--force` paths).
- no flag → `_start` called (regression guard for the desktop flow).

(The as-root provisioning-against-Postgres variant isn't included — it needs a root test env; the as-root code path is unchanged by this flag.)

## Docs

- README quick-start no longer shows the broken `init` + `start` pair.
- CONTRIBUTING documents `--no-start`/`--yes` and adds a **Run as a service (systemd)** section with a sample unit file.

## Release

First release carrying this flag will be the next tag (latest is `v1.2.5` → likely `v1.2.6`). The droplet's first-boot `pip install --upgrade celerp` picks it up automatically once published.
