### PR TITLE
Refresh bundled modules on upgrade

### DIFF
--- a/electron/app-main.js
+++ b/electron/app-main.js
@@ -96,7 +96,7 @@ const CONFIG_PATH = path.join(DATA_DIR, "celerp-config.json");
 const PYTHON_CONFIG_PATH = path.join(DATA_DIR, "config.toml");
 
 // Default modules shipped with the binary (in app resources/default_modules/).
-// Copied to MODULE_DIR on first boot if not already present.
+// Seeded into MODULE_DIR on first boot and refreshed from the bundle on upgrade.
 const DEFAULT_MODULES_SRC = IS_DEV
   ? path.resolve(__dirname, "../default_modules")
   : path.join(process.resourcesPath, "app", "default_modules");
@@ -260,20 +260,56 @@ function runMigrations(dbUrl) {
   });
 }
 
-/** Seed default modules from resources into DATA_DIR/modules/ on first boot. */
+/**
+ * Seed the bundled (first-party) default modules into DATA_DIR/modules/.
+ *
+ * The copies under MODULE_DIR are what actually run (they are on PYTHONPATH), so
+ * they must be refreshed whenever a new app version ships - otherwise a release's
+ * module fixes never reach users who upgrade in place. We record the app version
+ * that last seeded the bundle in a marker file and re-copy the first-party
+ * modules from the bundle whenever it changes.
+ *
+ * Only directories shipped in DEFAULT_MODULES_SRC are managed here. Modules a
+ * user added themselves (names not present in the bundle) are never touched -
+ * default modules are shipped code, not user data.
+ */
 function seedDefaultModules() {
   const srcDir = DEFAULT_MODULES_SRC;
   if (!fs.existsSync(srcDir)) return; // Dev mode, modules already on path
 
   fs.mkdirSync(MODULE_DIR, { recursive: true });
 
+  const markerPath = path.join(MODULE_DIR, ".default-modules-version");
+  const appVersion = app.getVersion();
+  let seededVersion = "";
+  try {
+    seededVersion = fs.readFileSync(markerPath, "utf8").trim();
+  } catch {
+    // No marker yet (fresh install): treat as a version change so we seed.
+  }
+  const refresh = seededVersion !== appVersion;
+
   for (const modName of fs.readdirSync(srcDir)) {
     const src = path.join(srcDir, modName);
     const dst = path.join(MODULE_DIR, modName);
     if (!fs.statSync(src).isDirectory()) continue;
-    if (fs.existsSync(dst)) continue; // Already installed — never overwrite user edits
+    const installed = fs.existsSync(dst);
+    // Already present and the app version is unchanged: the bundled source can't
+    // have changed either, so leave it as-is.
+    if (installed && !refresh) continue;
+    // Refresh from the bundle so shipped fixes (and removals) take effect. Only
+    // first-party modules - those present in the bundle - ever reach this path.
+    if (installed) fs.rmSync(dst, { recursive: true, force: true });
     _copyDirSync(src, dst);
-    console.log(`[modules] Seeded default module: ${modName}`);
+    console.log(`[modules] ${installed ? "Refreshed" : "Seeded"} default module: ${modName}`);
+  }
+
+  if (refresh) {
+    try {
+      fs.writeFileSync(markerPath, appVersion);
+    } catch (e) {
+      console.warn("[modules] could not record seeded module version:", e.message);
+    }
   }
 }
 

--- a/tests/test_modules/test_electron_integration.py
+++ b/tests/test_modules/test_electron_integration.py
@@ -94,10 +94,18 @@ class TestElectronMainJS:
         assert "default_modules" in self._src
         assert "process.resourcesPath" in self._src
 
-    def test_seed_skips_existing_modules(self):
-        """seedDefaultModules should not overwrite existing user-installed modules."""
-        assert "fs.existsSync(dst)" in self._src
-        assert "continue" in self._src  # Skip existing
+    def test_seed_refreshes_first_party_on_version_change(self):
+        """seedDefaultModules must re-seed bundled modules when the app version
+        changes, so shipped module fixes reach users who upgrade in place."""
+        assert "app.getVersion()" in self._src
+        assert ".default-modules-version" in self._src
+        # A version change replaces the installed copy (remove + re-copy).
+        assert "fs.rmSync(dst" in self._src
+
+    def test_seed_leaves_user_modules_untouched(self):
+        """Only bundled modules (iterated from DEFAULT_MODULES_SRC) are managed;
+        a user-added module whose name isn't in the bundle is never overwritten."""
+        assert "fs.readdirSync(srcDir)" in self._src
 
     def test_module_setup_failure_is_nonfatal(self):
         """module_setup.py failure should be caught and logged, not fatal."""
@@ -240,8 +248,10 @@ class TestSecondBootGuards:
             "pgInstance.initialise() must be inside an if (!fs.existsSync(...)) guard"
         )
 
-    def test_seed_default_modules_skips_existing(self):
-        """seedDefaultModules must skip already-installed module dirs (idempotent)."""
+    def test_seed_default_modules_idempotent_within_version(self):
+        """On a second boot of the same app version, seedDefaultModules must not
+        re-copy already-installed modules - it is version-gated, so it's a no-op."""
+        assert "seededVersion !== appVersion" in self._src
         assert "fs.existsSync(dst)" in self._src
         assert "continue" in self._src
 


### PR DESCRIPTION
Closes #192.

First-party modules under `DATA_DIR/modules` are what run at runtime (they are on `PYTHONPATH`). `seedDefaultModules` seeded them on first boot and skipped any that already existed, so an in-place upgrade kept running the previously seeded copy rather than the version shipped in the new build.

## Change
- Record the app version that last seeded the bundle in a `.default-modules-version` marker under `MODULE_DIR`.
- When the app version changes, re-copy each first-party module from the bundle (remove + re-copy) so every upgrade delivers the module code shipped with that release.
- Within the same version, seeding stays a no-op (version-gated).
- Modules a user added themselves (names not present in the bundle) are never touched - only directories shipped in `DEFAULT_MODULES_SRC` are managed.

## Behavior
| Scenario | Result |
| --- | --- |
| Fresh install | Bundled modules seeded; marker written |
| Reboot, same version | No-op |
| Upgrade to a new version | First-party modules refreshed from the bundle |
| User-added module | Left untouched |

The boot-smoke job exercises this path by launching the packaged app on every build.