### PR TITLE
fix(inventory): merge sums pieces and tolerates mixed types (#197)

### DIFF
--- a/default_modules/celerp-inventory/celerp_inventory/routes.py
+++ b/default_modules/celerp-inventory/celerp_inventory/routes.py
@@ -8,7 +8,7 @@ import io
 import uuid
 from datetime import datetime, timezone
 
-from decimal import Decimal
+from decimal import Decimal, InvalidOperation
 
 from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import StreamingResponse
@@ -58,6 +58,21 @@ def _read_pieces(state: dict) -> float | None:
     if raw is None:
         raw = (state.get("attributes") or {}).get("pieces")
     return float(raw) if raw not in (None, "") else None
+
+
+def _num_pieces(raw) -> Decimal | None:
+    """Coerce a stored `pieces` value (int / float / numeric str) to a Decimal.
+
+    Treats None / "" (and anything non-numeric) as *unset* → None. Different write paths
+    persist pieces as int, float, or string; coercing here lets the merge compare and sum
+    them uniformly (the rest of the system already coerces via float()/int(float())).
+    """
+    if raw is None or raw == "":
+        return None
+    try:
+        return Decimal(str(raw))
+    except (InvalidOperation, ValueError, TypeError):
+        return None
 
 
 def _read_float(state: dict, key: str) -> float | None:
@@ -2004,6 +2019,18 @@ async def merge_items(payload: MergeBody, company_id=Depends(get_current_company
 
     resolved_attrs: dict = {}
     for key in all_attr_keys:
+        if key == "pieces":
+            # `pieces` is an EXTENSIVE/additive count (unlike intensive numeric attributes such as
+            # size or grade), so it is summed rather than collapsed. Coerce every source's value to
+            # a number (int/float/str are equivalent). If every source has pieces set → the merged
+            # item's pieces is the sum; if any source has it unset, the true total is unknowable, so
+            # the merged item carries NO pieces. See issue #197.
+            coerced = [_num_pieces((p.state.get("attributes") or {}).get("pieces")) for p in source_projections]
+            if coerced and all(v is not None for v in coerced):
+                total = sum(coerced, Decimal(0))
+                resolved_attrs["pieces"] = int(total) if total == total.to_integral_value() else float(total)
+            # else: at least one source lacks pieces → omit the key (no value)
+            continue
         # Collect raw attribute values (preserve original type for numeric fields)
         raw_values = [(p.state.get("attributes") or {}).get(key) for p in source_projections if key in (p.state.get("attributes") or {})]
         str_values = [str(v) for v in raw_values]

--- a/tests/test_merge_pieces.py
+++ b/tests/test_merge_pieces.py
@@ -1,0 +1,109 @@
+# Copyright (c) 2026 Noah Severs
+# SPDX-License-Identifier: LicenseRef-Proprietary
+"""Regression tests for https://github.com/celerp/celerp/issues/197.
+
+Merging stocked items must handle the additive `pieces` count correctly:
+
+1. **Type-insensitive** — `pieces` may be stored as `int` / `float` / numeric `str`
+   (different write paths produce different types). The merge must coerce to a number
+   before comparing, so two items holding the same count merge cleanly.
+2. **Summed** — `pieces` is additive: if **every** source has `pieces` set, the merged
+   item's `pieces` is the **sum**; if **at least one** source has it unset, the merged
+   item has **no `pieces`** (an unknowable total must not be guessed).
+
+These are the six scenarios documented in `data/bug12.md`. They FAIL against the current
+merge (which compares raw `str(v)` and never sums) and pass once the merge coerces and sums.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+_UNSET = object()  # sentinel: source has no `pieces` attribute at all
+
+
+async def _token(client) -> str:
+    email = f"gems-{uuid.uuid4().hex[:8]}@example.com"
+    r = await client.post(
+        "/auth/register",
+        json={"company_name": "Gems & Jewelry", "email": email, "name": "Owner", "password": "pw"},
+    )
+    assert r.status_code == 200, r.text
+    return r.json()["access_token"]
+
+
+async def _seed(client, headers, sku: str, pieces, *, qty: float = 32.0) -> str:
+    """Create a carat-sold stone with `attributes.pieces` of the given value/type.
+
+    `pieces is _UNSET` leaves the attribute off entirely (the "unset" case).
+    """
+    payload: dict = {
+        "sku": sku,
+        "name": sku,
+        "quantity": qty,
+        "sell_by": "carat",
+        "category": "colored_stone",
+    }
+    if pieces is not _UNSET:
+        payload["attributes"] = {"pieces": pieces}
+    r = await client.post("/items", json=payload, headers=headers)
+    assert r.status_code == 200, r.text
+    return r.json()["id"]
+
+
+async def _merge(client, headers, source_ids: list[str], target_id: str) -> str:
+    r = await client.post(
+        "/items/merge",
+        json={"source_entity_ids": source_ids, "target_sku_from": target_id},
+        headers=headers,
+    )
+    assert r.status_code == 200, r.text
+    return r.json()["id"]
+
+
+async def _read_pieces(client, headers, item_id: str):
+    """Return the merged item's `pieces` (GET flattens attributes → top-level)."""
+    r = await client.get(f"/items/{item_id}", headers=headers)
+    assert r.status_code == 200, r.text
+    return r.json().get("pieces")
+
+
+def _assert_pieces(actual, expected) -> None:
+    if expected is None:
+        assert actual in (None, ""), f"expected no pieces, got {actual!r}"
+    else:
+        assert actual is not None and int(float(actual)) == expected, (
+            f"expected pieces == {expected}, got {actual!r}"
+        )
+
+
+# (name, source A pieces, source B pieces, expected merged pieces) — see data/bug12.md
+_SCENARIOS = [
+    ("scenario1_str_str_same",   "5",  "5",    10),   # same value, both str  -> sum
+    ("scenario2_int_float_same",  16,  16.0,   32),   # same value, int vs float -> coerce, then sum
+    ("scenario3_int_int_same",     8,   8,     16),   # same value, both int   -> sum
+    ("scenario4_str_str_diff",   "6",  "4",    10),   # different values, str  -> sum
+    ("scenario5_int_int_diff",    16,   8,     24),   # different values, int  -> sum
+    ("scenario6_set_unset",      "5", _UNSET,  None), # one set, one unset     -> no pieces
+]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "name, a_pieces, b_pieces, expected",
+    _SCENARIOS,
+    ids=[s[0] for s in _SCENARIOS],
+)
+async def test_merge_pieces(client, name, a_pieces, b_pieces, expected) -> None:
+    token = await _token(client)
+    headers = {"Authorization": f"Bearer {token}"}
+
+    a = await _seed(client, headers, "MERGE-A", a_pieces)
+    b = await _seed(client, headers, "MERGE-B", b_pieces)
+
+    merged_id = await _merge(client, headers, [a, b], a)
+    merged_pieces = await _read_pieces(client, headers, merged_id)
+
+    _assert_pieces(merged_pieces, expected)

--- a/tests/test_routers/test_items.py
+++ b/tests/test_routers/test_items.py
@@ -1610,14 +1610,17 @@ async def test_merge_then_split_does_not_500(client):
 
 @pytest.mark.asyncio
 async def test_merge_numeric_attrs_stored_as_numbers(client):
-    """An AGREEING numeric attribute carries through after merge as a number, not a string.
-    (Conflicting numeric attributes get no value — see test_merge_dropdown_fields_use_value_or_mixed_never_sum.)
+    """An AGREEING (intensive) numeric attribute carries through after merge as a number, not a string.
+    (Conflicting numeric attributes get no value — see test_merge_dropdown_fields_use_value_or_mixed_never_sum.
+    NOTE: `pieces` is intentionally NOT used here — it is an *additive* count that is summed on merge,
+    not carried through; see tests/test_merge_pieces.py / issue #197. `size` is intensive, so it carries
+    through unchanged.)
     """
     token = await _token(client)
     h = {"Authorization": f"Bearer {token}"}
     loc = (await client.post("/companies/me/locations", json={"name": "WH-MNA", "type": "warehouse"}, headers=h)).json()
-    r1 = await client.post("/items", json={"sku": "MNA-A", "name": "Item A", "quantity": 8.0, "sell_by": "carat", "location_id": loc["id"], "attributes": {"pieces": 8}}, headers=h)
-    r2 = await client.post("/items", json={"sku": "MNA-B", "name": "Item B", "quantity": 12.0, "sell_by": "carat", "location_id": loc["id"], "attributes": {"pieces": 8}}, headers=h)
+    r1 = await client.post("/items", json={"sku": "MNA-A", "name": "Item A", "quantity": 8.0, "sell_by": "carat", "location_id": loc["id"], "attributes": {"size": 8}}, headers=h)
+    r2 = await client.post("/items", json={"sku": "MNA-B", "name": "Item B", "quantity": 12.0, "sell_by": "carat", "location_id": loc["id"], "attributes": {"size": 8}}, headers=h)
     assert r1.status_code == 200
     assert r2.status_code == 200
     id1, id2 = r1.json()["id"], r2.json()["id"]
@@ -1625,11 +1628,11 @@ async def test_merge_numeric_attrs_stored_as_numbers(client):
     assert mr.status_code == 200, mr.text
     merged_id = mr.json()["id"]
     item = (await client.get(f"/items/{merged_id}", headers=h)).json()
-    pieces_val = (item.get("attributes") or {}).get("pieces")
-    if pieces_val is None:
-        pieces_val = item.get("pieces")
-    assert isinstance(pieces_val, (int, float)), f"pieces should be numeric, got {type(pieces_val)}: {pieces_val!r}"
-    assert int(float(pieces_val)) == 8
+    size_val = (item.get("attributes") or {}).get("size")
+    if size_val is None:
+        size_val = item.get("size")
+    assert isinstance(size_val, (int, float)), f"size should be numeric, got {type(size_val)}: {size_val!r}"
+    assert int(float(size_val)) == 8
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What this changes

The merge compared each source's raw `pieces` value as a string and never summed it, so:
- equal counts stored as different types (int 16 vs float 16.0 vs "16") were treated as conflicting and dropped;
- it kept a single value instead of adding (6 + 4 -> nothing, not 10);
- a source missing pieces was ignored, wrongly keeping the other's value.

Fix, inside `merge_items` only:
- add `_num_pieces()` to coerce int/float/numeric-str -> Decimal (None/"" = unset), matching how invoices/fulfillment already read pieces;
- treat `pieces` as an additive count: if every source has it set, the merged value is the sum; if any source is unset, the merged item has no pieces. Other (intensive) numeric attributes keep the agree-or-no-value rule.

Tests: new tests/test_merge_pieces.py covers the 6 scenarios from the issue. test_merge_numeric_attrs_stored_as_numbers switched from `pieces` to an intensive attribute (`size`), since pieces now sums.

No storage change, no migration. gross_weight (also additive) is left for a separate issue.

## Checklist

- [X] Tests added or updated, and the relevant suites pass locally
- [X] License headers are correct for the paths touched (see `LICENSING.md`; enforced by `scripts/licenses.py`)
