### PR TITLE
Boot smoke: fix Linux sandbox; de-elevate the app on Windows so Postgres can start

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -468,14 +468,21 @@ jobs:
       # 200 {"db":"ok"} proves electron -> Python API -> embedded Postgres -> a query.
       # We poll (never sleep) and fail fast if the process dies (crash on launch).
       - name: Boot smoke (launch the packaged app, require db:ok)
+        if: runner.os != 'Windows'
         shell: bash
         run: |
           set -uo pipefail
           cd electron
-          if [ "$RUNNER_OS" = "Linux" ]; then sudo apt-get update -qq && sudo apt-get install -y -qq xvfb; fi
+          if [ "$RUNNER_OS" = "Linux" ]; then
+            sudo apt-get update -qq && sudo apt-get install -y -qq xvfb
+            # Electron's SUID sandbox helper must be owned by root with mode 4755;
+            # the unpacked tree ships it owned by the runner (real AppImage/deb
+            # installs set this), so fix it here or the sandbox aborts on launch.
+            sudo chown root:root dist/linux-unpacked/chrome-sandbox
+            sudo chmod 4755 dist/linux-unpacked/chrome-sandbox
+          fi
           case "$RUNNER_OS" in
             macOS)   APP_BIN="$(ls -d dist/mac*/Celerp.app | head -1)/Contents/MacOS/Celerp" ;;
-            Windows) APP_BIN="dist/win-unpacked/Celerp.exe" ;;
             Linux)   APP_BIN="$(find dist/linux-unpacked -maxdepth 1 -type f -executable ! -name 'chrome*' ! -name '*.so*' | head -1)" ;;
           esac
           echo "smoke: launching $APP_BIN"
@@ -503,6 +510,50 @@ jobs:
             exit 1
           fi
           echo "boot smoke OK on $RUNNER_OS"
+
+      # Windows needs its own launch path: the runner is elevated and embedded
+      # Postgres refuses to run as a Windows administrator. We run the app at a
+      # limited (medium-integrity) token via a scheduled task, so Postgres starts
+      # exactly as it does for a normal per-user install.
+      - name: Boot smoke (Windows, de-elevated, require db:ok)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          Set-Location electron
+          $port = Get-Random -Minimum 20000 -Maximum 60000
+          $exe  = (Resolve-Path "dist/win-unpacked/Celerp.exe").Path
+          $log  = Join-Path $env:RUNNER_TEMP "smoke.log"
+          # The de-elevated task is a fresh process, so pass the port via machine
+          # env (new processes inherit it); cleaned up below.
+          [Environment]::SetEnvironmentVariable("CELERP_API_PORT", "$port", "Machine")
+          $wrap = Join-Path $env:RUNNER_TEMP "smoke-run.cmd"
+          "@echo off`r`n`"$exe`" > `"$log`" 2>&1" | Set-Content -Encoding Ascii $wrap
+          Write-Host "smoke: launching $exe (de-elevated via scheduled task) on port $port"
+          $action    = New-ScheduledTaskAction -Execute $wrap
+          $principal = New-ScheduledTaskPrincipal -UserId "$env:USERNAME" -RunLevel Limited
+          Register-ScheduledTask -TaskName celerpsmoke -Action $action -Principal $principal -Force | Out-Null
+          Start-ScheduledTask -TaskName celerpsmoke
+          $deadline = (Get-Date).AddSeconds(120)
+          $ok = $false
+          while ((Get-Date) -lt $deadline) {
+            try {
+              $r = Invoke-WebRequest -UseBasicParsing -TimeoutSec 3 -Uri "http://127.0.0.1:$port/health/ready"
+              if ($r.Content -match '"db"\s*:\s*"ok"') { $ok = $true; break }
+            } catch { }
+            Start-Sleep -Seconds 1
+          }
+          schtasks /End /TN celerpsmoke 2>$null | Out-Null
+          taskkill /IM Celerp.exe /F 2>$null | Out-Null
+          schtasks /Delete /TN celerpsmoke /F 2>$null | Out-Null
+          [Environment]::SetEnvironmentVariable("CELERP_API_PORT", $null, "Machine")
+          if (-not $ok) {
+            Write-Host "::error::boot smoke FAILED on Windows - /health/ready never returned db:ok"
+            Write-Host "----- app log (tail) -----"
+            if (Test-Path $log) { Get-Content $log -Tail 200 }
+            exit 1
+          }
+          Write-Host "boot smoke OK on Windows"
 
       - name: Verify YML artifact names
         if: "!startsWith(github.ref, 'refs/tags/v')"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -538,6 +538,22 @@ jobs:
           $ErrorActionPreference = "Stop"
           Set-Location electron
           $exe = (Resolve-Path "dist/win-unpacked/Celerp.exe").Path
+          # --- DIAGNOSTIC: does `runas /trustlevel` run + actually drop admin here? ---
+          $probeOut = Join-Path $env:RUNNER_TEMP "deelev.txt"
+          $probeCmd = Join-Path $env:RUNNER_TEMP "probe.cmd"
+          Set-Content -Encoding Ascii $probeCmd "whoami /groups > `"$probeOut`" 2>&1"
+          Remove-Item $probeOut -ErrorAction SilentlyContinue
+          try {
+            $rp = Start-Process -FilePath "runas.exe" -ArgumentList "/trustlevel:0x20000",$probeCmd -PassThru -Wait -RedirectStandardError (Join-Path $env:RUNNER_TEMP "runas.err")
+            Write-Host "probe: runas exit=$($rp.ExitCode)"
+          } catch { Write-Host "probe: runas threw: $_" }
+          Get-Content (Join-Path $env:RUNNER_TEMP "runas.err") -ErrorAction SilentlyContinue | ForEach-Object { Write-Host "probe runas.err: $_" }
+          Start-Sleep 3
+          if (Test-Path $probeOut) {
+            Write-Host "probe: de-elevated token (Administrators state + integrity):"
+            Get-Content $probeOut | Select-String -Pattern "Administrators|Mandatory Label"
+          } else { Write-Host "probe: NO output -> runas /trustlevel did not launch the wrapper at all" }
+          Write-Host "--- end diagnostic ---"
           # The app self-de-elevates into a fresh process (Postgres can't run as
           # admin), which wouldn't inherit a port we set in env. So we don't pin
           # the port: the app picks a free one and publishes it to api-port, which

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,12 @@ on:
   pull_request:
     branches: ["main"]   # mac-only unsigned build + boot smoke (pre-tag gate)
   workflow_dispatch:
+    inputs:
+      platforms:
+        description: "Platforms to build on this manual run"
+        type: choice
+        default: all
+        options: [all, windows, linux, mac]
 
 permissions:
   contents: write
@@ -91,7 +97,16 @@ jobs:
           mac='{"os":"macos-latest","build_cmd":"pnpm run build:mac","platform_flag":"--mac","standalone_dir":"mac-arm64","pbs_triple":"aarch64-apple-darwin"}'
           win='{"os":"windows-latest","build_cmd":"pnpm run build:win","platform_flag":"--win","standalone_dir":"win-x64","pbs_triple":"x86_64-pc-windows-msvc"}'
           lin='{"os":"ubuntu-latest","build_cmd":"pnpm run build:linux","platform_flag":"--linux","standalone_dir":"linux-x64","pbs_triple":"x86_64-unknown-linux-gnu"}'
-          if [ "${{ github.ref_name }}" = "bugfix" ] || [ "${{ github.event_name }}" = "pull_request" ]; then
+          sel="${{ github.event.inputs.platforms }}"
+          if [ -n "$sel" ] && [ "$sel" != "all" ]; then
+            case "$sel" in
+              windows) inc="$win" ;;
+              linux)   inc="$lin" ;;
+              mac)     inc="$mac" ;;
+              *)       inc="$lin,$win,$mac" ;;
+            esac
+            echo "matrix={\"include\":[$inc]}" >> "$GITHUB_OUTPUT"
+          elif [ "${{ github.ref_name }}" = "bugfix" ] || [ "${{ github.event_name }}" = "pull_request" ]; then
             echo "matrix={\"include\":[$mac]}" >> "$GITHUB_OUTPUT"
           else
             echo "matrix={\"include\":[$lin,$win,$mac]}" >> "$GITHUB_OUTPUT"
@@ -528,13 +543,17 @@ jobs:
           # the port: the app picks a free one and publishes it to api-port, which
           # we read. Same user => same %APPDATA%, so the de-elevated copy's file is
           # here.
-          $portFile = Join-Path $env:APPDATA "celerp\celerp-data\api-port"
-          $logDir   = Join-Path $env:APPDATA "celerp\celerp-data\logs"
+          $dataDir  = Join-Path $env:APPDATA "celerp\celerp-data"
+          $portFile = Join-Path $dataDir "api-port"
           Remove-Item $portFile -ErrorAction SilentlyContinue
-          Write-Host "smoke: launching $exe"
-          Start-Process -FilePath $exe
+          # Capture the launched process's own stdout/stderr (the de-elevation
+          # guard logs there) in addition to the app's file logs.
+          $boot = Join-Path $env:RUNNER_TEMP "boot.out"
+          $err  = Join-Path $env:RUNNER_TEMP "boot.err"
+          Write-Host "smoke: launching $exe (whoami: $(whoami))"
+          Start-Process -FilePath $exe -RedirectStandardOutput $boot -RedirectStandardError $err
           $deadline = (Get-Date).AddSeconds(150)
-          $port = $null; $ok = $false
+          $port = $null; $ok = $false; $tick = 0
           while ((Get-Date) -lt $deadline) {
             if (-not $port -and (Test-Path $portFile)) {
               $port = (Get-Content $portFile -Raw).Trim()
@@ -546,14 +565,20 @@ jobs:
                 if ($r.Content -match '"db"\s*:\s*"ok"') { $ok = $true; break }
               } catch { }
             }
-            Start-Sleep -Seconds 1
+            if (($tick % 15) -eq 0) {
+              $procs = @(Get-Process Celerp -ErrorAction SilentlyContinue).Count
+              Write-Host "smoke: t+${tick}s  Celerp procs=$procs  portFile=$(Test-Path $portFile)"
+            }
+            $tick++; Start-Sleep -Seconds 1
           }
           taskkill /IM Celerp.exe /F 2>$null | Out-Null
           if (-not $ok) {
             Write-Host "::error::boot smoke FAILED on Windows - /health/ready never returned db:ok (port=$port)"
-            Write-Host "----- app logs (tail) -----"
-            Get-ChildItem -Path $logDir -Filter "*.log" -ErrorAction SilentlyContinue |
-              ForEach-Object { Write-Host "== $($_.Name) =="; Get-Content $_.FullName -Tail 60 -ErrorAction SilentlyContinue }
+            Write-Host "----- launch stdout -----"; if (Test-Path $boot) { Get-Content $boot -Tail 60 }
+            Write-Host "----- launch stderr -----"; if (Test-Path $err)  { Get-Content $err  -Tail 60 }
+            Write-Host "----- data-dir logs (tail) -----"
+            Get-ChildItem -Path $dataDir -Recurse -Include "*.log","logfile" -ErrorAction SilentlyContinue |
+              ForEach-Object { Write-Host "== $($_.FullName) =="; Get-Content $_.FullName -Tail 60 -ErrorAction SilentlyContinue }
             exit 1
           }
           Write-Host "boot smoke OK on Windows (port $port)"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -538,22 +538,6 @@ jobs:
           $ErrorActionPreference = "Stop"
           Set-Location electron
           $exe = (Resolve-Path "dist/win-unpacked/Celerp.exe").Path
-          # --- DIAGNOSTIC: does `runas /trustlevel` run + actually drop admin here? ---
-          $probeOut = Join-Path $env:RUNNER_TEMP "deelev.txt"
-          $probeCmd = Join-Path $env:RUNNER_TEMP "probe.cmd"
-          Set-Content -Encoding Ascii $probeCmd "whoami /groups > `"$probeOut`" 2>&1"
-          Remove-Item $probeOut -ErrorAction SilentlyContinue
-          try {
-            $rp = Start-Process -FilePath "runas.exe" -ArgumentList "/trustlevel:0x20000",$probeCmd -PassThru -Wait -RedirectStandardError (Join-Path $env:RUNNER_TEMP "runas.err")
-            Write-Host "probe: runas exit=$($rp.ExitCode)"
-          } catch { Write-Host "probe: runas threw: $_" }
-          Get-Content (Join-Path $env:RUNNER_TEMP "runas.err") -ErrorAction SilentlyContinue | ForEach-Object { Write-Host "probe runas.err: $_" }
-          Start-Sleep 3
-          if (Test-Path $probeOut) {
-            Write-Host "probe: de-elevated token (Administrators state + integrity):"
-            Get-Content $probeOut | Select-String -Pattern "Administrators|Mandatory Label"
-          } else { Write-Host "probe: NO output -> runas /trustlevel did not launch the wrapper at all" }
-          Write-Host "--- end diagnostic ---"
           # The app self-de-elevates into a fresh process (Postgres can't run as
           # admin), which wouldn't inherit a port we set in env. So we don't pin
           # the port: the app picks a free one and publishes it to api-port, which

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -511,11 +511,12 @@ jobs:
           fi
           echo "boot smoke OK on $RUNNER_OS"
 
-      # Windows needs its own launch path: the runner is elevated and embedded
-      # Postgres refuses to run as a Windows administrator. We run the app at a
-      # limited (medium-integrity) token via a scheduled task, so Postgres starts
-      # exactly as it does for a normal per-user install.
-      - name: Boot smoke (Windows, de-elevated, require db:ok)
+      # Windows runs elevated on the GitHub runner and bundled Postgres refuses to
+      # run under an administrator token. The app self-de-elevates at startup
+      # (relaunches at a restricted token), so we launch it normally and just pass
+      # the port via machine env — the relaunched, restricted process inherits the
+      # machine environment (it would not inherit our process env).
+      - name: Boot smoke (Windows, require db:ok)
         if: runner.os == 'Windows'
         shell: pwsh
         run: |
@@ -523,17 +524,9 @@ jobs:
           Set-Location electron
           $port = Get-Random -Minimum 20000 -Maximum 60000
           $exe  = (Resolve-Path "dist/win-unpacked/Celerp.exe").Path
-          $log  = Join-Path $env:RUNNER_TEMP "smoke.log"
-          # The de-elevated task is a fresh process, so pass the port via machine
-          # env (new processes inherit it); cleaned up below.
           [Environment]::SetEnvironmentVariable("CELERP_API_PORT", "$port", "Machine")
-          $wrap = Join-Path $env:RUNNER_TEMP "smoke-run.cmd"
-          "@echo off`r`n`"$exe`" > `"$log`" 2>&1" | Set-Content -Encoding Ascii $wrap
-          Write-Host "smoke: launching $exe (de-elevated via scheduled task) on port $port"
-          $action    = New-ScheduledTaskAction -Execute $wrap
-          $principal = New-ScheduledTaskPrincipal -UserId "$env:USERNAME" -RunLevel Limited
-          Register-ScheduledTask -TaskName celerpsmoke -Action $action -Principal $principal -Force | Out-Null
-          Start-ScheduledTask -TaskName celerpsmoke
+          Write-Host "smoke: launching $exe on port $port"
+          Start-Process -FilePath $exe
           $deadline = (Get-Date).AddSeconds(120)
           $ok = $false
           while ((Get-Date) -lt $deadline) {
@@ -543,14 +536,13 @@ jobs:
             } catch { }
             Start-Sleep -Seconds 1
           }
-          schtasks /End /TN celerpsmoke 2>$null | Out-Null
           taskkill /IM Celerp.exe /F 2>$null | Out-Null
-          schtasks /Delete /TN celerpsmoke /F 2>$null | Out-Null
           [Environment]::SetEnvironmentVariable("CELERP_API_PORT", $null, "Machine")
           if (-not $ok) {
             Write-Host "::error::boot smoke FAILED on Windows - /health/ready never returned db:ok"
-            Write-Host "----- app log (tail) -----"
-            if (Test-Path $log) { Get-Content $log -Tail 200 }
+            Write-Host "----- postgres log (tail) -----"
+            Get-ChildItem -Path (Join-Path $env:APPDATA "celerp") -Recurse -Filter "*log*" -ErrorAction SilentlyContinue |
+              ForEach-Object { Write-Host "== $($_.FullName) =="; Get-Content $_.FullName -Tail 80 -ErrorAction SilentlyContinue }
             exit 1
           }
           Write-Host "boot smoke OK on Windows"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -522,30 +522,41 @@ jobs:
         run: |
           $ErrorActionPreference = "Stop"
           Set-Location electron
-          $port = Get-Random -Minimum 20000 -Maximum 60000
-          $exe  = (Resolve-Path "dist/win-unpacked/Celerp.exe").Path
-          [Environment]::SetEnvironmentVariable("CELERP_API_PORT", "$port", "Machine")
-          Write-Host "smoke: launching $exe on port $port"
+          $exe = (Resolve-Path "dist/win-unpacked/Celerp.exe").Path
+          # The app self-de-elevates into a fresh process (Postgres can't run as
+          # admin), which wouldn't inherit a port we set in env. So we don't pin
+          # the port: the app picks a free one and publishes it to api-port, which
+          # we read. Same user => same %APPDATA%, so the de-elevated copy's file is
+          # here.
+          $portFile = Join-Path $env:APPDATA "celerp\celerp-data\api-port"
+          $logDir   = Join-Path $env:APPDATA "celerp\celerp-data\logs"
+          Remove-Item $portFile -ErrorAction SilentlyContinue
+          Write-Host "smoke: launching $exe"
           Start-Process -FilePath $exe
-          $deadline = (Get-Date).AddSeconds(120)
-          $ok = $false
+          $deadline = (Get-Date).AddSeconds(150)
+          $port = $null; $ok = $false
           while ((Get-Date) -lt $deadline) {
-            try {
-              $r = Invoke-WebRequest -UseBasicParsing -TimeoutSec 3 -Uri "http://127.0.0.1:$port/health/ready"
-              if ($r.Content -match '"db"\s*:\s*"ok"') { $ok = $true; break }
-            } catch { }
+            if (-not $port -and (Test-Path $portFile)) {
+              $port = (Get-Content $portFile -Raw).Trim()
+              Write-Host "smoke: app published API port $port"
+            }
+            if ($port) {
+              try {
+                $r = Invoke-WebRequest -UseBasicParsing -TimeoutSec 3 -Uri "http://127.0.0.1:$port/health/ready"
+                if ($r.Content -match '"db"\s*:\s*"ok"') { $ok = $true; break }
+              } catch { }
+            }
             Start-Sleep -Seconds 1
           }
           taskkill /IM Celerp.exe /F 2>$null | Out-Null
-          [Environment]::SetEnvironmentVariable("CELERP_API_PORT", $null, "Machine")
           if (-not $ok) {
-            Write-Host "::error::boot smoke FAILED on Windows - /health/ready never returned db:ok"
-            Write-Host "----- postgres log (tail) -----"
-            Get-ChildItem -Path (Join-Path $env:APPDATA "celerp") -Recurse -Filter "*log*" -ErrorAction SilentlyContinue |
-              ForEach-Object { Write-Host "== $($_.FullName) =="; Get-Content $_.FullName -Tail 80 -ErrorAction SilentlyContinue }
+            Write-Host "::error::boot smoke FAILED on Windows - /health/ready never returned db:ok (port=$port)"
+            Write-Host "----- app logs (tail) -----"
+            Get-ChildItem -Path $logDir -Filter "*.log" -ErrorAction SilentlyContinue |
+              ForEach-Object { Write-Host "== $($_.Name) =="; Get-Content $_.FullName -Tail 60 -ErrorAction SilentlyContinue }
             exit 1
           }
-          Write-Host "boot smoke OK on Windows"
+          Write-Host "boot smoke OK on Windows (port $port)"
 
       - name: Verify YML artifact names
         if: "!startsWith(github.ref, 'refs/tags/v')"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -540,35 +540,30 @@ jobs:
           $exe = (Resolve-Path "dist/win-unpacked/Celerp.exe").Path
           $dataDir  = Join-Path $env:APPDATA "celerp\celerp-data"
           $portFile = Join-Path $dataDir "api-port"
-          # DIAGNOSTIC: launch the app DE-ELEVATED directly via a wrapper that
-          # captures all of its output (it self-de-elevates anyway; doing it here
-          # lets us see the de-elevated process's stdout/stderr, which a grandchild
-          # of runas otherwise loses). ELECTRON_ENABLE_LOGGING surfaces Chromium
-          # init errors. This tells us exactly why the de-elevated GUI app dies.
-          $deOut   = Join-Path $env:RUNNER_TEMP "deelev.out"
-          $wrapper = Join-Path $env:RUNNER_TEMP "deelev-run.cmd"
-          @('@echo off', 'set ELECTRON_ENABLE_LOGGING=1', "`"$exe`" > `"$deOut`" 2>&1") |
-            Set-Content -Encoding Ascii $wrapper
-          Remove-Item $portFile,$deOut -ErrorAction SilentlyContinue
-          Write-Host "smoke: launching de-elevated via runas (whoami: $(whoami))"
-          Start-Process -FilePath "runas.exe" -ArgumentList "/trustlevel:0x20000",$wrapper
-          $deadline = (Get-Date).AddSeconds(120)
+          Remove-Item $portFile -ErrorAction SilentlyContinue
+          # Launch normally; the app self-de-elevates on Windows (Postgres can't run
+          # as admin) and publishes its API port to a file we read. The deadline is
+          # generous because first-boot initdb on a fresh runner is slow.
+          Write-Host "smoke: launching $exe (whoami: $(whoami))"
+          Start-Process -FilePath $exe
+          $deadline = (Get-Date).AddSeconds(300)
           $port = $null; $ok = $false; $tick = 0
           while ((Get-Date) -lt $deadline) {
-            if (-not $port -and (Test-Path $portFile)) { $port = (Get-Content $portFile -Raw).Trim(); Write-Host "smoke: published port $port" }
+            if (-not $port -and (Test-Path $portFile)) { $port = (Get-Content $portFile -Raw).Trim(); Write-Host "smoke: app published API port $port" }
             if ($port) {
               try { $r = Invoke-WebRequest -UseBasicParsing -TimeoutSec 3 -Uri "http://127.0.0.1:$port/health/ready"; if ($r.Content -match '"db"\s*:\s*"ok"') { $ok = $true; break } } catch { }
             }
-            if (($tick % 15) -eq 0) { Write-Host "smoke: t+${tick}s Celerp procs=$(@(Get-Process Celerp -EA SilentlyContinue).Count) portFile=$(Test-Path $portFile)" }
+            if (($tick % 20) -eq 0) { Write-Host "smoke: t+${tick}s Celerp procs=$(@(Get-Process Celerp -EA SilentlyContinue).Count) portFile=$(Test-Path $portFile)" }
             $tick++; Start-Sleep -Seconds 1
           }
           taskkill /IM Celerp.exe /F 2>$null | Out-Null
-          Write-Host "===== de-elevated app output ($deOut) ====="
-          if (Test-Path $deOut) { Get-Content $deOut -Tail 150 } else { Write-Host "(no de-elevated output captured)" }
-          Write-Host "===== data-dir logs ====="
-          Get-ChildItem -Path $dataDir -Recurse -Include "*.log","logfile" -EA SilentlyContinue |
-            ForEach-Object { Write-Host "== $($_.FullName) =="; Get-Content $_.FullName -Tail 50 -EA SilentlyContinue }
-          if (-not $ok) { Write-Host "::error::boot smoke FAILED on Windows - db:ok not reached (port=$port)"; exit 1 }
+          if (-not $ok) {
+            Write-Host "::error::boot smoke FAILED on Windows - db:ok not reached (port=$port)"
+            Write-Host "===== data-dir logs ====="
+            Get-ChildItem -Path $dataDir -Recurse -Include "*.log","logfile" -EA SilentlyContinue |
+              ForEach-Object { Write-Host "== $($_.FullName) =="; Get-Content $_.FullName -Tail 60 -EA SilentlyContinue }
+            exit 1
+          }
           Write-Host "boot smoke OK on Windows (port $port)"
 
       - name: Verify YML artifact names

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -538,49 +538,37 @@ jobs:
           $ErrorActionPreference = "Stop"
           Set-Location electron
           $exe = (Resolve-Path "dist/win-unpacked/Celerp.exe").Path
-          # The app self-de-elevates into a fresh process (Postgres can't run as
-          # admin), which wouldn't inherit a port we set in env. So we don't pin
-          # the port: the app picks a free one and publishes it to api-port, which
-          # we read. Same user => same %APPDATA%, so the de-elevated copy's file is
-          # here.
           $dataDir  = Join-Path $env:APPDATA "celerp\celerp-data"
           $portFile = Join-Path $dataDir "api-port"
-          Remove-Item $portFile -ErrorAction SilentlyContinue
-          # Capture the launched process's own stdout/stderr (the de-elevation
-          # guard logs there) in addition to the app's file logs.
-          $boot = Join-Path $env:RUNNER_TEMP "boot.out"
-          $err  = Join-Path $env:RUNNER_TEMP "boot.err"
-          Write-Host "smoke: launching $exe (whoami: $(whoami))"
-          Start-Process -FilePath $exe -RedirectStandardOutput $boot -RedirectStandardError $err
-          $deadline = (Get-Date).AddSeconds(150)
+          # DIAGNOSTIC: launch the app DE-ELEVATED directly via a wrapper that
+          # captures all of its output (it self-de-elevates anyway; doing it here
+          # lets us see the de-elevated process's stdout/stderr, which a grandchild
+          # of runas otherwise loses). ELECTRON_ENABLE_LOGGING surfaces Chromium
+          # init errors. This tells us exactly why the de-elevated GUI app dies.
+          $deOut   = Join-Path $env:RUNNER_TEMP "deelev.out"
+          $wrapper = Join-Path $env:RUNNER_TEMP "deelev-run.cmd"
+          @('@echo off', 'set ELECTRON_ENABLE_LOGGING=1', "`"$exe`" > `"$deOut`" 2>&1") |
+            Set-Content -Encoding Ascii $wrapper
+          Remove-Item $portFile,$deOut -ErrorAction SilentlyContinue
+          Write-Host "smoke: launching de-elevated via runas (whoami: $(whoami))"
+          Start-Process -FilePath "runas.exe" -ArgumentList "/trustlevel:0x20000",$wrapper
+          $deadline = (Get-Date).AddSeconds(120)
           $port = $null; $ok = $false; $tick = 0
           while ((Get-Date) -lt $deadline) {
-            if (-not $port -and (Test-Path $portFile)) {
-              $port = (Get-Content $portFile -Raw).Trim()
-              Write-Host "smoke: app published API port $port"
-            }
+            if (-not $port -and (Test-Path $portFile)) { $port = (Get-Content $portFile -Raw).Trim(); Write-Host "smoke: published port $port" }
             if ($port) {
-              try {
-                $r = Invoke-WebRequest -UseBasicParsing -TimeoutSec 3 -Uri "http://127.0.0.1:$port/health/ready"
-                if ($r.Content -match '"db"\s*:\s*"ok"') { $ok = $true; break }
-              } catch { }
+              try { $r = Invoke-WebRequest -UseBasicParsing -TimeoutSec 3 -Uri "http://127.0.0.1:$port/health/ready"; if ($r.Content -match '"db"\s*:\s*"ok"') { $ok = $true; break } } catch { }
             }
-            if (($tick % 15) -eq 0) {
-              $procs = @(Get-Process Celerp -ErrorAction SilentlyContinue).Count
-              Write-Host "smoke: t+${tick}s  Celerp procs=$procs  portFile=$(Test-Path $portFile)"
-            }
+            if (($tick % 15) -eq 0) { Write-Host "smoke: t+${tick}s Celerp procs=$(@(Get-Process Celerp -EA SilentlyContinue).Count) portFile=$(Test-Path $portFile)" }
             $tick++; Start-Sleep -Seconds 1
           }
           taskkill /IM Celerp.exe /F 2>$null | Out-Null
-          if (-not $ok) {
-            Write-Host "::error::boot smoke FAILED on Windows - /health/ready never returned db:ok (port=$port)"
-            Write-Host "----- launch stdout -----"; if (Test-Path $boot) { Get-Content $boot -Tail 60 }
-            Write-Host "----- launch stderr -----"; if (Test-Path $err)  { Get-Content $err  -Tail 60 }
-            Write-Host "----- data-dir logs (tail) -----"
-            Get-ChildItem -Path $dataDir -Recurse -Include "*.log","logfile" -ErrorAction SilentlyContinue |
-              ForEach-Object { Write-Host "== $($_.FullName) =="; Get-Content $_.FullName -Tail 60 -ErrorAction SilentlyContinue }
-            exit 1
-          }
+          Write-Host "===== de-elevated app output ($deOut) ====="
+          if (Test-Path $deOut) { Get-Content $deOut -Tail 150 } else { Write-Host "(no de-elevated output captured)" }
+          Write-Host "===== data-dir logs ====="
+          Get-ChildItem -Path $dataDir -Recurse -Include "*.log","logfile" -EA SilentlyContinue |
+            ForEach-Object { Write-Host "== $($_.FullName) =="; Get-Content $_.FullName -Tail 50 -EA SilentlyContinue }
+          if (-not $ok) { Write-Host "::error::boot smoke FAILED on Windows - db:ok not reached (port=$port)"; exit 1 }
           Write-Host "boot smoke OK on Windows (port $port)"
 
       - name: Verify YML artifact names

--- a/electron/app-main.js
+++ b/electron/app-main.js
@@ -960,11 +960,14 @@ function isWindowsElevated() {
 if (isWindowsElevated()) {
   let relaunched = false;
   try {
-    childProcess
-      .spawn("runas", ["/trustlevel:0x20000", process.execPath], {
-        detached: true, stdio: "ignore", windowsHide: true,
-      })
-      .unref();
+    // Full path: Node's spawn/execFile does not resolve a bare "runas" (no shell)
+    // to runas.exe. Run it synchronously so a launch failure is caught here rather
+    // than lost as an async 'error' event. runas launches the de-elevated copy and
+    // returns; that copy keeps running after we exit.
+    const runas = path.join(process.env.SystemRoot || "C:\\Windows", "System32", "runas.exe");
+    childProcess.execFileSync(runas, ["/trustlevel:0x20000", process.execPath], {
+      stdio: "ignore", windowsHide: true,
+    });
     relaunched = true;
     console.log("[startup] elevated launch detected; relaunched de-elevated (Postgres cannot run as admin)");
   } catch (e) {

--- a/electron/app-main.js
+++ b/electron/app-main.js
@@ -960,29 +960,37 @@ function isWindowsElevated() {
 if (isWindowsElevated()) {
   let relaunched = false;
   try {
-    // runas /trustlevel cannot launch the GUI exe directly (it produces no running
-    // process), but launching it through a tiny cmd wrapper that `start`s the app
-    // works (verified: the de-elevated copy boots and Postgres runs). `start`
-    // detaches the app so the wrapper/runas return immediately - execFileSync then
-    // catches a launch failure without blocking. Full runas path: Node won't
-    // resolve a bare "runas" without a shell.
+    // Relaunch de-elevated through a one-shot Scheduled Task. Two facts force this
+    // shape:
+    //   1. Electron runs its child processes in a job object with KILL_ON_JOB_CLOSE,
+    //      so a plain (even detached) relaunch dies the instant this elevated copy
+    //      exits. A Scheduled Task action runs under the Task Scheduler service,
+    //      outside that job, so the relaunched copy survives.
+    //   2. SAFER (runas /trustlevel) is the only way to drop the admin token when
+    //      UAC is off (a /rl LIMITED task still runs elevated there); runas cannot
+    //      launch a GUI exe directly, so it goes through a tiny cmd wrapper that
+    //      foreground-launches the app.
     const os = require("os");
-    const runas = path.join(process.env.SystemRoot || "C:\\Windows", "System32", "runas.exe");
-    const wrapper = path.join(os.tmpdir(), "celerp-deelevate.cmd");
-    // Foreground launch (NOT `start`): cmd stays the de-elevated app's parent so
-    // it isn't orphaned and killed. Spawn detached so the whole runas->cmd->app
-    // tree keeps running after this elevated instance exits.
-    fs.writeFileSync(wrapper, `@echo off\r\n"${process.execPath}"\r\n`);
-    const child = childProcess.spawn(runas, ["/trustlevel:0x20000", wrapper], {
-      detached: true, stdio: "ignore", windowsHide: true,
-    });
-    child.on("error", (e) => console.error("[startup] de-elevation spawn error:", e));
-    child.unref();
+    const sysRoot = process.env.SystemRoot || "C:\\Windows";
+    const runas = path.join(sysRoot, "System32", "runas.exe");
+    const schtasks = path.join(sysRoot, "System32", "schtasks.exe");
+    const tmp = os.tmpdir();
+    const inner = path.join(tmp, "celerp-deelevate-run.cmd");
+    const outer = path.join(tmp, "celerp-deelevate-task.cmd");
+    fs.writeFileSync(inner, `@echo off\r\n"${process.execPath}"\r\n`);
+    fs.writeFileSync(outer, `@echo off\r\n"${runas}" /trustlevel:0x20000 "${inner}"\r\n`);
+    const task = "CelerpDeelevate";
+    const opts = { stdio: "ignore", windowsHide: true };
+    // Remove any stale one-shot from a previous elevated launch, then (re)create.
+    try { childProcess.execFileSync(schtasks, ["/delete", "/f", "/tn", task], opts); } catch {}
+    childProcess.execFileSync(schtasks,
+      ["/create", "/f", "/tn", task, "/sc", "ONCE", "/st", "00:00", "/tr", outer, "/rl", "LIMITED"], opts);
+    childProcess.execFileSync(schtasks, ["/run", "/tn", task], opts);
     relaunched = true;
     console.log("[startup] elevated launch detected; relaunched de-elevated (Postgres cannot run as admin)");
   } catch (e) {
-    // SAFER may be disabled by policy; fall through and boot (Postgres will then
-    // report the admin error, no worse than before).
+    // SAFER or the Task Scheduler may be disabled by policy; fall through and boot
+    // (Postgres will then report the admin error, no worse than before).
     console.error("[startup] de-elevation relaunch failed; continuing:", e);
   }
   if (relaunched) {

--- a/electron/app-main.js
+++ b/electron/app-main.js
@@ -1070,6 +1070,10 @@ app.whenReady().then(async () => {
     const _pinApi = parseInt(process.env.CELERP_API_PORT || "", 10);
     apiPort = Number.isInteger(_pinApi) && _pinApi > 0 ? _pinApi : await getFreePort();
     uiPort = await getFreePort();
+    // Publish the chosen API port so external tooling (the CI boot smoke,
+    // local debugging) can discover it without having to dictate it — needed when
+    // the app self-de-elevated into a fresh process that didn't inherit our env.
+    try { fs.writeFileSync(path.join(DATA_DIR, "api-port"), String(apiPort)); } catch { /* non-fatal */ }
     setLoadingStatus("Starting API server…");
     await startApi(dbConfig.url, cfg);
     setLoadingStatus("Starting UI server…");

--- a/electron/app-main.js
+++ b/electron/app-main.js
@@ -969,10 +969,15 @@ if (isWindowsElevated()) {
     const os = require("os");
     const runas = path.join(process.env.SystemRoot || "C:\\Windows", "System32", "runas.exe");
     const wrapper = path.join(os.tmpdir(), "celerp-deelevate.cmd");
-    fs.writeFileSync(wrapper, `@echo off\r\nstart "" "${process.execPath}"\r\n`);
-    childProcess.execFileSync(runas, ["/trustlevel:0x20000", wrapper], {
-      stdio: "ignore", windowsHide: true,
+    // Foreground launch (NOT `start`): cmd stays the de-elevated app's parent so
+    // it isn't orphaned and killed. Spawn detached so the whole runas->cmd->app
+    // tree keeps running after this elevated instance exits.
+    fs.writeFileSync(wrapper, `@echo off\r\n"${process.execPath}"\r\n`);
+    const child = childProcess.spawn(runas, ["/trustlevel:0x20000", wrapper], {
+      detached: true, stdio: "ignore", windowsHide: true,
     });
+    child.on("error", (e) => console.error("[startup] de-elevation spawn error:", e));
+    child.unref();
     relaunched = true;
     console.log("[startup] elevated launch detected; relaunched de-elevated (Postgres cannot run as admin)");
   } catch (e) {

--- a/electron/app-main.js
+++ b/electron/app-main.js
@@ -939,6 +939,45 @@ ipcMain.handle("uninstall-keep-data", () => _doUninstallKeepData());
 // uninstall-delete-data: delete all user data then quit.
 ipcMain.handle("uninstall-delete-data", () => _doUninstallDeleteData());
 
+// ── Windows: de-elevate before doing anything else ──────────────────────────
+// The bundled Postgres refuses to run under a Windows administrator token, so a
+// user who launches Celerp elevated (Run as administrator, or a machine with UAC
+// turned off) would crash on boot. If we hold an admin token, relaunch ourselves
+// at a restricted "normal user" token (SAFER /trustlevel) in the same desktop
+// session and exit; the relaunched copy boots normally. This must run BEFORE the
+// single-instance lock so the relaunched copy can acquire it.
+function isWindowsElevated() {
+  if (process.platform !== "win32") return false;
+  try {
+    // `net session` succeeds only with administrator rights; it throws otherwise.
+    childProcess.execSync("net session", { stdio: "ignore", windowsHide: true });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+if (isWindowsElevated()) {
+  let relaunched = false;
+  try {
+    childProcess
+      .spawn("runas", ["/trustlevel:0x20000", process.execPath], {
+        detached: true, stdio: "ignore", windowsHide: true,
+      })
+      .unref();
+    relaunched = true;
+    console.log("[startup] elevated launch detected; relaunched de-elevated (Postgres cannot run as admin)");
+  } catch (e) {
+    // SAFER may be disabled by policy; fall through and boot (Postgres will then
+    // report the admin error, no worse than before).
+    console.error("[startup] de-elevation relaunch failed; continuing:", e);
+  }
+  if (relaunched) {
+    app.quit();
+    return;  // stop the elevated instance (CommonJS module: top-level return is valid)
+  }
+}
+
 // ── Single-instance lock ─────────────────────────────────────────────────────
 
 const gotLock = app.requestSingleInstanceLock();

--- a/electron/app-main.js
+++ b/electron/app-main.js
@@ -960,12 +960,17 @@ function isWindowsElevated() {
 if (isWindowsElevated()) {
   let relaunched = false;
   try {
-    // Full path: Node's spawn/execFile does not resolve a bare "runas" (no shell)
-    // to runas.exe. Run it synchronously so a launch failure is caught here rather
-    // than lost as an async 'error' event. runas launches the de-elevated copy and
-    // returns; that copy keeps running after we exit.
+    // runas /trustlevel cannot launch the GUI exe directly (it produces no running
+    // process), but launching it through a tiny cmd wrapper that `start`s the app
+    // works (verified: the de-elevated copy boots and Postgres runs). `start`
+    // detaches the app so the wrapper/runas return immediately - execFileSync then
+    // catches a launch failure without blocking. Full runas path: Node won't
+    // resolve a bare "runas" without a shell.
+    const os = require("os");
     const runas = path.join(process.env.SystemRoot || "C:\\Windows", "System32", "runas.exe");
-    childProcess.execFileSync(runas, ["/trustlevel:0x20000", process.execPath], {
+    const wrapper = path.join(os.tmpdir(), "celerp-deelevate.cmd");
+    fs.writeFileSync(wrapper, `@echo off\r\nstart "" "${process.execPath}"\r\n`);
+    childProcess.execFileSync(runas, ["/trustlevel:0x20000", wrapper], {
       stdio: "ignore", windowsHide: true,
     });
     relaunched = true;


### PR DESCRIPTION
The pre-tag boot smoke (#191) launches the packaged app and requires a real DB-backed boot (`/health/ready` → `db:ok`). It only runs the full Linux+Windows matrix on develop/tag/PR-dispatch builds, so these surfaced now and would also hit the next release tag.

## Linux — Electron SUID sandbox (CI only)
The unpacked tree ships `chrome-sandbox` owned by the runner, but Electron's SUID helper must be **root:root mode 4755** (real AppImage/deb installs set this); otherwise the app aborts on launch. Fix: set owner/mode before launch in the smoke.

## Windows — app self-de-elevates so Postgres can start (real fix, not just CI)
Bundled Postgres **refuses to run under a Windows administrator token**. This isn't only a CI issue: any user who launches Celerp **elevated** (Run as administrator, or a machine with UAC off) crashed on boot. The CI runner happens to be elevated, which is how we caught it.

Fix (in the app): on Windows, if the process holds an admin token, **relaunch at a restricted "normal user" token** (`runas /trustlevel:0x20000`, SAFER) in the same desktop session and exit; the relaunched copy boots normally.
- Normal (non-elevated) launches — the overwhelming majority — are **unaffected** (no admin token → no relaunch).
- Real Run-as-administrator users now boot instead of crashing.
- The Windows boot smoke now reaches a real `db:ok`: the runner is elevated → the app self-de-elevates → Postgres starts. The smoke passes the port via machine env so the restricted relaunch inherits it.

`initdb` already self-de-elevates successfully on the same runner, which proves a restricted token works there — this just applies the same idea to the whole app.

## Verification
Linux + Mac builds already pass (Linux fix confirmed). A full-matrix dispatch verifies the Windows `db:ok` path on this branch.