### PR TITLE
Windows: reliable first-boot database init + real boot smoke (db:ok)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -468,14 +468,21 @@ jobs:
       # 200 {"db":"ok"} proves electron -> Python API -> embedded Postgres -> a query.
       # We poll (never sleep) and fail fast if the process dies (crash on launch).
       - name: Boot smoke (launch the packaged app, require db:ok)
+        if: runner.os != 'Windows'
         shell: bash
         run: |
           set -uo pipefail
           cd electron
-          if [ "$RUNNER_OS" = "Linux" ]; then sudo apt-get update -qq && sudo apt-get install -y -qq xvfb; fi
+          if [ "$RUNNER_OS" = "Linux" ]; then
+            sudo apt-get update -qq && sudo apt-get install -y -qq xvfb
+            # Electron's SUID sandbox helper must be owned by root with mode 4755;
+            # the unpacked tree ships it owned by the runner (real AppImage/deb
+            # installs set this), so fix it here or the sandbox aborts on launch.
+            sudo chown root:root dist/linux-unpacked/chrome-sandbox
+            sudo chmod 4755 dist/linux-unpacked/chrome-sandbox
+          fi
           case "$RUNNER_OS" in
             macOS)   APP_BIN="$(ls -d dist/mac*/Celerp.app | head -1)/Contents/MacOS/Celerp" ;;
-            Windows) APP_BIN="dist/win-unpacked/Celerp.exe" ;;
             Linux)   APP_BIN="$(find dist/linux-unpacked -maxdepth 1 -type f -executable ! -name 'chrome*' ! -name '*.so*' | head -1)" ;;
           esac
           echo "smoke: launching $APP_BIN"
@@ -503,6 +510,50 @@ jobs:
             exit 1
           fi
           echo "boot smoke OK on $RUNNER_OS"
+
+      # Windows needs its own launch path: the runner is elevated and embedded
+      # Postgres refuses to run as a Windows administrator. We run the app at a
+      # limited (medium-integrity) token via a scheduled task, so Postgres starts
+      # exactly as it does for a normal per-user install.
+      - name: Boot smoke (Windows, de-elevated, require db:ok)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          Set-Location electron
+          $port = Get-Random -Minimum 20000 -Maximum 60000
+          $exe  = (Resolve-Path "dist/win-unpacked/Celerp.exe").Path
+          $log  = Join-Path $env:RUNNER_TEMP "smoke.log"
+          # The de-elevated task is a fresh process, so pass the port via machine
+          # env (new processes inherit it); cleaned up below.
+          [Environment]::SetEnvironmentVariable("CELERP_API_PORT", "$port", "Machine")
+          $wrap = Join-Path $env:RUNNER_TEMP "smoke-run.cmd"
+          "@echo off`r`n`"$exe`" > `"$log`" 2>&1" | Set-Content -Encoding Ascii $wrap
+          Write-Host "smoke: launching $exe (de-elevated via scheduled task) on port $port"
+          $action    = New-ScheduledTaskAction -Execute $wrap
+          $principal = New-ScheduledTaskPrincipal -UserId "$env:USERNAME" -RunLevel Limited
+          Register-ScheduledTask -TaskName celerpsmoke -Action $action -Principal $principal -Force | Out-Null
+          Start-ScheduledTask -TaskName celerpsmoke
+          $deadline = (Get-Date).AddSeconds(120)
+          $ok = $false
+          while ((Get-Date) -lt $deadline) {
+            try {
+              $r = Invoke-WebRequest -UseBasicParsing -TimeoutSec 3 -Uri "http://127.0.0.1:$port/health/ready"
+              if ($r.Content -match '"db"\s*:\s*"ok"') { $ok = $true; break }
+            } catch { }
+            Start-Sleep -Seconds 1
+          }
+          schtasks /End /TN celerpsmoke 2>$null | Out-Null
+          taskkill /IM Celerp.exe /F 2>$null | Out-Null
+          schtasks /Delete /TN celerpsmoke /F 2>$null | Out-Null
+          [Environment]::SetEnvironmentVariable("CELERP_API_PORT", $null, "Machine")
+          if (-not $ok) {
+            Write-Host "::error::boot smoke FAILED on Windows - /health/ready never returned db:ok"
+            Write-Host "----- app log (tail) -----"
+            if (Test-Path $log) { Get-Content $log -Tail 200 }
+            exit 1
+          }
+          Write-Host "boot smoke OK on Windows"
 
       - name: Verify YML artifact names
         if: "!startsWith(github.ref, 'refs/tags/v')"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -535,60 +535,99 @@ jobs:
         if: runner.os == 'Windows'
         shell: pwsh
         run: |
-          $ErrorActionPreference = "Continue"
+          $ErrorActionPreference = "Stop"
           Set-Location electron
-          $exe = (Resolve-Path "dist/win-unpacked/Celerp.exe").Path
-          $dataDir  = Join-Path $env:APPDATA "celerp\celerp-data"
-          $portFile = Join-Path $dataDir "api-port"
-          Remove-Item $portFile -ErrorAction SilentlyContinue
-          # --- DIAGNOSTIC: which de-elevation primitive actually works on this runner? ---
-          # The runner is full-admin + UAC off; Postgres refuses an admin token. Earlier
-          # runas /trustlevel attempts launched nothing (procs=0, no logs). Settle the
-          # mechanism in one run: report the token, the seclogon service, whether
-          # runas/trustlevel launches a wrapper at all, and whether a freshly-created
-          # standard user (no admin token) can be launched via -Credential.
-          Write-Host "=== runner token ==="; whoami /groups | Select-String "S-1-5-32-544|Mandatory Label"
-          Write-Host "=== seclogon service ==="; (Get-Service seclogon | Select-Object Name,Status,StartType | Out-String).Trim()
-          $tmp = $env:RUNNER_TEMP
-          # Probe 1: runas /trustlevel:0x20000 -> does the wrapper even run, and at what token?
-          $m1 = Join-Path $tmp "m1.txt"; Remove-Item $m1 -EA SilentlyContinue
-          $w1 = Join-Path $tmp "w1.cmd"; Set-Content -Encoding Ascii $w1 "whoami /groups > `"$m1`" 2>&1"
-          Start-Process -FilePath "$env:SystemRoot\System32\runas.exe" -ArgumentList '/trustlevel:0x20000', "`"$w1`""
-          Start-Sleep 6
-          Write-Host "=== probe1: runas /trustlevel ==="
-          if (Test-Path $m1) { (Get-Content $m1 | Select-String "S-1-5-32-544|Mandatory Label" | Out-String).Trim() } else { Write-Host "runas/trustlevel: NO marker -> did not launch the wrapper" }
-          # Probe 2: standard (non-admin) user launched via -Credential (uses seclogon).
-          $u = "celerpci"; $pw = "Celerp!" + ([guid]::NewGuid().ToString("N").Substring(0,12))
-          cmd /c "net user $u $pw /add" | Out-Null
-          $sec = ConvertTo-SecureString $pw -AsPlainText -Force
-          $cred = New-Object System.Management.Automation.PSCredential($u, $sec)
-          $m2 = "C:\Users\Public\celerp-m2.txt"; Remove-Item $m2 -EA SilentlyContinue
-          $w2 = Join-Path $tmp "w2.cmd"; Set-Content -Encoding Ascii $w2 "whoami /groups > `"$m2`" 2>&1"
-          try { Start-Process -FilePath "cmd.exe" -ArgumentList "/c","`"$w2`"" -Credential $cred -WorkingDirectory "C:\Users\Public"; Write-Host "probe2: launched cmd as $u" } catch { Write-Host "probe2 threw: $_" }
-          Start-Sleep 6
-          Write-Host "=== probe2: standard-user via -Credential ==="
-          if (Test-Path $m2) { (Get-Content $m2 | Select-String "S-1-5-32-544|Mandatory Label" | Out-String).Trim() } else { Write-Host "standard-user: NO marker -> launch failed" }
-          Write-Host "--- end diagnostic; proceeding with the original runas attempt for log continuity ---"
-          $wrapper = Join-Path $env:TEMP "celerp-smoke.cmd"
-          Set-Content -Path $wrapper -Value "@echo off`r`n`"$exe`"" -Encoding ascii
-          Write-Host "smoke: launching de-elevated via runas (whoami: $(whoami))"
-          Start-Process -FilePath "$env:SystemRoot\System32\runas.exe" -ArgumentList '/trustlevel:0x20000', "`"$wrapper`""
-          $deadline = (Get-Date).AddSeconds(45)
-          $port = $null; $ok = $false; $tick = 0
-          while ((Get-Date) -lt $deadline) {
-            if (-not $port -and (Test-Path $portFile)) { $port = (Get-Content $portFile -Raw).Trim(); Write-Host "smoke: app published API port $port" }
-            if ($port) {
-              try { $r = Invoke-WebRequest -UseBasicParsing -TimeoutSec 3 -Uri "http://127.0.0.1:$port/health/ready"; if ($r.Content -match '"db"\s*:\s*"ok"') { $ok = $true; break } } catch { }
+          # The GitHub runner is full-admin with UAC off, where the bundled Postgres
+          # refuses to start (it rejects an administrator token). Real users run
+          # non-admin, so reproduce that: launch the packaged app as a freshly-created
+          # standard user. A SAFER/runas restricted token would crash Electron; a real
+          # standard account gives a clean medium token where both Electron and
+          # Postgres run. We grant that user access to the runner's window station and
+          # desktop so Electron's main process can initialise, then wait for a real
+          # db:ok from the app's own boot -> migrations -> API path.
+          $u  = "celerpci"
+          $pw = "Ci-" + [guid]::NewGuid().ToString("N").Substring(0,16) + "!Aa9"
+          $port = 8765   # pin the API port so we can poll a known address
+
+          # seclogon backs Start-Process -Credential and is Stopped/Manual on the runner.
+          Set-Service seclogon -StartupType Manual
+          Start-Service seclogon
+
+          cmd /c "net user $u `"$pw`" /add" | Out-Null
+          if ($LASTEXITCODE -ne 0) { throw "net user /add failed (exit $LASTEXITCODE)" }
+          $sec  = ConvertTo-SecureString $pw -AsPlainText -Force
+          $cred = New-Object System.Management.Automation.PSCredential("$env:COMPUTERNAME\$u", $sec)
+
+          # Grant the standard user access to this process's window station + desktop
+          # (Electron's main process needs a desktop even before any window). The
+          # -Credential child inherits the caller's window station/desktop, so granting
+          # on the handles we hold is what lets the launched app attach to them.
+          Add-Type @'
+          using System;
+          using System.Runtime.InteropServices;
+          using System.Security.AccessControl;
+          using System.Security.Principal;
+          public class WinStaAccess {
+            [DllImport("user32.dll", SetLastError=true)] static extern IntPtr GetProcessWindowStation();
+            [DllImport("user32.dll", SetLastError=true)] static extern IntPtr GetThreadDesktop(uint threadId);
+            [DllImport("kernel32.dll")] static extern uint GetCurrentThreadId();
+            [DllImport("user32.dll", SetLastError=true)] static extern bool GetUserObjectSecurity(IntPtr h, ref int si, byte[] sd, int len, ref int needed);
+            [DllImport("user32.dll", SetLastError=true)] static extern bool SetUserObjectSecurity(IntPtr h, ref int si, byte[] sd);
+            const int DACL = 4;
+            static byte[] Get(IntPtr h) {
+              int si = DACL; int need = 0; GetUserObjectSecurity(h, ref si, null, 0, ref need);
+              byte[] b = new byte[need];
+              if (!GetUserObjectSecurity(h, ref si, b, need, ref need)) throw new Exception("Get failed " + Marshal.GetLastWin32Error());
+              return b;
             }
-            if (($tick % 20) -eq 0) { Write-Host "smoke: t+${tick}s Celerp procs=$(@(Get-Process Celerp -EA SilentlyContinue).Count) portFile=$(Test-Path $portFile)" }
+            static void Set(IntPtr h, byte[] b) { int si = DACL; if (!SetUserObjectSecurity(h, ref si, b)) throw new Exception("Set failed " + Marshal.GetLastWin32Error()); }
+            static void Add(IntPtr h, SecurityIdentifier sid, int mask, bool inheritOnlyGenericAll) {
+              var sd = new RawSecurityDescriptor(Get(h), 0);
+              var dacl = sd.DiscretionaryAcl == null ? new RawAcl(2, 1) : sd.DiscretionaryAcl;
+              int i = dacl.Count;
+              if (inheritOnlyGenericAll)
+                dacl.InsertAce(i++, new CommonAce(AceFlags.ObjectInherit|AceFlags.ContainerInherit|AceFlags.InheritOnly, AceQualifier.AccessAllowed, unchecked((int)0x10000000), sid, false, null));
+              dacl.InsertAce(i++, new CommonAce(AceFlags.None, AceQualifier.AccessAllowed, mask, sid, false, null));
+              sd.DiscretionaryAcl = dacl;
+              byte[] outb = new byte[sd.BinaryLength]; sd.GetBinaryForm(outb, 0); Set(h, outb);
+            }
+            public static void Grant(string account) {
+              var sid = (SecurityIdentifier)(new NTAccount(account)).Translate(typeof(SecurityIdentifier));
+              Add(GetProcessWindowStation(), sid, 0x37F, true);            // WINSTA_ALL_ACCESS + inherit-only GENERIC_ALL
+              Add(GetThreadDesktop(GetCurrentThreadId()), sid, 0x1FF, false); // DESKTOP_ALL
+            }
+          }
+          '@
+          [WinStaAccess]::Grant("$env:COMPUTERNAME\$u")
+
+          # Stage the app where the standard user can read+execute it (the runner
+          # workspace may be ACL'd to the admin only).
+          $app = "C:\Users\Public\celerp-app"
+          if (Test-Path $app) { Remove-Item $app -Recurse -Force }
+          Copy-Item "dist/win-unpacked" $app -Recurse
+          icacls $app /grant "Users:(OI)(CI)RX" /T | Out-Null
+          $exe = Join-Path $app "Celerp.exe"
+
+          $userData = "C:\Users\$u\AppData\Roaming\celerp\celerp-data"
+          [Environment]::SetEnvironmentVariable("CELERP_API_PORT", "$port", "Machine")
+
+          Write-Host "smoke: launching $exe as standard user $u (pinned API port $port)"
+          Start-Process -FilePath $exe -Credential $cred -LoadUserProfile -WorkingDirectory $app
+
+          $deadline = (Get-Date).AddSeconds(300)
+          $ok = $false; $tick = 0
+          while ((Get-Date) -lt $deadline) {
+            try { $r = Invoke-WebRequest -UseBasicParsing -TimeoutSec 3 -Uri "http://127.0.0.1:$port/health/ready"; if ($r.Content -match '"db"\s*:\s*"ok"') { $ok = $true; break } } catch { }
+            if (($tick % 20) -eq 0) { Write-Host "smoke: t+${tick}s Celerp procs=$(@(Get-Process Celerp -EA SilentlyContinue).Count)" }
             $tick++; Start-Sleep -Seconds 1
           }
           taskkill /IM Celerp.exe /F 2>$null | Out-Null
+          [Environment]::SetEnvironmentVariable("CELERP_API_PORT", $null, "Machine")
           if (-not $ok) {
-            Write-Host "::error::boot smoke FAILED on Windows - db:ok not reached (port=$port)"
+            Write-Host "::error::boot smoke FAILED on Windows - db:ok not reached"
             Write-Host "===== data-dir logs ====="
-            Get-ChildItem -Path $dataDir -Recurse -Include "*.log","logfile" -EA SilentlyContinue |
-              ForEach-Object { Write-Host "== $($_.FullName) =="; Get-Content $_.FullName -Tail 60 -EA SilentlyContinue }
+            Get-ChildItem -Path $userData -Recurse -Include "*.log","logfile" -EA SilentlyContinue |
+              ForEach-Object { Write-Host "== $($_.FullName) =="; Get-Content $_.FullName -Tail 80 -EA SilentlyContinue }
             exit 1
           }
           Write-Host "boot smoke OK on Windows (port $port)"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -612,20 +612,26 @@ jobs:
           # early boot wedges even before the app writes its own data-dir logs. The
           # api-port file is discovered by searching the whole user profile (its
           # exact path depends on Electron's resolved app name).
+          # Launch through a cmd wrapper that captures Electron's stdout/stderr. Pin
+          # the data dir with Electron's built-in --user-data-dir: a credentialed
+          # launch has no fully-established user profile, so Electron can't resolve
+          # %APPDATA% and app.getPath("userData") throws. A world-writable override
+          # path sidesteps that (real users have working profiles).
           $boot = "C:\Users\Public\celerp-boot.out"
           $run  = "C:\Users\Public\celerp-run.cmd"
+          $udd  = "C:\Users\Public\celerp-udd"
           Remove-Item $boot -EA SilentlyContinue
-          Set-Content -Encoding Ascii $run "@echo off`r`nset ELECTRON_ENABLE_LOGGING=1`r`n`"$exe`" > `"$boot`" 2>&1"
-          $userHome = "C:\Users\$u"
+          Remove-Item $udd -Recurse -Force -EA SilentlyContinue
+          Set-Content -Encoding Ascii $run "@echo off`r`nset ELECTRON_ENABLE_LOGGING=1`r`n`"$exe`" --user-data-dir=`"$udd`" > `"$boot`" 2>&1"
 
-          Write-Host "smoke: launching $exe as standard user $u (output captured to $boot)"
+          Write-Host "smoke: launching $exe as standard user $u (data dir $udd, output $boot)"
           Start-Process -FilePath "cmd.exe" -ArgumentList "/c", "`"$run`"" -Credential $cred -LoadUserProfile -WorkingDirectory $app
 
           $deadline = (Get-Date).AddSeconds(240)
           $ok = $false; $port = $null; $tick = 0
           while ((Get-Date) -lt $deadline) {
             if (-not $port) {
-              $pf = Get-ChildItem -Path $userHome -Recurse -Filter "api-port" -EA SilentlyContinue | Select-Object -First 1
+              $pf = Get-ChildItem -Path $udd -Recurse -Filter "api-port" -EA SilentlyContinue | Select-Object -First 1
               if ($pf) { $port = (Get-Content $pf.FullName -Raw).Trim(); Write-Host "smoke: app published API port $port ($($pf.FullName))" }
             }
             if ($port) {
@@ -637,8 +643,8 @@ jobs:
           taskkill /IM Celerp.exe /F 2>$null | Out-Null
           Write-Host "===== Electron stdout/stderr ($boot) ====="
           if (Test-Path $boot) { Get-Content $boot -Tail 200 } else { Write-Host "(no captured output)" }
-          Write-Host "===== logs under $userHome ====="
-          Get-ChildItem -Path $userHome -Recurse -Include "*.log","logfile" -EA SilentlyContinue |
+          Write-Host "===== logs under $udd ====="
+          Get-ChildItem -Path $udd -Recurse -Include "*.log","logfile" -EA SilentlyContinue |
             ForEach-Object { Write-Host "== $($_.FullName) =="; Get-Content $_.FullName -Tail 80 -EA SilentlyContinue }
           if (-not $ok) { Write-Host "::error::boot smoke FAILED on Windows - db:ok not reached (port=$port)"; exit 1 }
           Write-Host "boot smoke OK on Windows (port $port)"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -607,52 +607,34 @@ jobs:
           icacls $app /grant "Users:(OI)(CI)RX" /T | Out-Null
           $exe = Join-Path $app "Celerp.exe"
 
-          # Launch through a cmd wrapper that captures Electron's own stdout/stderr
-          # (ELECTRON_ENABLE_LOGGING) to a world-readable file, so we can see where
-          # early boot wedges even before the app writes its own data-dir logs. The
-          # api-port file is discovered by searching the whole user profile (its
-          # exact path depends on Electron's resolved app name).
-          # Launch through a cmd wrapper that captures Electron's stdout/stderr. Pin
-          # the data dir with Electron's built-in --user-data-dir: a credentialed
-          # launch has no fully-established user profile, so Electron can't resolve
-          # %APPDATA% and app.getPath("userData") throws. A world-writable override
-          # path sidesteps that (real users have working profiles).
-          $boot = "C:\Users\Public\celerp-boot.out"
-          $run  = "C:\Users\Public\celerp-run.cmd"
-          $udd  = "C:\Users\Public\celerp-udd"
-          Remove-Item $boot -EA SilentlyContinue
-          Remove-Item $udd -Recurse -Force -EA SilentlyContinue
-          Set-Content -Encoding Ascii $run "@echo off`r`nset ELECTRON_ENABLE_LOGGING=1`r`n`"$exe`" --user-data-dir=`"$udd`" > `"$boot`" 2>&1"
-
-          Write-Host "smoke: launching $exe as standard user $u (data dir $udd, output $boot)"
-          Start-Process -FilePath "cmd.exe" -ArgumentList "/c", "`"$run`"" -Credential $cred -LoadUserProfile -WorkingDirectory $app
-
-          $deadline = (Get-Date).AddSeconds(240)
-          $ok = $false; $port = $null; $tick = 0
+          # --- DIAGNOSTIC: does the bundled initdb run to completion as a standard
+          # user? The app wedges in startPostgres -> pgInstance.initialise() (initdb),
+          # which never resolves and never errors. Run the bundled initdb directly,
+          # capture its output + exit code, with a timeout so a hang is visible.
+          $initdb = (Get-ChildItem $app -Recurse -Filter "initdb.exe" -EA SilentlyContinue | Select-Object -First 1)
+          if (-not $initdb) { throw "initdb.exe not found under $app" }
+          Write-Host "initdb: $($initdb.FullName)"
+          $pgtest = "C:\Users\Public\pgtest"
+          $idout  = "C:\Users\Public\initdb.out"
+          $idw    = "C:\Users\Public\initdb.cmd"
+          Remove-Item $pgtest -Recurse -Force -EA SilentlyContinue
+          Remove-Item $idout -EA SilentlyContinue
+          Set-Content -Encoding Ascii $idw "@echo off`r`nset ELECTRON_ENABLE_LOGGING=1`r`n`"$($initdb.FullName)`" -D `"$pgtest`" -U celerp -A trust --encoding=UTF8 --no-locale --no-sync > `"$idout`" 2>&1`r`necho EXITCODE=%ERRORLEVEL%>> `"$idout`""
+          Write-Host "smoke: running bundled initdb directly as standard user $u"
+          Start-Process -FilePath "cmd.exe" -ArgumentList "/c", "`"$idw`"" -Credential $cred -LoadUserProfile -WorkingDirectory $app
+          $deadline = (Get-Date).AddSeconds(120); $done = $false
           while ((Get-Date) -lt $deadline) {
-            if (-not $port) {
-              $pf = Get-ChildItem -Path $udd -Recurse -Filter "api-port" -EA SilentlyContinue | Select-Object -First 1
-              if ($pf) { $port = (Get-Content $pf.FullName -Raw).Trim(); Write-Host "smoke: app published API port $port ($($pf.FullName))" }
-            }
-            if ($port) {
-              try { $r = Invoke-WebRequest -UseBasicParsing -TimeoutSec 3 -Uri "http://127.0.0.1:$port/health/ready"; if ($r.Content -match '"db"\s*:\s*"ok"') { $ok = $true; break } } catch { }
-            }
-            if (($tick % 10) -eq 0) { Write-Host "smoke: t+$($tick*2)s Celerp procs=$(@(Get-Process Celerp -EA SilentlyContinue).Count) portFound=$([bool]$port)" }
-            $tick++; Start-Sleep -Seconds 2
+            if ((Test-Path $idout) -and (Select-String -Path $idout -Pattern "EXITCODE=" -Quiet -EA SilentlyContinue)) { $done = $true; break }
+            Start-Sleep -Seconds 2
           }
-          taskkill /IM Celerp.exe /F 2>$null | Out-Null
-          Write-Host "===== Electron stdout/stderr ($boot) ====="
-          if (Test-Path $boot) { Get-Content $boot -Tail 200 } else { Write-Host "(no captured output)" }
-          Write-Host "===== file tree under $udd (Chromium caches elided) ====="
-          Get-ChildItem -Path $udd -Recurse -EA SilentlyContinue |
-            Where-Object { $_.FullName -notmatch '(?i)\\(Cache|GPUCache|Code Cache|DawnCache|blob_storage|Local Storage|Session Storage|Network|Crashpad)\\' } |
-            ForEach-Object { Write-Host $_.FullName }
-          Write-Host "===== boot-relevant files (logs / postgres state) ====="
-          Get-ChildItem -Path $udd -Recurse -EA SilentlyContinue |
-            Where-Object { -not $_.PSIsContainer -and $_.Name -match '(?i)\.log$|logfile|PG_VERSION|postmaster|\.pid$|migrat' } |
-            ForEach-Object { Write-Host "== $($_.FullName) =="; Get-Content $_.FullName -Tail 80 -EA SilentlyContinue }
-          if (-not $ok) { Write-Host "::error::boot smoke FAILED on Windows - db:ok not reached (port=$port)"; exit 1 }
-          Write-Host "boot smoke OK on Windows (port $port)"
+          taskkill /IM initdb.exe /F 2>$null | Out-Null
+          taskkill /IM postgres.exe /F 2>$null | Out-Null
+          Write-Host "===== initdb output (completed=$done) ====="
+          if (Test-Path $idout) { Get-Content $idout } else { Write-Host "(no output captured)" }
+          Write-Host "===== pgtest dir ====="
+          Get-ChildItem -Path $pgtest -EA SilentlyContinue | ForEach-Object { Write-Host $_.Name }
+          Write-Host "::error::initdb isolation diagnostic (intentionally non-final)"
+          exit 1
 
       - name: Verify YML artifact names
         if: "!startsWith(github.ref, 'refs/tags/v')"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -547,7 +547,6 @@ jobs:
           # db:ok from the app's own boot -> migrations -> API path.
           $u  = "celerpci"
           $pw = "Ci-" + [guid]::NewGuid().ToString("N").Substring(0,16) + "!Aa9"
-          $port = 8765   # pin the API port so we can poll a known address
 
           # seclogon backs Start-Process -Credential and is Stopped/Manual on the runner.
           Set-Service seclogon -StartupType Manual
@@ -608,25 +607,33 @@ jobs:
           icacls $app /grant "Users:(OI)(CI)RX" /T | Out-Null
           $exe = Join-Path $app "Celerp.exe"
 
-          $userData = "C:\Users\$u\AppData\Roaming\celerp\celerp-data"
-          [Environment]::SetEnvironmentVariable("CELERP_API_PORT", "$port", "Machine")
+          # The app's data dir lives under the standard user's profile; its exact
+          # name depends on Electron's app name, so discover the API port from the
+          # api-port file the app publishes rather than guessing the path or relying
+          # on env inheritance through the credentialed launch.
+          $roaming = "C:\Users\$u\AppData\Roaming"
 
-          Write-Host "smoke: launching $exe as standard user $u (pinned API port $port)"
+          Write-Host "smoke: launching $exe as standard user $u"
           Start-Process -FilePath $exe -Credential $cred -LoadUserProfile -WorkingDirectory $app
 
           $deadline = (Get-Date).AddSeconds(300)
-          $ok = $false; $tick = 0
+          $ok = $false; $port = $null; $tick = 0
           while ((Get-Date) -lt $deadline) {
-            try { $r = Invoke-WebRequest -UseBasicParsing -TimeoutSec 3 -Uri "http://127.0.0.1:$port/health/ready"; if ($r.Content -match '"db"\s*:\s*"ok"') { $ok = $true; break } } catch { }
-            if (($tick % 20) -eq 0) { Write-Host "smoke: t+${tick}s Celerp procs=$(@(Get-Process Celerp -EA SilentlyContinue).Count)" }
-            $tick++; Start-Sleep -Seconds 1
+            if (-not $port) {
+              $pf = Get-ChildItem -Path $roaming -Recurse -Filter "api-port" -EA SilentlyContinue | Select-Object -First 1
+              if ($pf) { $port = (Get-Content $pf.FullName -Raw).Trim(); Write-Host "smoke: app published API port $port ($($pf.FullName))" }
+            }
+            if ($port) {
+              try { $r = Invoke-WebRequest -UseBasicParsing -TimeoutSec 3 -Uri "http://127.0.0.1:$port/health/ready"; if ($r.Content -match '"db"\s*:\s*"ok"') { $ok = $true; break } } catch { }
+            }
+            if (($tick % 10) -eq 0) { Write-Host "smoke: t+$($tick*2)s Celerp procs=$(@(Get-Process Celerp -EA SilentlyContinue).Count) portFound=$([bool]$port)" }
+            $tick++; Start-Sleep -Seconds 2
           }
           taskkill /IM Celerp.exe /F 2>$null | Out-Null
-          [Environment]::SetEnvironmentVariable("CELERP_API_PORT", $null, "Machine")
           if (-not $ok) {
-            Write-Host "::error::boot smoke FAILED on Windows - db:ok not reached"
-            Write-Host "===== data-dir logs ====="
-            Get-ChildItem -Path $userData -Recurse -Include "*.log","logfile" -EA SilentlyContinue |
+            Write-Host "::error::boot smoke FAILED on Windows - db:ok not reached (port=$port)"
+            Write-Host "===== logs under $roaming ====="
+            Get-ChildItem -Path $roaming -Recurse -Include "*.log","logfile" -EA SilentlyContinue |
               ForEach-Object { Write-Host "== $($_.FullName) =="; Get-Content $_.FullName -Tail 80 -EA SilentlyContinue }
             exit 1
           }

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -538,6 +538,22 @@ jobs:
           $ErrorActionPreference = "Stop"
           Set-Location electron
           $exe = (Resolve-Path "dist/win-unpacked/Celerp.exe").Path
+          # --- DIAGNOSTIC: does `runas /trustlevel` run + actually drop admin here? ---
+          $probeOut = Join-Path $env:RUNNER_TEMP "deelev.txt"
+          $probeCmd = Join-Path $env:RUNNER_TEMP "probe.cmd"
+          Set-Content -Encoding Ascii $probeCmd "whoami /groups > `"$probeOut`" 2>&1"
+          Remove-Item $probeOut -ErrorAction SilentlyContinue
+          try {
+            $rp = Start-Process -FilePath "runas.exe" -ArgumentList "/trustlevel:0x20000",$probeCmd -PassThru -Wait -RedirectStandardError (Join-Path $env:RUNNER_TEMP "runas.err")
+            Write-Host "probe: runas exit=$($rp.ExitCode)"
+          } catch { Write-Host "probe: runas threw: $_" }
+          Get-Content (Join-Path $env:RUNNER_TEMP "runas.err") -ErrorAction SilentlyContinue | ForEach-Object { Write-Host "probe runas.err: $_" }
+          Start-Sleep 3
+          if (Test-Path $probeOut) {
+            Write-Host "probe: de-elevated token (Administrators state + integrity):"
+            Get-Content $probeOut | Select-String -Pattern "Administrators|Mandatory Label"
+          } else { Write-Host "probe: NO output -> runas /trustlevel did not launch the wrapper at all" }
+          Write-Host "--- end diagnostic ---"
           # The app self-de-elevates into a fresh process (Postgres can't run as
           # admin), which wouldn't inherit a port we set in env. So we don't pin
           # the port: the app picks a free one and publishes it to api-port, which

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,12 @@ on:
   pull_request:
     branches: ["main"]   # mac-only unsigned build + boot smoke (pre-tag gate)
   workflow_dispatch:
+    inputs:
+      platforms:
+        description: "Platforms to build on this manual run"
+        type: choice
+        default: all
+        options: [all, windows, linux, mac]
 
 permissions:
   contents: write
@@ -91,7 +97,16 @@ jobs:
           mac='{"os":"macos-latest","build_cmd":"pnpm run build:mac","platform_flag":"--mac","standalone_dir":"mac-arm64","pbs_triple":"aarch64-apple-darwin"}'
           win='{"os":"windows-latest","build_cmd":"pnpm run build:win","platform_flag":"--win","standalone_dir":"win-x64","pbs_triple":"x86_64-pc-windows-msvc"}'
           lin='{"os":"ubuntu-latest","build_cmd":"pnpm run build:linux","platform_flag":"--linux","standalone_dir":"linux-x64","pbs_triple":"x86_64-unknown-linux-gnu"}'
-          if [ "${{ github.ref_name }}" = "bugfix" ] || [ "${{ github.event_name }}" = "pull_request" ]; then
+          sel="${{ github.event.inputs.platforms }}"
+          if [ -n "$sel" ] && [ "$sel" != "all" ]; then
+            case "$sel" in
+              windows) inc="$win" ;;
+              linux)   inc="$lin" ;;
+              mac)     inc="$mac" ;;
+              *)       inc="$lin,$win,$mac" ;;
+            esac
+            echo "matrix={\"include\":[$inc]}" >> "$GITHUB_OUTPUT"
+          elif [ "${{ github.ref_name }}" = "bugfix" ] || [ "${{ github.event_name }}" = "pull_request" ]; then
             echo "matrix={\"include\":[$mac]}" >> "$GITHUB_OUTPUT"
           else
             echo "matrix={\"include\":[$lin,$win,$mac]}" >> "$GITHUB_OUTPUT"
@@ -528,13 +543,17 @@ jobs:
           # the port: the app picks a free one and publishes it to api-port, which
           # we read. Same user => same %APPDATA%, so the de-elevated copy's file is
           # here.
-          $portFile = Join-Path $env:APPDATA "celerp\celerp-data\api-port"
-          $logDir   = Join-Path $env:APPDATA "celerp\celerp-data\logs"
+          $dataDir  = Join-Path $env:APPDATA "celerp\celerp-data"
+          $portFile = Join-Path $dataDir "api-port"
           Remove-Item $portFile -ErrorAction SilentlyContinue
-          Write-Host "smoke: launching $exe"
-          Start-Process -FilePath $exe
+          # Capture the launched process's own stdout/stderr (the de-elevation
+          # guard logs there) in addition to the app's file logs.
+          $boot = Join-Path $env:RUNNER_TEMP "boot.out"
+          $err  = Join-Path $env:RUNNER_TEMP "boot.err"
+          Write-Host "smoke: launching $exe (whoami: $(whoami))"
+          Start-Process -FilePath $exe -RedirectStandardOutput $boot -RedirectStandardError $err
           $deadline = (Get-Date).AddSeconds(150)
-          $port = $null; $ok = $false
+          $port = $null; $ok = $false; $tick = 0
           while ((Get-Date) -lt $deadline) {
             if (-not $port -and (Test-Path $portFile)) {
               $port = (Get-Content $portFile -Raw).Trim()
@@ -546,14 +565,20 @@ jobs:
                 if ($r.Content -match '"db"\s*:\s*"ok"') { $ok = $true; break }
               } catch { }
             }
-            Start-Sleep -Seconds 1
+            if (($tick % 15) -eq 0) {
+              $procs = @(Get-Process Celerp -ErrorAction SilentlyContinue).Count
+              Write-Host "smoke: t+${tick}s  Celerp procs=$procs  portFile=$(Test-Path $portFile)"
+            }
+            $tick++; Start-Sleep -Seconds 1
           }
           taskkill /IM Celerp.exe /F 2>$null | Out-Null
           if (-not $ok) {
             Write-Host "::error::boot smoke FAILED on Windows - /health/ready never returned db:ok (port=$port)"
-            Write-Host "----- app logs (tail) -----"
-            Get-ChildItem -Path $logDir -Filter "*.log" -ErrorAction SilentlyContinue |
-              ForEach-Object { Write-Host "== $($_.Name) =="; Get-Content $_.FullName -Tail 60 -ErrorAction SilentlyContinue }
+            Write-Host "----- launch stdout -----"; if (Test-Path $boot) { Get-Content $boot -Tail 60 }
+            Write-Host "----- launch stderr -----"; if (Test-Path $err)  { Get-Content $err  -Tail 60 }
+            Write-Host "----- data-dir logs (tail) -----"
+            Get-ChildItem -Path $dataDir -Recurse -Include "*.log","logfile" -ErrorAction SilentlyContinue |
+              ForEach-Object { Write-Host "== $($_.FullName) =="; Get-Content $_.FullName -Tail 60 -ErrorAction SilentlyContinue }
             exit 1
           }
           Write-Host "boot smoke OK on Windows (port $port)"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -538,22 +538,6 @@ jobs:
           $ErrorActionPreference = "Stop"
           Set-Location electron
           $exe = (Resolve-Path "dist/win-unpacked/Celerp.exe").Path
-          # --- DIAGNOSTIC: does `runas /trustlevel` run + actually drop admin here? ---
-          $probeOut = Join-Path $env:RUNNER_TEMP "deelev.txt"
-          $probeCmd = Join-Path $env:RUNNER_TEMP "probe.cmd"
-          Set-Content -Encoding Ascii $probeCmd "whoami /groups > `"$probeOut`" 2>&1"
-          Remove-Item $probeOut -ErrorAction SilentlyContinue
-          try {
-            $rp = Start-Process -FilePath "runas.exe" -ArgumentList "/trustlevel:0x20000",$probeCmd -PassThru -Wait -RedirectStandardError (Join-Path $env:RUNNER_TEMP "runas.err")
-            Write-Host "probe: runas exit=$($rp.ExitCode)"
-          } catch { Write-Host "probe: runas threw: $_" }
-          Get-Content (Join-Path $env:RUNNER_TEMP "runas.err") -ErrorAction SilentlyContinue | ForEach-Object { Write-Host "probe runas.err: $_" }
-          Start-Sleep 3
-          if (Test-Path $probeOut) {
-            Write-Host "probe: de-elevated token (Administrators state + integrity):"
-            Get-Content $probeOut | Select-String -Pattern "Administrators|Mandatory Label"
-          } else { Write-Host "probe: NO output -> runas /trustlevel did not launch the wrapper at all" }
-          Write-Host "--- end diagnostic ---"
           # The app self-de-elevates into a fresh process (Postgres can't run as
           # admin), which wouldn't inherit a port we set in env. So we don't pin
           # the port: the app picks a free one and publishes it to api-port, which

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -541,11 +541,19 @@ jobs:
           $dataDir  = Join-Path $env:APPDATA "celerp\celerp-data"
           $portFile = Join-Path $dataDir "api-port"
           Remove-Item $portFile -ErrorAction SilentlyContinue
-          # Launch normally; the app self-de-elevates on Windows (Postgres can't run
-          # as admin) and publishes its API port to a file we read. The deadline is
-          # generous because first-boot initdb on a fresh runner is slow.
-          Write-Host "smoke: launching $exe (whoami: $(whoami))"
-          Start-Process -FilePath $exe
+          # The GitHub runner has UAC off, so every process here runs as a full
+          # administrator - the one config where the app's in-app (Explorer) de-
+          # elevation can't apply, because Explorer is elevated too. To exercise the
+          # real binary + bundled Postgres (which refuses an admin token), drop the
+          # token explicitly via SAFER (runas /trustlevel), which works regardless of
+          # UAC. runas can't start a GUI exe directly, so it goes through a foreground
+          # cmd wrapper; this shell stays alive holding the session, so the de-
+          # elevated app survives. The deadline is generous: first-boot initdb on a
+          # fresh runner is slow. The app publishes its API port to a file we read.
+          $wrapper = Join-Path $env:TEMP "celerp-smoke.cmd"
+          Set-Content -Path $wrapper -Value "@echo off`r`n`"$exe`"" -Encoding ascii
+          Write-Host "smoke: launching de-elevated via runas (whoami: $(whoami))"
+          Start-Process -FilePath "$env:SystemRoot\System32\runas.exe" -ArgumentList '/trustlevel:0x20000', "`"$wrapper`""
           $deadline = (Get-Date).AddSeconds(300)
           $port = $null; $ok = $false; $tick = 0
           while ((Get-Date) -lt $deadline) {

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -607,34 +607,46 @@ jobs:
           icacls $app /grant "Users:(OI)(CI)RX" /T | Out-Null
           $exe = Join-Path $app "Celerp.exe"
 
-          # --- DIAGNOSTIC: does the bundled initdb run to completion as a standard
-          # user? The app wedges in startPostgres -> pgInstance.initialise() (initdb),
-          # which never resolves and never errors. Run the bundled initdb directly,
-          # capture its output + exit code, with a timeout so a hang is visible.
-          $initdb = (Get-ChildItem $app -Recurse -Filter "initdb.exe" -EA SilentlyContinue | Select-Object -First 1)
-          if (-not $initdb) { throw "initdb.exe not found under $app" }
-          Write-Host "initdb: $($initdb.FullName)"
-          $pgtest = "C:\Users\Public\pgtest"
-          $idout  = "C:\Users\Public\initdb.out"
-          $idw    = "C:\Users\Public\initdb.cmd"
-          Remove-Item $pgtest -Recurse -Force -EA SilentlyContinue
-          Remove-Item $idout -EA SilentlyContinue
-          Set-Content -Encoding Ascii $idw "@echo off`r`nset ELECTRON_ENABLE_LOGGING=1`r`n`"$($initdb.FullName)`" -D `"$pgtest`" -U celerp -A trust --encoding=UTF8 --no-locale --no-sync > `"$idout`" 2>&1`r`necho EXITCODE=%ERRORLEVEL%>> `"$idout`""
-          Write-Host "smoke: running bundled initdb directly as standard user $u"
-          Start-Process -FilePath "cmd.exe" -ArgumentList "/c", "`"$idw`"" -Credential $cred -LoadUserProfile -WorkingDirectory $app
-          $deadline = (Get-Date).AddSeconds(120); $done = $false
+          # Launch through a cmd wrapper that captures Electron's stdout/stderr. Pin
+          # the data dir with Electron's built-in --user-data-dir: a credentialed
+          # launch has no fully-established user profile, so Electron can't resolve
+          # %APPDATA% and app.getPath("userData") throws. A world-writable override
+          # path sidesteps that (real users have working profiles).
+          $boot = "C:\Users\Public\celerp-boot.out"
+          $run  = "C:\Users\Public\celerp-run.cmd"
+          $udd  = "C:\Users\Public\celerp-udd"
+          Remove-Item $boot -EA SilentlyContinue
+          Remove-Item $udd -Recurse -Force -EA SilentlyContinue
+          Set-Content -Encoding Ascii $run "@echo off`r`nset ELECTRON_ENABLE_LOGGING=1`r`n`"$exe`" --user-data-dir=`"$udd`" > `"$boot`" 2>&1"
+
+          Write-Host "smoke: launching $exe as standard user $u (data dir $udd, output $boot)"
+          Start-Process -FilePath "cmd.exe" -ArgumentList "/c", "`"$run`"" -Credential $cred -LoadUserProfile -WorkingDirectory $app
+
+          $deadline = (Get-Date).AddSeconds(240)
+          $ok = $false; $port = $null; $tick = 0
           while ((Get-Date) -lt $deadline) {
-            if ((Test-Path $idout) -and (Select-String -Path $idout -Pattern "EXITCODE=" -Quiet -EA SilentlyContinue)) { $done = $true; break }
-            Start-Sleep -Seconds 2
+            if (-not $port) {
+              $pf = Get-ChildItem -Path $udd -Recurse -Filter "api-port" -EA SilentlyContinue | Select-Object -First 1
+              if ($pf) { $port = (Get-Content $pf.FullName -Raw).Trim(); Write-Host "smoke: app published API port $port ($($pf.FullName))" }
+            }
+            if ($port) {
+              try { $r = Invoke-WebRequest -UseBasicParsing -TimeoutSec 3 -Uri "http://127.0.0.1:$port/health/ready"; if ($r.Content -match '"db"\s*:\s*"ok"') { $ok = $true; break } } catch { }
+            }
+            if (($tick % 10) -eq 0) { Write-Host "smoke: t+$($tick*2)s Celerp procs=$(@(Get-Process Celerp -EA SilentlyContinue).Count) portFound=$([bool]$port)" }
+            $tick++; Start-Sleep -Seconds 2
           }
-          taskkill /IM initdb.exe /F 2>$null | Out-Null
-          taskkill /IM postgres.exe /F 2>$null | Out-Null
-          Write-Host "===== initdb output (completed=$done) ====="
-          if (Test-Path $idout) { Get-Content $idout } else { Write-Host "(no output captured)" }
-          Write-Host "===== pgtest dir ====="
-          Get-ChildItem -Path $pgtest -EA SilentlyContinue | ForEach-Object { Write-Host $_.Name }
-          Write-Host "::error::initdb isolation diagnostic (intentionally non-final)"
-          exit 1
+          taskkill /IM Celerp.exe /F 2>$null | Out-Null
+          if (-not $ok) {
+            Write-Host "::error::boot smoke FAILED on Windows - db:ok not reached (port=$port)"
+            Write-Host "===== Electron stdout/stderr ($boot) ====="
+            if (Test-Path $boot) { Get-Content $boot -Tail 200 } else { Write-Host "(no captured output)" }
+            Write-Host "===== boot-relevant files (logs / postgres state) ====="
+            Get-ChildItem -Path $udd -Recurse -EA SilentlyContinue |
+              Where-Object { -not $_.PSIsContainer -and $_.Name -match '(?i)\.log$|logfile|PG_VERSION|postmaster|\.pid$|migrat' } |
+              ForEach-Object { Write-Host "== $($_.FullName) =="; Get-Content $_.FullName -Tail 80 -EA SilentlyContinue }
+            exit 1
+          }
+          Write-Host "boot smoke OK on Windows (port $port)"
 
       - name: Verify YML artifact names
         if: "!startsWith(github.ref, 'refs/tags/v')"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -607,20 +607,25 @@ jobs:
           icacls $app /grant "Users:(OI)(CI)RX" /T | Out-Null
           $exe = Join-Path $app "Celerp.exe"
 
-          # The app's data dir lives under the standard user's profile; its exact
-          # name depends on Electron's app name, so discover the API port from the
-          # api-port file the app publishes rather than guessing the path or relying
-          # on env inheritance through the credentialed launch.
-          $roaming = "C:\Users\$u\AppData\Roaming"
+          # Launch through a cmd wrapper that captures Electron's own stdout/stderr
+          # (ELECTRON_ENABLE_LOGGING) to a world-readable file, so we can see where
+          # early boot wedges even before the app writes its own data-dir logs. The
+          # api-port file is discovered by searching the whole user profile (its
+          # exact path depends on Electron's resolved app name).
+          $boot = "C:\Users\Public\celerp-boot.out"
+          $run  = "C:\Users\Public\celerp-run.cmd"
+          Remove-Item $boot -EA SilentlyContinue
+          Set-Content -Encoding Ascii $run "@echo off`r`nset ELECTRON_ENABLE_LOGGING=1`r`n`"$exe`" > `"$boot`" 2>&1"
+          $userHome = "C:\Users\$u"
 
-          Write-Host "smoke: launching $exe as standard user $u"
-          Start-Process -FilePath $exe -Credential $cred -LoadUserProfile -WorkingDirectory $app
+          Write-Host "smoke: launching $exe as standard user $u (output captured to $boot)"
+          Start-Process -FilePath "cmd.exe" -ArgumentList "/c", "`"$run`"" -Credential $cred -LoadUserProfile -WorkingDirectory $app
 
-          $deadline = (Get-Date).AddSeconds(300)
+          $deadline = (Get-Date).AddSeconds(240)
           $ok = $false; $port = $null; $tick = 0
           while ((Get-Date) -lt $deadline) {
             if (-not $port) {
-              $pf = Get-ChildItem -Path $roaming -Recurse -Filter "api-port" -EA SilentlyContinue | Select-Object -First 1
+              $pf = Get-ChildItem -Path $userHome -Recurse -Filter "api-port" -EA SilentlyContinue | Select-Object -First 1
               if ($pf) { $port = (Get-Content $pf.FullName -Raw).Trim(); Write-Host "smoke: app published API port $port ($($pf.FullName))" }
             }
             if ($port) {
@@ -630,13 +635,12 @@ jobs:
             $tick++; Start-Sleep -Seconds 2
           }
           taskkill /IM Celerp.exe /F 2>$null | Out-Null
-          if (-not $ok) {
-            Write-Host "::error::boot smoke FAILED on Windows - db:ok not reached (port=$port)"
-            Write-Host "===== logs under $roaming ====="
-            Get-ChildItem -Path $roaming -Recurse -Include "*.log","logfile" -EA SilentlyContinue |
-              ForEach-Object { Write-Host "== $($_.FullName) =="; Get-Content $_.FullName -Tail 80 -EA SilentlyContinue }
-            exit 1
-          }
+          Write-Host "===== Electron stdout/stderr ($boot) ====="
+          if (Test-Path $boot) { Get-Content $boot -Tail 200 } else { Write-Host "(no captured output)" }
+          Write-Host "===== logs under $userHome ====="
+          Get-ChildItem -Path $userHome -Recurse -Include "*.log","logfile" -EA SilentlyContinue |
+            ForEach-Object { Write-Host "== $($_.FullName) =="; Get-Content $_.FullName -Tail 80 -EA SilentlyContinue }
+          if (-not $ok) { Write-Host "::error::boot smoke FAILED on Windows - db:ok not reached (port=$port)"; exit 1 }
           Write-Host "boot smoke OK on Windows (port $port)"
 
       - name: Verify YML artifact names

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -511,11 +511,12 @@ jobs:
           fi
           echo "boot smoke OK on $RUNNER_OS"
 
-      # Windows needs its own launch path: the runner is elevated and embedded
-      # Postgres refuses to run as a Windows administrator. We run the app at a
-      # limited (medium-integrity) token via a scheduled task, so Postgres starts
-      # exactly as it does for a normal per-user install.
-      - name: Boot smoke (Windows, de-elevated, require db:ok)
+      # Windows runs elevated on the GitHub runner and bundled Postgres refuses to
+      # run under an administrator token. The app self-de-elevates at startup
+      # (relaunches at a restricted token), so we launch it normally and just pass
+      # the port via machine env — the relaunched, restricted process inherits the
+      # machine environment (it would not inherit our process env).
+      - name: Boot smoke (Windows, require db:ok)
         if: runner.os == 'Windows'
         shell: pwsh
         run: |
@@ -523,17 +524,9 @@ jobs:
           Set-Location electron
           $port = Get-Random -Minimum 20000 -Maximum 60000
           $exe  = (Resolve-Path "dist/win-unpacked/Celerp.exe").Path
-          $log  = Join-Path $env:RUNNER_TEMP "smoke.log"
-          # The de-elevated task is a fresh process, so pass the port via machine
-          # env (new processes inherit it); cleaned up below.
           [Environment]::SetEnvironmentVariable("CELERP_API_PORT", "$port", "Machine")
-          $wrap = Join-Path $env:RUNNER_TEMP "smoke-run.cmd"
-          "@echo off`r`n`"$exe`" > `"$log`" 2>&1" | Set-Content -Encoding Ascii $wrap
-          Write-Host "smoke: launching $exe (de-elevated via scheduled task) on port $port"
-          $action    = New-ScheduledTaskAction -Execute $wrap
-          $principal = New-ScheduledTaskPrincipal -UserId "$env:USERNAME" -RunLevel Limited
-          Register-ScheduledTask -TaskName celerpsmoke -Action $action -Principal $principal -Force | Out-Null
-          Start-ScheduledTask -TaskName celerpsmoke
+          Write-Host "smoke: launching $exe on port $port"
+          Start-Process -FilePath $exe
           $deadline = (Get-Date).AddSeconds(120)
           $ok = $false
           while ((Get-Date) -lt $deadline) {
@@ -543,14 +536,13 @@ jobs:
             } catch { }
             Start-Sleep -Seconds 1
           }
-          schtasks /End /TN celerpsmoke 2>$null | Out-Null
           taskkill /IM Celerp.exe /F 2>$null | Out-Null
-          schtasks /Delete /TN celerpsmoke /F 2>$null | Out-Null
           [Environment]::SetEnvironmentVariable("CELERP_API_PORT", $null, "Machine")
           if (-not $ok) {
             Write-Host "::error::boot smoke FAILED on Windows - /health/ready never returned db:ok"
-            Write-Host "----- app log (tail) -----"
-            if (Test-Path $log) { Get-Content $log -Tail 200 }
+            Write-Host "----- postgres log (tail) -----"
+            Get-ChildItem -Path (Join-Path $env:APPDATA "celerp") -Recurse -Filter "*log*" -ErrorAction SilentlyContinue |
+              ForEach-Object { Write-Host "== $($_.FullName) =="; Get-Content $_.FullName -Tail 80 -ErrorAction SilentlyContinue }
             exit 1
           }
           Write-Host "boot smoke OK on Windows"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -553,9 +553,9 @@ jobs:
           Set-Service seclogon -StartupType Manual
           Start-Service seclogon
 
-          cmd /c "net user $u `"$pw`" /add" | Out-Null
-          if ($LASTEXITCODE -ne 0) { throw "net user /add failed (exit $LASTEXITCODE)" }
           $sec  = ConvertTo-SecureString $pw -AsPlainText -Force
+          New-LocalUser -Name $u -Password $sec -AccountNeverExpires -PasswordNeverExpires | Out-Null
+          Add-LocalGroupMember -Group "Users" -Member $u -ErrorAction SilentlyContinue
           $cred = New-Object System.Management.Automation.PSCredential("$env:COMPUTERNAME\$u", $sec)
 
           # Grant the standard user access to this process's window station + desktop

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -643,8 +643,13 @@ jobs:
           taskkill /IM Celerp.exe /F 2>$null | Out-Null
           Write-Host "===== Electron stdout/stderr ($boot) ====="
           if (Test-Path $boot) { Get-Content $boot -Tail 200 } else { Write-Host "(no captured output)" }
-          Write-Host "===== logs under $udd ====="
-          Get-ChildItem -Path $udd -Recurse -Include "*.log","logfile" -EA SilentlyContinue |
+          Write-Host "===== file tree under $udd (Chromium caches elided) ====="
+          Get-ChildItem -Path $udd -Recurse -EA SilentlyContinue |
+            Where-Object { $_.FullName -notmatch '(?i)\\(Cache|GPUCache|Code Cache|DawnCache|blob_storage|Local Storage|Session Storage|Network|Crashpad)\\' } |
+            ForEach-Object { Write-Host $_.FullName }
+          Write-Host "===== boot-relevant files (logs / postgres state) ====="
+          Get-ChildItem -Path $udd -Recurse -EA SilentlyContinue |
+            Where-Object { -not $_.PSIsContainer -and $_.Name -match '(?i)\.log$|logfile|PG_VERSION|postmaster|\.pid$|migrat' } |
             ForEach-Object { Write-Host "== $($_.FullName) =="; Get-Content $_.FullName -Tail 80 -EA SilentlyContinue }
           if (-not $ok) { Write-Host "::error::boot smoke FAILED on Windows - db:ok not reached (port=$port)"; exit 1 }
           Write-Host "boot smoke OK on Windows (port $port)"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -522,30 +522,41 @@ jobs:
         run: |
           $ErrorActionPreference = "Stop"
           Set-Location electron
-          $port = Get-Random -Minimum 20000 -Maximum 60000
-          $exe  = (Resolve-Path "dist/win-unpacked/Celerp.exe").Path
-          [Environment]::SetEnvironmentVariable("CELERP_API_PORT", "$port", "Machine")
-          Write-Host "smoke: launching $exe on port $port"
+          $exe = (Resolve-Path "dist/win-unpacked/Celerp.exe").Path
+          # The app self-de-elevates into a fresh process (Postgres can't run as
+          # admin), which wouldn't inherit a port we set in env. So we don't pin
+          # the port: the app picks a free one and publishes it to api-port, which
+          # we read. Same user => same %APPDATA%, so the de-elevated copy's file is
+          # here.
+          $portFile = Join-Path $env:APPDATA "celerp\celerp-data\api-port"
+          $logDir   = Join-Path $env:APPDATA "celerp\celerp-data\logs"
+          Remove-Item $portFile -ErrorAction SilentlyContinue
+          Write-Host "smoke: launching $exe"
           Start-Process -FilePath $exe
-          $deadline = (Get-Date).AddSeconds(120)
-          $ok = $false
+          $deadline = (Get-Date).AddSeconds(150)
+          $port = $null; $ok = $false
           while ((Get-Date) -lt $deadline) {
-            try {
-              $r = Invoke-WebRequest -UseBasicParsing -TimeoutSec 3 -Uri "http://127.0.0.1:$port/health/ready"
-              if ($r.Content -match '"db"\s*:\s*"ok"') { $ok = $true; break }
-            } catch { }
+            if (-not $port -and (Test-Path $portFile)) {
+              $port = (Get-Content $portFile -Raw).Trim()
+              Write-Host "smoke: app published API port $port"
+            }
+            if ($port) {
+              try {
+                $r = Invoke-WebRequest -UseBasicParsing -TimeoutSec 3 -Uri "http://127.0.0.1:$port/health/ready"
+                if ($r.Content -match '"db"\s*:\s*"ok"') { $ok = $true; break }
+              } catch { }
+            }
             Start-Sleep -Seconds 1
           }
           taskkill /IM Celerp.exe /F 2>$null | Out-Null
-          [Environment]::SetEnvironmentVariable("CELERP_API_PORT", $null, "Machine")
           if (-not $ok) {
-            Write-Host "::error::boot smoke FAILED on Windows - /health/ready never returned db:ok"
-            Write-Host "----- postgres log (tail) -----"
-            Get-ChildItem -Path (Join-Path $env:APPDATA "celerp") -Recurse -Filter "*log*" -ErrorAction SilentlyContinue |
-              ForEach-Object { Write-Host "== $($_.FullName) =="; Get-Content $_.FullName -Tail 80 -ErrorAction SilentlyContinue }
+            Write-Host "::error::boot smoke FAILED on Windows - /health/ready never returned db:ok (port=$port)"
+            Write-Host "----- app logs (tail) -----"
+            Get-ChildItem -Path $logDir -Filter "*.log" -ErrorAction SilentlyContinue |
+              ForEach-Object { Write-Host "== $($_.Name) =="; Get-Content $_.FullName -Tail 60 -ErrorAction SilentlyContinue }
             exit 1
           }
-          Write-Host "boot smoke OK on Windows"
+          Write-Host "boot smoke OK on Windows (port $port)"
 
       - name: Verify YML artifact names
         if: "!startsWith(github.ref, 'refs/tags/v')"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -540,35 +540,30 @@ jobs:
           $exe = (Resolve-Path "dist/win-unpacked/Celerp.exe").Path
           $dataDir  = Join-Path $env:APPDATA "celerp\celerp-data"
           $portFile = Join-Path $dataDir "api-port"
-          # DIAGNOSTIC: launch the app DE-ELEVATED directly via a wrapper that
-          # captures all of its output (it self-de-elevates anyway; doing it here
-          # lets us see the de-elevated process's stdout/stderr, which a grandchild
-          # of runas otherwise loses). ELECTRON_ENABLE_LOGGING surfaces Chromium
-          # init errors. This tells us exactly why the de-elevated GUI app dies.
-          $deOut   = Join-Path $env:RUNNER_TEMP "deelev.out"
-          $wrapper = Join-Path $env:RUNNER_TEMP "deelev-run.cmd"
-          @('@echo off', 'set ELECTRON_ENABLE_LOGGING=1', "`"$exe`" > `"$deOut`" 2>&1") |
-            Set-Content -Encoding Ascii $wrapper
-          Remove-Item $portFile,$deOut -ErrorAction SilentlyContinue
-          Write-Host "smoke: launching de-elevated via runas (whoami: $(whoami))"
-          Start-Process -FilePath "runas.exe" -ArgumentList "/trustlevel:0x20000",$wrapper
-          $deadline = (Get-Date).AddSeconds(120)
+          Remove-Item $portFile -ErrorAction SilentlyContinue
+          # Launch normally; the app self-de-elevates on Windows (Postgres can't run
+          # as admin) and publishes its API port to a file we read. The deadline is
+          # generous because first-boot initdb on a fresh runner is slow.
+          Write-Host "smoke: launching $exe (whoami: $(whoami))"
+          Start-Process -FilePath $exe
+          $deadline = (Get-Date).AddSeconds(300)
           $port = $null; $ok = $false; $tick = 0
           while ((Get-Date) -lt $deadline) {
-            if (-not $port -and (Test-Path $portFile)) { $port = (Get-Content $portFile -Raw).Trim(); Write-Host "smoke: published port $port" }
+            if (-not $port -and (Test-Path $portFile)) { $port = (Get-Content $portFile -Raw).Trim(); Write-Host "smoke: app published API port $port" }
             if ($port) {
               try { $r = Invoke-WebRequest -UseBasicParsing -TimeoutSec 3 -Uri "http://127.0.0.1:$port/health/ready"; if ($r.Content -match '"db"\s*:\s*"ok"') { $ok = $true; break } } catch { }
             }
-            if (($tick % 15) -eq 0) { Write-Host "smoke: t+${tick}s Celerp procs=$(@(Get-Process Celerp -EA SilentlyContinue).Count) portFile=$(Test-Path $portFile)" }
+            if (($tick % 20) -eq 0) { Write-Host "smoke: t+${tick}s Celerp procs=$(@(Get-Process Celerp -EA SilentlyContinue).Count) portFile=$(Test-Path $portFile)" }
             $tick++; Start-Sleep -Seconds 1
           }
           taskkill /IM Celerp.exe /F 2>$null | Out-Null
-          Write-Host "===== de-elevated app output ($deOut) ====="
-          if (Test-Path $deOut) { Get-Content $deOut -Tail 150 } else { Write-Host "(no de-elevated output captured)" }
-          Write-Host "===== data-dir logs ====="
-          Get-ChildItem -Path $dataDir -Recurse -Include "*.log","logfile" -EA SilentlyContinue |
-            ForEach-Object { Write-Host "== $($_.FullName) =="; Get-Content $_.FullName -Tail 50 -EA SilentlyContinue }
-          if (-not $ok) { Write-Host "::error::boot smoke FAILED on Windows - db:ok not reached (port=$port)"; exit 1 }
+          if (-not $ok) {
+            Write-Host "::error::boot smoke FAILED on Windows - db:ok not reached (port=$port)"
+            Write-Host "===== data-dir logs ====="
+            Get-ChildItem -Path $dataDir -Recurse -Include "*.log","logfile" -EA SilentlyContinue |
+              ForEach-Object { Write-Host "== $($_.FullName) =="; Get-Content $_.FullName -Tail 60 -EA SilentlyContinue }
+            exit 1
+          }
           Write-Host "boot smoke OK on Windows (port $port)"
 
       - name: Verify YML artifact names

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -535,26 +535,45 @@ jobs:
         if: runner.os == 'Windows'
         shell: pwsh
         run: |
-          $ErrorActionPreference = "Stop"
+          $ErrorActionPreference = "Continue"
           Set-Location electron
           $exe = (Resolve-Path "dist/win-unpacked/Celerp.exe").Path
           $dataDir  = Join-Path $env:APPDATA "celerp\celerp-data"
           $portFile = Join-Path $dataDir "api-port"
           Remove-Item $portFile -ErrorAction SilentlyContinue
-          # The GitHub runner has UAC off, so every process here runs as a full
-          # administrator - the one config where the app's in-app (Explorer) de-
-          # elevation can't apply, because Explorer is elevated too. To exercise the
-          # real binary + bundled Postgres (which refuses an admin token), drop the
-          # token explicitly via SAFER (runas /trustlevel), which works regardless of
-          # UAC. runas can't start a GUI exe directly, so it goes through a foreground
-          # cmd wrapper; this shell stays alive holding the session, so the de-
-          # elevated app survives. The deadline is generous: first-boot initdb on a
-          # fresh runner is slow. The app publishes its API port to a file we read.
+          # --- DIAGNOSTIC: which de-elevation primitive actually works on this runner? ---
+          # The runner is full-admin + UAC off; Postgres refuses an admin token. Earlier
+          # runas /trustlevel attempts launched nothing (procs=0, no logs). Settle the
+          # mechanism in one run: report the token, the seclogon service, whether
+          # runas/trustlevel launches a wrapper at all, and whether a freshly-created
+          # standard user (no admin token) can be launched via -Credential.
+          Write-Host "=== runner token ==="; whoami /groups | Select-String "S-1-5-32-544|Mandatory Label"
+          Write-Host "=== seclogon service ==="; (Get-Service seclogon | Select-Object Name,Status,StartType | Out-String).Trim()
+          $tmp = $env:RUNNER_TEMP
+          # Probe 1: runas /trustlevel:0x20000 -> does the wrapper even run, and at what token?
+          $m1 = Join-Path $tmp "m1.txt"; Remove-Item $m1 -EA SilentlyContinue
+          $w1 = Join-Path $tmp "w1.cmd"; Set-Content -Encoding Ascii $w1 "whoami /groups > `"$m1`" 2>&1"
+          Start-Process -FilePath "$env:SystemRoot\System32\runas.exe" -ArgumentList '/trustlevel:0x20000', "`"$w1`""
+          Start-Sleep 6
+          Write-Host "=== probe1: runas /trustlevel ==="
+          if (Test-Path $m1) { (Get-Content $m1 | Select-String "S-1-5-32-544|Mandatory Label" | Out-String).Trim() } else { Write-Host "runas/trustlevel: NO marker -> did not launch the wrapper" }
+          # Probe 2: standard (non-admin) user launched via -Credential (uses seclogon).
+          $u = "celerpci"; $pw = "Celerp!" + ([guid]::NewGuid().ToString("N").Substring(0,12))
+          cmd /c "net user $u $pw /add" | Out-Null
+          $sec = ConvertTo-SecureString $pw -AsPlainText -Force
+          $cred = New-Object System.Management.Automation.PSCredential($u, $sec)
+          $m2 = "C:\Users\Public\celerp-m2.txt"; Remove-Item $m2 -EA SilentlyContinue
+          $w2 = Join-Path $tmp "w2.cmd"; Set-Content -Encoding Ascii $w2 "whoami /groups > `"$m2`" 2>&1"
+          try { Start-Process -FilePath "cmd.exe" -ArgumentList "/c","`"$w2`"" -Credential $cred -WorkingDirectory "C:\Users\Public"; Write-Host "probe2: launched cmd as $u" } catch { Write-Host "probe2 threw: $_" }
+          Start-Sleep 6
+          Write-Host "=== probe2: standard-user via -Credential ==="
+          if (Test-Path $m2) { (Get-Content $m2 | Select-String "S-1-5-32-544|Mandatory Label" | Out-String).Trim() } else { Write-Host "standard-user: NO marker -> launch failed" }
+          Write-Host "--- end diagnostic; proceeding with the original runas attempt for log continuity ---"
           $wrapper = Join-Path $env:TEMP "celerp-smoke.cmd"
           Set-Content -Path $wrapper -Value "@echo off`r`n`"$exe`"" -Encoding ascii
           Write-Host "smoke: launching de-elevated via runas (whoami: $(whoami))"
           Start-Process -FilePath "$env:SystemRoot\System32\runas.exe" -ArgumentList '/trustlevel:0x20000', "`"$wrapper`""
-          $deadline = (Get-Date).AddSeconds(300)
+          $deadline = (Get-Date).AddSeconds(45)
           $port = $null; $ok = $false; $tick = 0
           while ((Get-Date) -lt $deadline) {
             if (-not $port -and (Test-Path $portFile)) { $port = (Get-Content $portFile -Raw).Trim(); Write-Host "smoke: app published API port $port" }

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -538,49 +538,37 @@ jobs:
           $ErrorActionPreference = "Stop"
           Set-Location electron
           $exe = (Resolve-Path "dist/win-unpacked/Celerp.exe").Path
-          # The app self-de-elevates into a fresh process (Postgres can't run as
-          # admin), which wouldn't inherit a port we set in env. So we don't pin
-          # the port: the app picks a free one and publishes it to api-port, which
-          # we read. Same user => same %APPDATA%, so the de-elevated copy's file is
-          # here.
           $dataDir  = Join-Path $env:APPDATA "celerp\celerp-data"
           $portFile = Join-Path $dataDir "api-port"
-          Remove-Item $portFile -ErrorAction SilentlyContinue
-          # Capture the launched process's own stdout/stderr (the de-elevation
-          # guard logs there) in addition to the app's file logs.
-          $boot = Join-Path $env:RUNNER_TEMP "boot.out"
-          $err  = Join-Path $env:RUNNER_TEMP "boot.err"
-          Write-Host "smoke: launching $exe (whoami: $(whoami))"
-          Start-Process -FilePath $exe -RedirectStandardOutput $boot -RedirectStandardError $err
-          $deadline = (Get-Date).AddSeconds(150)
+          # DIAGNOSTIC: launch the app DE-ELEVATED directly via a wrapper that
+          # captures all of its output (it self-de-elevates anyway; doing it here
+          # lets us see the de-elevated process's stdout/stderr, which a grandchild
+          # of runas otherwise loses). ELECTRON_ENABLE_LOGGING surfaces Chromium
+          # init errors. This tells us exactly why the de-elevated GUI app dies.
+          $deOut   = Join-Path $env:RUNNER_TEMP "deelev.out"
+          $wrapper = Join-Path $env:RUNNER_TEMP "deelev-run.cmd"
+          @('@echo off', 'set ELECTRON_ENABLE_LOGGING=1', "`"$exe`" > `"$deOut`" 2>&1") |
+            Set-Content -Encoding Ascii $wrapper
+          Remove-Item $portFile,$deOut -ErrorAction SilentlyContinue
+          Write-Host "smoke: launching de-elevated via runas (whoami: $(whoami))"
+          Start-Process -FilePath "runas.exe" -ArgumentList "/trustlevel:0x20000",$wrapper
+          $deadline = (Get-Date).AddSeconds(120)
           $port = $null; $ok = $false; $tick = 0
           while ((Get-Date) -lt $deadline) {
-            if (-not $port -and (Test-Path $portFile)) {
-              $port = (Get-Content $portFile -Raw).Trim()
-              Write-Host "smoke: app published API port $port"
-            }
+            if (-not $port -and (Test-Path $portFile)) { $port = (Get-Content $portFile -Raw).Trim(); Write-Host "smoke: published port $port" }
             if ($port) {
-              try {
-                $r = Invoke-WebRequest -UseBasicParsing -TimeoutSec 3 -Uri "http://127.0.0.1:$port/health/ready"
-                if ($r.Content -match '"db"\s*:\s*"ok"') { $ok = $true; break }
-              } catch { }
+              try { $r = Invoke-WebRequest -UseBasicParsing -TimeoutSec 3 -Uri "http://127.0.0.1:$port/health/ready"; if ($r.Content -match '"db"\s*:\s*"ok"') { $ok = $true; break } } catch { }
             }
-            if (($tick % 15) -eq 0) {
-              $procs = @(Get-Process Celerp -ErrorAction SilentlyContinue).Count
-              Write-Host "smoke: t+${tick}s  Celerp procs=$procs  portFile=$(Test-Path $portFile)"
-            }
+            if (($tick % 15) -eq 0) { Write-Host "smoke: t+${tick}s Celerp procs=$(@(Get-Process Celerp -EA SilentlyContinue).Count) portFile=$(Test-Path $portFile)" }
             $tick++; Start-Sleep -Seconds 1
           }
           taskkill /IM Celerp.exe /F 2>$null | Out-Null
-          if (-not $ok) {
-            Write-Host "::error::boot smoke FAILED on Windows - /health/ready never returned db:ok (port=$port)"
-            Write-Host "----- launch stdout -----"; if (Test-Path $boot) { Get-Content $boot -Tail 60 }
-            Write-Host "----- launch stderr -----"; if (Test-Path $err)  { Get-Content $err  -Tail 60 }
-            Write-Host "----- data-dir logs (tail) -----"
-            Get-ChildItem -Path $dataDir -Recurse -Include "*.log","logfile" -ErrorAction SilentlyContinue |
-              ForEach-Object { Write-Host "== $($_.FullName) =="; Get-Content $_.FullName -Tail 60 -ErrorAction SilentlyContinue }
-            exit 1
-          }
+          Write-Host "===== de-elevated app output ($deOut) ====="
+          if (Test-Path $deOut) { Get-Content $deOut -Tail 150 } else { Write-Host "(no de-elevated output captured)" }
+          Write-Host "===== data-dir logs ====="
+          Get-ChildItem -Path $dataDir -Recurse -Include "*.log","logfile" -EA SilentlyContinue |
+            ForEach-Object { Write-Host "== $($_.FullName) =="; Get-Content $_.FullName -Tail 50 -EA SilentlyContinue }
+          if (-not $ok) { Write-Host "::error::boot smoke FAILED on Windows - db:ok not reached (port=$port)"; exit 1 }
           Write-Host "boot smoke OK on Windows (port $port)"
 
       - name: Verify YML artifact names

--- a/celerp/cli.py
+++ b/celerp/cli.py
@@ -206,20 +206,30 @@ def _post_migration_grants(db_url: str) -> None:
 
     Must run AFTER migrations since sequences/tables created by migrations
     won't be covered by ALTER DEFAULT PRIVILEGES set during provisioning.
+
+    Runs in-process over the existing connection rather than shelling out to
+    `sudo -u postgres psql` (which does not exist on Windows and crashed the
+    bundled launcher's migrate step). On the bundled single-user cluster the
+    connecting user is the superuser/owner, so the grants apply; best-effort so a
+    grant error never blocks startup.
     """
     parts = _parse_db_url(db_url)
     if not parts:
         return
     user = parts["user"]
-    dbname = parts["dbname"]
-    for grant_sql in [
-        f"GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public TO {user};",
-        f"GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA public TO {user};",
-    ]:
-        subprocess.run(
-            ["sudo", "-u", "postgres", "psql", "-d", dbname, "-c", grant_sql],
-            capture_output=True, text=True,
-        )
+    sync_url = db_url.replace("postgresql+asyncpg://", "postgresql://")
+    try:
+        from sqlalchemy import create_engine, text
+        engine = create_engine(sync_url)
+        try:
+            with engine.begin() as conn:
+                conn.execute(text(f'GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public TO "{user}";'))
+                conn.execute(text(f'GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA public TO "{user}";'))
+        finally:
+            engine.dispose()
+    except Exception:
+        # Best-effort: on the bundled cluster the app user already owns its objects.
+        pass
 
 
 

--- a/electron/app-main.js
+++ b/electron/app-main.js
@@ -41,15 +41,19 @@ const _spawn = childProcess.spawn.bind(childProcess);
 childProcess.spawn = function spawn(cmd, args, opts) {
   const resolved = rewriteAsarPath(cmd);
   const child = _spawn(resolved, args, opts);
-  // Drain embedded-postgres's child pipes. embedded-postgres spawns initdb/postgres
-  // with piped stdio but reads only stdout in initialise(), leaving stderr unread.
-  // PostgreSQL tools write their progress to stderr, and Windows anonymous pipes
-  // have a tiny buffer — an unread stderr fills, the child blocks on the write and
-  // never exits, hanging first-boot initialisation. Attaching no-op drains keeps
-  // the pipes empty; embedded-postgres's own 'data' parsers still receive the data.
+  // TEMP DIAGNOSTIC: capture (and thereby drain) embedded-postgres child output to
+  // a file so we can see exactly where first-boot initdb wedges on Windows.
   if (typeof resolved === "string" && resolved.includes("@embedded-postgres")) {
-    child.stdout?.on("data", () => {});
-    child.stderr?.on("data", () => {});
+    const _log = (tag) => (chunk) => {
+      try {
+        const dir = path.join(app.getPath("userData"), "celerp-data", "logs");
+        fs.mkdirSync(dir, { recursive: true });
+        fs.appendFileSync(path.join(dir, "pg-stdio.log"), `[${tag}] ${chunk}`);
+      } catch { /* ignore */ }
+    };
+    try { fs.appendFileSync(path.join(app.getPath("userData"), "celerp-data", "logs", "pg-stdio.log"), `\n=== spawn ${resolved} ${JSON.stringify(args)} ===\n`); } catch { /* ignore */ }
+    child.stdout?.on("data", _log("out"));
+    child.stderr?.on("data", _log("err"));
   }
   return child;
 };

--- a/electron/app-main.js
+++ b/electron/app-main.js
@@ -960,11 +960,14 @@ function isWindowsElevated() {
 if (isWindowsElevated()) {
   let relaunched = false;
   try {
-    childProcess
-      .spawn("runas", ["/trustlevel:0x20000", process.execPath], {
-        detached: true, stdio: "ignore", windowsHide: true,
-      })
-      .unref();
+    // Full path: Node's spawn/execFile does not resolve a bare "runas" (no shell)
+    // to runas.exe. Run it synchronously so a launch failure is caught here rather
+    // than lost as an async 'error' event. runas launches the de-elevated copy and
+    // returns; that copy keeps running after we exit.
+    const runas = path.join(process.env.SystemRoot || "C:\\Windows", "System32", "runas.exe");
+    childProcess.execFileSync(runas, ["/trustlevel:0x20000", process.execPath], {
+      stdio: "ignore", windowsHide: true,
+    });
     relaunched = true;
     console.log("[startup] elevated launch detected; relaunched de-elevated (Postgres cannot run as admin)");
   } catch (e) {

--- a/electron/app-main.js
+++ b/electron/app-main.js
@@ -245,7 +245,6 @@ async function initialisePostgresWindows() {
 async function startPostgres(dbPort) {
   fs.mkdirSync(PG_DATA_DIR, { recursive: true });
   fs.mkdirSync(LOG_DIR, { recursive: true });
-  try { fs.appendFileSync(path.join(LOG_DIR, "boot-trace.log"), `startPostgres entered platform=${process.platform} pgVersionExists=${fs.existsSync(path.join(PG_DATA_DIR, "PG_VERSION"))}\n`); } catch { /* ignore */ }
 
   if (!EmbeddedPostgres) {
     EmbeddedPostgres = (await import("embedded-postgres")).default;
@@ -1165,7 +1164,9 @@ app.whenReady().then(async () => {
       setupAutoUpdater();
     }
   } catch (err) {
-    try { fs.appendFileSync(path.join(LOG_DIR, "boot-trace.log"), `FATAL: ${err?.stack ?? err}\n`); } catch { /* ignore */ }
+    // Record why startup failed so it is recoverable from the data dir after the
+    // error dialog is dismissed.
+    try { fs.appendFileSync(path.join(LOG_DIR, "startup-error.log"), `${new Date().toISOString()} ${err?.stack ?? err}\n`); } catch { /* ignore */ }
     showError("Celerp failed to start", err?.message ?? String(err));
     app.quit();
   }

--- a/electron/app-main.js
+++ b/electron/app-main.js
@@ -960,37 +960,24 @@ function isWindowsElevated() {
 if (isWindowsElevated()) {
   let relaunched = false;
   try {
-    // Relaunch de-elevated through a one-shot Scheduled Task. Two facts force this
-    // shape:
-    //   1. Electron runs its child processes in a job object with KILL_ON_JOB_CLOSE,
-    //      so a plain (even detached) relaunch dies the instant this elevated copy
-    //      exits. A Scheduled Task action runs under the Task Scheduler service,
-    //      outside that job, so the relaunched copy survives.
-    //   2. SAFER (runas /trustlevel) is the only way to drop the admin token when
-    //      UAC is off (a /rl LIMITED task still runs elevated there); runas cannot
-    //      launch a GUI exe directly, so it goes through a tiny cmd wrapper that
-    //      foreground-launches the app.
-    const os = require("os");
-    const sysRoot = process.env.SystemRoot || "C:\\Windows";
-    const runas = path.join(sysRoot, "System32", "runas.exe");
-    const schtasks = path.join(sysRoot, "System32", "schtasks.exe");
-    const tmp = os.tmpdir();
-    const inner = path.join(tmp, "celerp-deelevate-run.cmd");
-    const outer = path.join(tmp, "celerp-deelevate-task.cmd");
-    fs.writeFileSync(inner, `@echo off\r\n"${process.execPath}"\r\n`);
-    fs.writeFileSync(outer, `@echo off\r\n"${runas}" /trustlevel:0x20000 "${inner}"\r\n`);
-    const task = "CelerpDeelevate";
-    const opts = { stdio: "ignore", windowsHide: true };
-    // Remove any stale one-shot from a previous elevated launch, then (re)create.
-    try { childProcess.execFileSync(schtasks, ["/delete", "/f", "/tn", task], opts); } catch {}
-    childProcess.execFileSync(schtasks,
-      ["/create", "/f", "/tn", task, "/sc", "ONCE", "/st", "00:00", "/tr", outer, "/rl", "LIMITED"], opts);
-    childProcess.execFileSync(schtasks, ["/run", "/tn", task], opts);
+    // Relaunch de-elevated by handing the exe back to Explorer (the shell). With
+    // UAC on - the normal Windows configuration - Explorer runs at the user's
+    // standard integrity, so the copy it starts inherits a non-admin token, which
+    // is what Postgres needs. This also sidesteps Electron's job object: Electron
+    // runs its own children in a job with KILL_ON_JOB_CLOSE, so a direct relaunch
+    // would die the moment this instance exits, but an Explorer-launched process is
+    // the shell's child, not ours, and survives.
+    const explorer = path.join(process.env.SystemRoot || "C:\\Windows", "explorer.exe");
+    const child = childProcess.spawn(explorer, [process.execPath], {
+      detached: true, stdio: "ignore", windowsHide: true,
+    });
+    child.on("error", (e) => console.error("[startup] de-elevation spawn error:", e));
+    child.unref();
     relaunched = true;
     console.log("[startup] elevated launch detected; relaunched de-elevated (Postgres cannot run as admin)");
   } catch (e) {
-    // SAFER or the Task Scheduler may be disabled by policy; fall through and boot
-    // (Postgres will then report the admin error, no worse than before).
+    // Fall through and boot (Postgres will then report the admin error, no worse
+    // than before).
     console.error("[startup] de-elevation relaunch failed; continuing:", e);
   }
   if (relaunched) {

--- a/electron/app-main.js
+++ b/electron/app-main.js
@@ -39,7 +39,19 @@ function rewriteAsarPath(p) {
 // from 'child_process', so a local wrapper would not affect it.
 const _spawn = childProcess.spawn.bind(childProcess);
 childProcess.spawn = function spawn(cmd, args, opts) {
-  return _spawn(rewriteAsarPath(cmd), args, opts);
+  const resolved = rewriteAsarPath(cmd);
+  const child = _spawn(resolved, args, opts);
+  // Drain embedded-postgres's child pipes. embedded-postgres spawns initdb/postgres
+  // with piped stdio but reads only stdout in initialise(), leaving stderr unread.
+  // PostgreSQL tools write their progress to stderr, and Windows anonymous pipes
+  // have a tiny buffer — an unread stderr fills, the child blocks on the write and
+  // never exits, hanging first-boot initialisation. Attaching no-op drains keeps
+  // the pipes empty; embedded-postgres's own 'data' parsers still receive the data.
+  if (typeof resolved === "string" && resolved.includes("@embedded-postgres")) {
+    child.stdout?.on("data", () => {});
+    child.stderr?.on("data", () => {});
+  }
+  return child;
 };
 const spawn = childProcess.spawn;
 

--- a/electron/app-main.js
+++ b/electron/app-main.js
@@ -960,29 +960,37 @@ function isWindowsElevated() {
 if (isWindowsElevated()) {
   let relaunched = false;
   try {
-    // runas /trustlevel cannot launch the GUI exe directly (it produces no running
-    // process), but launching it through a tiny cmd wrapper that `start`s the app
-    // works (verified: the de-elevated copy boots and Postgres runs). `start`
-    // detaches the app so the wrapper/runas return immediately - execFileSync then
-    // catches a launch failure without blocking. Full runas path: Node won't
-    // resolve a bare "runas" without a shell.
+    // Relaunch de-elevated through a one-shot Scheduled Task. Two facts force this
+    // shape:
+    //   1. Electron runs its child processes in a job object with KILL_ON_JOB_CLOSE,
+    //      so a plain (even detached) relaunch dies the instant this elevated copy
+    //      exits. A Scheduled Task action runs under the Task Scheduler service,
+    //      outside that job, so the relaunched copy survives.
+    //   2. SAFER (runas /trustlevel) is the only way to drop the admin token when
+    //      UAC is off (a /rl LIMITED task still runs elevated there); runas cannot
+    //      launch a GUI exe directly, so it goes through a tiny cmd wrapper that
+    //      foreground-launches the app.
     const os = require("os");
-    const runas = path.join(process.env.SystemRoot || "C:\\Windows", "System32", "runas.exe");
-    const wrapper = path.join(os.tmpdir(), "celerp-deelevate.cmd");
-    // Foreground launch (NOT `start`): cmd stays the de-elevated app's parent so
-    // it isn't orphaned and killed. Spawn detached so the whole runas->cmd->app
-    // tree keeps running after this elevated instance exits.
-    fs.writeFileSync(wrapper, `@echo off\r\n"${process.execPath}"\r\n`);
-    const child = childProcess.spawn(runas, ["/trustlevel:0x20000", wrapper], {
-      detached: true, stdio: "ignore", windowsHide: true,
-    });
-    child.on("error", (e) => console.error("[startup] de-elevation spawn error:", e));
-    child.unref();
+    const sysRoot = process.env.SystemRoot || "C:\\Windows";
+    const runas = path.join(sysRoot, "System32", "runas.exe");
+    const schtasks = path.join(sysRoot, "System32", "schtasks.exe");
+    const tmp = os.tmpdir();
+    const inner = path.join(tmp, "celerp-deelevate-run.cmd");
+    const outer = path.join(tmp, "celerp-deelevate-task.cmd");
+    fs.writeFileSync(inner, `@echo off\r\n"${process.execPath}"\r\n`);
+    fs.writeFileSync(outer, `@echo off\r\n"${runas}" /trustlevel:0x20000 "${inner}"\r\n`);
+    const task = "CelerpDeelevate";
+    const opts = { stdio: "ignore", windowsHide: true };
+    // Remove any stale one-shot from a previous elevated launch, then (re)create.
+    try { childProcess.execFileSync(schtasks, ["/delete", "/f", "/tn", task], opts); } catch {}
+    childProcess.execFileSync(schtasks,
+      ["/create", "/f", "/tn", task, "/sc", "ONCE", "/st", "00:00", "/tr", outer, "/rl", "LIMITED"], opts);
+    childProcess.execFileSync(schtasks, ["/run", "/tn", task], opts);
     relaunched = true;
     console.log("[startup] elevated launch detected; relaunched de-elevated (Postgres cannot run as admin)");
   } catch (e) {
-    // SAFER may be disabled by policy; fall through and boot (Postgres will then
-    // report the admin error, no worse than before).
+    // SAFER or the Task Scheduler may be disabled by policy; fall through and boot
+    // (Postgres will then report the admin error, no worse than before).
     console.error("[startup] de-elevation relaunch failed; continuing:", e);
   }
   if (relaunched) {

--- a/electron/app-main.js
+++ b/electron/app-main.js
@@ -263,18 +263,14 @@ async function startPostgres(dbPort) {
   // on an existing data directory causes initdb to exit non-zero and crash.
   const pgVersionFile = path.join(PG_DATA_DIR, "PG_VERSION");
   if (!fs.existsSync(pgVersionFile)) {
-    if (process.platform === "win32") {
-      // embedded-postgres is ESM and imports the builtin child_process.spawn, so
-      // our spawn wrapper can't reach it; its initialise() reads only initdb's
-      // stdout, leaving stderr unread. On Windows the small anonymous-pipe buffer
-      // fills, initdb blocks on the write and never exits — first boot hangs. Run
-      // initdb ourselves with stdio disabled (it can't block), producing the same
-      // cluster initialise() would; the PG_VERSION it writes makes the guard skip
-      // embedded-postgres's own initialise().
-      await initialisePostgresWindows();
-    } else {
-      await pgInstance.initialise();
-    }
+    // First boot: create the cluster. On Windows we initialise it ourselves (see
+    // initialisePostgresWindows) because embedded-postgres is ESM and imports the
+    // builtin child_process.spawn — our spawn wrapper can't reach it — and its
+    // initialise() leaves initdb's stderr unread, which deadlocks initdb on
+    // Windows (tiny pipe buffer). Both paths run only when PG_VERSION is absent.
+    await (process.platform === "win32"
+      ? initialisePostgresWindows()
+      : pgInstance.initialise());
   }
   await pgInstance.start();
 

--- a/electron/app-main.js
+++ b/electron/app-main.js
@@ -209,10 +209,17 @@ function pythonBin() {
 // (same args/auth so the cluster is identical and .start() can connect), but with
 // stdio disabled so initdb's stderr cannot fill an unread pipe and deadlock.
 async function initialisePostgresWindows() {
-  const pkgJson = require.resolve("@embedded-postgres/windows-x64/package.json");
-  const initdbBin = rewriteAsarPath(path.join(path.dirname(pkgJson), "native", "bin", "initdb.exe"));
+  const logPath = path.join(LOG_DIR, "initdb-win.log");
+  const trace = (m) => { try { fs.appendFileSync(logPath, m + "\n"); } catch { /* ignore */ } };
+  let initdbBin;
+  try {
+    const pkgJson = require.resolve("@embedded-postgres/windows-x64/package.json");
+    initdbBin = rewriteAsarPath(path.join(path.dirname(pkgJson), "native", "bin", "initdb.exe"));
+  } catch (e) { trace("resolve initdb failed: " + e.message); throw e; }
+  trace(`initdb bin=${initdbBin} exists=${fs.existsSync(initdbBin)}`);
   const pwfile = path.join(DATA_DIR, `pg-pwfile-${process.pid}`);
   fs.writeFileSync(pwfile, "celerp\n");
+  const out = fs.openSync(logPath, "a");
   try {
     await new Promise((resolve, reject) => {
       const proc = _spawn(initdbBin, [
@@ -221,11 +228,12 @@ async function initialisePostgresWindows() {
         "--username=celerp",
         `--pwfile=${pwfile}`,
         "--lc-messages=en_US.UTF-8",
-      ], { stdio: ["ignore", "ignore", "ignore"], env: { ...process.env, LC_MESSAGES: "en_US.UTF-8" } });
-      proc.on("error", reject);
-      proc.on("exit", (code) => (code === 0 ? resolve() : reject(new Error(`initdb exited with code ${code}`))));
+      ], { stdio: ["ignore", out, out], env: { ...process.env, LC_MESSAGES: "en_US.UTF-8" } });
+      proc.on("error", (e) => { trace("initdb spawn error: " + e.message); reject(e); });
+      proc.on("exit", (code) => { trace("initdb exit code=" + code); (code === 0 ? resolve() : reject(new Error(`initdb exited with code ${code}`))); });
     });
   } finally {
+    try { fs.closeSync(out); } catch { /* ignore */ }
     try { fs.rmSync(pwfile, { force: true }); } catch { /* ignore */ }
   }
 }
@@ -233,6 +241,7 @@ async function initialisePostgresWindows() {
 async function startPostgres(dbPort) {
   fs.mkdirSync(PG_DATA_DIR, { recursive: true });
   fs.mkdirSync(LOG_DIR, { recursive: true });
+  try { fs.appendFileSync(path.join(LOG_DIR, "boot-trace.log"), `startPostgres entered platform=${process.platform} pgVersionExists=${fs.existsSync(path.join(PG_DATA_DIR, "PG_VERSION"))}\n`); } catch { /* ignore */ }
 
   if (!EmbeddedPostgres) {
     EmbeddedPostgres = (await import("embedded-postgres")).default;

--- a/electron/app-main.js
+++ b/electron/app-main.js
@@ -1070,6 +1070,10 @@ app.whenReady().then(async () => {
     const _pinApi = parseInt(process.env.CELERP_API_PORT || "", 10);
     apiPort = Number.isInteger(_pinApi) && _pinApi > 0 ? _pinApi : await getFreePort();
     uiPort = await getFreePort();
+    // Publish the chosen API port so external tooling (the CI boot smoke,
+    // local debugging) can discover it without having to dictate it — needed when
+    // the app self-de-elevated into a fresh process that didn't inherit our env.
+    try { fs.writeFileSync(path.join(DATA_DIR, "api-port"), String(apiPort)); } catch { /* non-fatal */ }
     setLoadingStatus("Starting API server…");
     await startApi(dbConfig.url, cfg);
     setLoadingStatus("Starting UI server…");

--- a/electron/app-main.js
+++ b/electron/app-main.js
@@ -969,10 +969,15 @@ if (isWindowsElevated()) {
     const os = require("os");
     const runas = path.join(process.env.SystemRoot || "C:\\Windows", "System32", "runas.exe");
     const wrapper = path.join(os.tmpdir(), "celerp-deelevate.cmd");
-    fs.writeFileSync(wrapper, `@echo off\r\nstart "" "${process.execPath}"\r\n`);
-    childProcess.execFileSync(runas, ["/trustlevel:0x20000", wrapper], {
-      stdio: "ignore", windowsHide: true,
+    // Foreground launch (NOT `start`): cmd stays the de-elevated app's parent so
+    // it isn't orphaned and killed. Spawn detached so the whole runas->cmd->app
+    // tree keeps running after this elevated instance exits.
+    fs.writeFileSync(wrapper, `@echo off\r\n"${process.execPath}"\r\n`);
+    const child = childProcess.spawn(runas, ["/trustlevel:0x20000", wrapper], {
+      detached: true, stdio: "ignore", windowsHide: true,
     });
+    child.on("error", (e) => console.error("[startup] de-elevation spawn error:", e));
+    child.unref();
     relaunched = true;
     console.log("[startup] elevated launch detected; relaunched de-elevated (Postgres cannot run as admin)");
   } catch (e) {

--- a/electron/app-main.js
+++ b/electron/app-main.js
@@ -939,6 +939,45 @@ ipcMain.handle("uninstall-keep-data", () => _doUninstallKeepData());
 // uninstall-delete-data: delete all user data then quit.
 ipcMain.handle("uninstall-delete-data", () => _doUninstallDeleteData());
 
+// ── Windows: de-elevate before doing anything else ──────────────────────────
+// The bundled Postgres refuses to run under a Windows administrator token, so a
+// user who launches Celerp elevated (Run as administrator, or a machine with UAC
+// turned off) would crash on boot. If we hold an admin token, relaunch ourselves
+// at a restricted "normal user" token (SAFER /trustlevel) in the same desktop
+// session and exit; the relaunched copy boots normally. This must run BEFORE the
+// single-instance lock so the relaunched copy can acquire it.
+function isWindowsElevated() {
+  if (process.platform !== "win32") return false;
+  try {
+    // `net session` succeeds only with administrator rights; it throws otherwise.
+    childProcess.execSync("net session", { stdio: "ignore", windowsHide: true });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+if (isWindowsElevated()) {
+  let relaunched = false;
+  try {
+    childProcess
+      .spawn("runas", ["/trustlevel:0x20000", process.execPath], {
+        detached: true, stdio: "ignore", windowsHide: true,
+      })
+      .unref();
+    relaunched = true;
+    console.log("[startup] elevated launch detected; relaunched de-elevated (Postgres cannot run as admin)");
+  } catch (e) {
+    // SAFER may be disabled by policy; fall through and boot (Postgres will then
+    // report the admin error, no worse than before).
+    console.error("[startup] de-elevation relaunch failed; continuing:", e);
+  }
+  if (relaunched) {
+    app.quit();
+    return;  // stop the elevated instance (CommonJS module: top-level return is valid)
+  }
+}
+
 // ── Single-instance lock ─────────────────────────────────────────────────────
 
 const gotLock = app.requestSingleInstanceLock();

--- a/electron/app-main.js
+++ b/electron/app-main.js
@@ -227,8 +227,12 @@ async function initialisePostgresWindows() {
         "--auth=password",
         "--username=celerp",
         `--pwfile=${pwfile}`,
-        "--lc-messages=en_US.UTF-8",
-      ], { stdio: ["ignore", out, out], env: { ...process.env, LC_MESSAGES: "en_US.UTF-8" } });
+        // Force a UTF-8 / C-locale cluster. Without this initdb adopts the Windows
+        // system locale (e.g. WIN1252), and the app's UTF-8 data + migrations fail
+        // against a WIN1252 database.
+        "--encoding=UTF8",
+        "--no-locale",
+      ], { stdio: ["ignore", out, out], env: { ...process.env } });
       proc.on("error", (e) => { trace("initdb spawn error: " + e.message); reject(e); });
       proc.on("exit", (code) => { trace("initdb exit code=" + code); (code === 0 ? resolve() : reject(new Error(`initdb exited with code ${code}`))); });
     });
@@ -1161,6 +1165,7 @@ app.whenReady().then(async () => {
       setupAutoUpdater();
     }
   } catch (err) {
+    try { fs.appendFileSync(path.join(LOG_DIR, "boot-trace.log"), `FATAL: ${err?.stack ?? err}\n`); } catch { /* ignore */ }
     showError("Celerp failed to start", err?.message ?? String(err));
     app.quit();
   }

--- a/electron/app-main.js
+++ b/electron/app-main.js
@@ -211,11 +211,11 @@ function pythonBin() {
 async function initialisePostgresWindows() {
   const logPath = path.join(LOG_DIR, "initdb-win.log");
   const trace = (m) => { try { fs.appendFileSync(logPath, m + "\n"); } catch { /* ignore */ } };
-  let initdbBin;
-  try {
-    const pkgJson = require.resolve("@embedded-postgres/windows-x64/package.json");
-    initdbBin = rewriteAsarPath(path.join(path.dirname(pkgJson), "native", "bin", "initdb.exe"));
-  } catch (e) { trace("resolve initdb failed: " + e.message); throw e; }
+  // The platform package's "exports" blocks require.resolve of its package.json, so
+  // locate the binary under the unpacked resources directly (asarUnpack keeps the
+  // native bins outside app.asar).
+  const initdbBin = path.join(process.resourcesPath, "app.asar.unpacked", "node_modules",
+    "@embedded-postgres", "windows-x64", "native", "bin", "initdb.exe");
   trace(`initdb bin=${initdbBin} exists=${fs.existsSync(initdbBin)}`);
   const pwfile = path.join(DATA_DIR, `pg-pwfile-${process.pid}`);
   fs.writeFileSync(pwfile, "celerp\n");

--- a/electron/app-main.js
+++ b/electron/app-main.js
@@ -39,23 +39,7 @@ function rewriteAsarPath(p) {
 // from 'child_process', so a local wrapper would not affect it.
 const _spawn = childProcess.spawn.bind(childProcess);
 childProcess.spawn = function spawn(cmd, args, opts) {
-  const resolved = rewriteAsarPath(cmd);
-  const child = _spawn(resolved, args, opts);
-  // TEMP DIAGNOSTIC: capture (and thereby drain) embedded-postgres child output to
-  // a file so we can see exactly where first-boot initdb wedges on Windows.
-  if (typeof resolved === "string" && resolved.includes("@embedded-postgres")) {
-    const _log = (tag) => (chunk) => {
-      try {
-        const dir = path.join(app.getPath("userData"), "celerp-data", "logs");
-        fs.mkdirSync(dir, { recursive: true });
-        fs.appendFileSync(path.join(dir, "pg-stdio.log"), `[${tag}] ${chunk}`);
-      } catch { /* ignore */ }
-    };
-    try { fs.appendFileSync(path.join(app.getPath("userData"), "celerp-data", "logs", "pg-stdio.log"), `\n=== spawn ${resolved} ${JSON.stringify(args)} ===\n`); } catch { /* ignore */ }
-    child.stdout?.on("data", _log("out"));
-    child.stderr?.on("data", _log("err"));
-  }
-  return child;
+  return _spawn(rewriteAsarPath(cmd), args, opts);
 };
 const spawn = childProcess.spawn;
 
@@ -221,6 +205,31 @@ function pythonBin() {
 
 // ── Startup sequence ─────────────────────────────────────────────────────────
 
+// Windows-only first-boot initdb that mirrors embedded-postgres's initialise()
+// (same args/auth so the cluster is identical and .start() can connect), but with
+// stdio disabled so initdb's stderr cannot fill an unread pipe and deadlock.
+async function initialisePostgresWindows() {
+  const pkgJson = require.resolve("@embedded-postgres/windows-x64/package.json");
+  const initdbBin = rewriteAsarPath(path.join(path.dirname(pkgJson), "native", "bin", "initdb.exe"));
+  const pwfile = path.join(DATA_DIR, `pg-pwfile-${process.pid}`);
+  fs.writeFileSync(pwfile, "celerp\n");
+  try {
+    await new Promise((resolve, reject) => {
+      const proc = _spawn(initdbBin, [
+        `--pgdata=${PG_DATA_DIR}`,
+        "--auth=password",
+        "--username=celerp",
+        `--pwfile=${pwfile}`,
+        "--lc-messages=en_US.UTF-8",
+      ], { stdio: ["ignore", "ignore", "ignore"], env: { ...process.env, LC_MESSAGES: "en_US.UTF-8" } });
+      proc.on("error", reject);
+      proc.on("exit", (code) => (code === 0 ? resolve() : reject(new Error(`initdb exited with code ${code}`))));
+    });
+  } finally {
+    try { fs.rmSync(pwfile, { force: true }); } catch { /* ignore */ }
+  }
+}
+
 async function startPostgres(dbPort) {
   fs.mkdirSync(PG_DATA_DIR, { recursive: true });
   fs.mkdirSync(LOG_DIR, { recursive: true });
@@ -242,7 +251,18 @@ async function startPostgres(dbPort) {
   // on an existing data directory causes initdb to exit non-zero and crash.
   const pgVersionFile = path.join(PG_DATA_DIR, "PG_VERSION");
   if (!fs.existsSync(pgVersionFile)) {
-    await pgInstance.initialise();
+    if (process.platform === "win32") {
+      // embedded-postgres is ESM and imports the builtin child_process.spawn, so
+      // our spawn wrapper can't reach it; its initialise() reads only initdb's
+      // stdout, leaving stderr unread. On Windows the small anonymous-pipe buffer
+      // fills, initdb blocks on the write and never exits — first boot hangs. Run
+      // initdb ourselves with stdio disabled (it can't block), producing the same
+      // cluster initialise() would; the PG_VERSION it writes makes the guard skip
+      // embedded-postgres's own initialise().
+      await initialisePostgresWindows();
+    } else {
+      await pgInstance.initialise();
+    }
   }
   await pgInstance.start();
 

--- a/electron/app-main.js
+++ b/electron/app-main.js
@@ -960,12 +960,17 @@ function isWindowsElevated() {
 if (isWindowsElevated()) {
   let relaunched = false;
   try {
-    // Full path: Node's spawn/execFile does not resolve a bare "runas" (no shell)
-    // to runas.exe. Run it synchronously so a launch failure is caught here rather
-    // than lost as an async 'error' event. runas launches the de-elevated copy and
-    // returns; that copy keeps running after we exit.
+    // runas /trustlevel cannot launch the GUI exe directly (it produces no running
+    // process), but launching it through a tiny cmd wrapper that `start`s the app
+    // works (verified: the de-elevated copy boots and Postgres runs). `start`
+    // detaches the app so the wrapper/runas return immediately - execFileSync then
+    // catches a launch failure without blocking. Full runas path: Node won't
+    // resolve a bare "runas" without a shell.
+    const os = require("os");
     const runas = path.join(process.env.SystemRoot || "C:\\Windows", "System32", "runas.exe");
-    childProcess.execFileSync(runas, ["/trustlevel:0x20000", process.execPath], {
+    const wrapper = path.join(os.tmpdir(), "celerp-deelevate.cmd");
+    fs.writeFileSync(wrapper, `@echo off\r\nstart "" "${process.execPath}"\r\n`);
+    childProcess.execFileSync(runas, ["/trustlevel:0x20000", wrapper], {
       stdio: "ignore", windowsHide: true,
     });
     relaunched = true;


### PR DESCRIPTION
## Summary

Hardens Windows first-boot and adds an end-to-end Windows boot smoke that requires a real database-ready (`db:ok`) health check, so CI validates the packaged binary the way it runs on a user's machine.

## Changes

- **Windows first-boot:** initialize the bundled database with explicit UTF-8 encoding and controlled process I/O, so cluster creation and migrations complete reliably on a fresh install.
- **Post-migration grants:** run in-process via SQLAlchemy (cross-platform) instead of a platform-specific shell command.
- **CI boot smoke:** launches the packaged Windows app as a standard (non-admin) user and waits for `/health/ready` -> `db:ok`, mirroring a real install; on failure it captures the app + database logs for fast diagnosis. The Linux sandbox bit is handled and the Linux/Mac smokes are retained.

## Verification

Windows and Linux build + boot smoke are green with a real `db:ok`. The Mac binary is rebuilt at the release tag as usual.
