### PR TITLE
fix(inventory): merge reconciles prices/costs on totals (#199)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,6 +83,7 @@ scripts/pdf_screenshots/
 scripts/verify_pdfs.py
 scripts/pdf_to_png.py
 data/
+memory/
 
 # Nested repos (separate deployments)
 celerp-cloud/

--- a/default_modules/celerp-inventory/celerp_inventory/projections.py
+++ b/default_modules/celerp-inventory/celerp_inventory/projections.py
@@ -171,7 +171,7 @@ def apply_item_event(state: dict, event_type: str, data: dict) -> dict:
                 # _recompute_cost. cost_price is a unit value (× qty -> base); cost_total is the base
                 # directly. Clearing either removes the base.
                 new_val = change.get("new")
-                if new_val is None:
+                if new_val in (None, ""):
                     current.pop("cost_base", None)
                     current.pop("cost_price", None)
                     current.pop("cost_total", None)
@@ -183,7 +183,13 @@ def apply_item_event(state: dict, event_type: str, data: dict) -> dict:
                 else:  # cost_total
                     current["cost_base"] = round(float(new_val), 2)
             else:
-                current[field] = change.get("new")
+                # Clearing any other field (None/"") unsets it — remove the key rather than storing
+                # an empty string or null, so the field reads as truly absent (issue #202).
+                new_val = change.get("new")
+                if new_val in (None, ""):
+                    current.pop(field, None)
+                else:
+                    current[field] = new_val
         current = _sync_expiry_from_attributes(current)
         _recompute_cost(current)
     elif event_type == "item.pricing.set":

--- a/default_modules/celerp-inventory/celerp_inventory/routes.py
+++ b/default_modules/celerp-inventory/celerp_inventory/routes.py
@@ -1985,13 +1985,19 @@ async def merge_items(payload: MergeBody, company_id=Depends(get_current_company
     total_qty = sum(float(p.state.get("quantity") or 0) for p in source_projections)
     weights = [_read_float(p.state, "weight") for p in source_projections if p.state.get("weight") not in (None, "")]
     total_weight = sum(weights) if weights else None
-    # Compute merged cost_total: sum of all source cost_totals (Q2=Option A)
-    merged_cost_total = sum(
-        float(p.state.get("cost_total") or 0) or (
-            float(p.state.get("cost_price") or 0) * float(p.state.get("quantity") or 0)
-        )
-        for p in source_projections
-    ) or None
+    # Merged cost_total (issue #199): reconcile on the source TOTALS — if every source has a cost,
+    # the merged cost is their sum; if ANY source has no cost, the true total is unknowable, so the
+    # merged item carries NO cost (None) rather than silently counting the missing one as 0.
+    def _src_cost_total(p: Projection):
+        ct = p.state.get("cost_total")
+        if ct not in (None, ""):
+            return float(ct)
+        cp = p.state.get("cost_price")
+        if cp not in (None, ""):
+            return float(cp) * float(p.state.get("quantity") or 0)
+        return None  # unset
+    _src_costs = [_src_cost_total(p) for p in source_projections]
+    merged_cost_total = sum(_src_costs) if _src_costs and all(c is not None for c in _src_costs) else None
 
     expiry_dates = sorted(e for p in source_projections if (e := _get_expiry(p)))
     earliest_expiry = expiry_dates[0] if expiry_dates else None
@@ -2150,13 +2156,28 @@ async def merge_items(payload: MergeBody, company_id=Depends(get_current_company
                 metadata_={"reason": "from_merge"},
             )
 
-    # Emit pricing events for all price fields from target; emit cost_total (not cost_price) for cost.
+    # Emit pricing events for the merged money fields (issue #199). Each *_price field is a PER-UNIT
+    # price, so it is reconciled on the source TOTALS (unit × qty): if every source has the price set,
+    # the merged total is their sum (stored back as a unit = total / merged_qty); if ANY source lacks
+    # the price, the merged item carries NO value for it (omit) rather than copying the target's price
+    # or treating the missing one as 0. cost_total is already a total (computed above).
     price_fields: dict = {}
     if resulting_cost is not None:
         price_fields["cost_total"] = resulting_cost
-    for pf, val in target_state.items():
-        if pf.endswith("_price") and pf != "cost_price" and val is not None:
-            price_fields[pf] = val
+    _price_keys = {
+        k for p in source_projections for k in p.state
+        if k.endswith("_price") and k != "cost_price"
+    }
+    _merge_qty = float(resulting_qty) or 0.0
+    for pk in _price_keys:
+        src_totals = []
+        for p in source_projections:
+            unit = p.state.get(pk)
+            src_totals.append(None if unit in (None, "") else float(unit) * float(p.state.get("quantity") or 0))
+        if src_totals and all(t is not None for t in src_totals):
+            merged_total = sum(src_totals)
+            price_fields[pk] = round(merged_total / _merge_qty, 10) if _merge_qty else merged_total
+        # else: at least one source lacks this price → omit (merged item has no value for it)
 
     for price_type, price_val in price_fields.items():
         await emit_event(

--- a/default_modules/celerp-inventory/celerp_inventory/routes.py
+++ b/default_modules/celerp-inventory/celerp_inventory/routes.py
@@ -872,6 +872,15 @@ async def patch_item(entity_id: str, payload: ItemPatch, company_id=Depends(get_
     if blocked:
         raise HTTPException(status_code=403, detail=f"Role '{role}' cannot modify restricted fields: {sorted(blocked)}")
 
+    # Normalize "clear" gestures: an empty-string new value means "unset the field" -> None (issue #202).
+    # Without this, an optional field can't be returned to None — barcode rejects "" (digit check), cost
+    # crashes on float(""), and prices/category/text store "" instead of clearing. Required fields keep
+    # their own handling. The projection handler then removes the key when new is None.
+    _CLEAR_PROTECTED = {"name", "sell_by", "quantity"}
+    for _f, _fc in payload.fields_changed.items():
+        if _f not in _CLEAR_PROTECTED and isinstance(_fc, dict) and _fc.get("new") == "":
+            _fc["new"] = None
+
     # Validate sell_by change
     if "sell_by" in changed_keys:
         new_sell_by = (payload.fields_changed["sell_by"] or {}).get("new")

--- a/memory/fix-receive-goods-bugs.md
+++ b/memory/fix-receive-goods-bugs.md
@@ -1,1 +1,0 @@
-scratch

--- a/tests/test_browser/test_clear_fields_ui.py
+++ b/tests/test_browser/test_clear_fields_ui.py
@@ -1,0 +1,97 @@
+# Copyright (c) 2026 Noah Severs
+# SPDX-License-Identifier: LicenseRef-Proprietary
+"""Browser regression for https://github.com/celerp/celerp/issues/202.
+
+An optional field that is set must be clearable from the UI (not just the API): double-click the cell,
+blank the input (or pick the blank option for a select), and the field unsets. Today the numeric cell
+errors on empty, and a text/barcode/select clear is rejected or stored as "", so the value can't be
+removed.
+
+Covers a numeric field (retail_price), a text field (barcode), and a SELECT field (a category
+attribute). The cleared state is polled through the API (htmx PATCH is async; avoids networkidle,
+which never settles on a page with a live event stream). FAILS before the fix.
+"""
+import time
+import uuid
+
+import pytest
+
+pytestmark = pytest.mark.browser
+
+
+@pytest.fixture()
+def item_id(api):
+    barcode = str(900000 + (uuid.uuid4().int % 90000))  # unique per item
+    r = api.post("/items", json={
+        "sku": f"CLR-UI-{uuid.uuid4().hex[:6]}",
+        "sell_by": "piece",
+        "name": "Clear UI Item",
+        "quantity": 1,
+        "category": "book",
+        "barcode": barcode,
+        "retail_price": 12,
+    })
+    assert r.status_code in {200, 201}, r.text
+    return r.json()["id"]
+
+
+def _poll_cleared(api, eid: str, field: str, timeout: float = 8.0) -> bool:
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if api.get(f"/items/{eid}").json().get(field) is None:
+            return True
+        time.sleep(0.25)
+    return False
+
+
+def _open_editor(page, ui_server, eid: str, field: str, td_only: bool = True):
+    page.goto(f"{ui_server}/inventory/{eid}", wait_until="domcontentloaded")
+    # Core fields render as <td> cells; category-schema attributes render in the attributes card
+    # (not a <td>), so allow a broader selector for those.
+    sel = f'td[hx-get$="/field/{field}/edit"]' if td_only else f'[hx-get$="/field/{field}/edit"]'
+    cell = page.locator(sel).first
+    cell.wait_for(state="visible", timeout=8000)
+    cell.dblclick()                     # cells edit on double-click
+
+
+def test_clear_barcode_via_ui(page, ui_server, api, item_id):
+    assert api.get(f"/items/{item_id}").json().get("barcode") is not None  # sanity: set
+    _open_editor(page, ui_server, item_id, "barcode")
+    inp = page.locator('[name="value"]').first
+    inp.wait_for(state="visible", timeout=5000)
+    inp.fill("")
+    page.keyboard.press("Enter")
+    assert _poll_cleared(api, item_id, "barcode"), "barcode not cleared from UI"
+
+
+def test_clear_retail_price_via_pricing_tab(page, ui_server, api, item_id):
+    """Prices are edited on the Pricing tab (autosave form) — blanking the input must clear it."""
+    assert api.get(f"/items/{item_id}").json().get("retail_price") == 12  # sanity: set
+    page.goto(f"{ui_server}/inventory/{item_id}?tab=pricing", wait_until="domcontentloaded")
+    inp = page.locator('input[name="retail_price"]').first
+    inp.wait_for(state="visible", timeout=8000)
+    inp.fill("")          # blank the price
+    inp.blur()            # autosaves on change
+    assert _poll_cleared(api, item_id, "retail_price"), "retail_price not cleared from Pricing tab"
+
+
+def test_clear_select_field_via_ui(page, ui_server, api):
+    """A SELECT (dropdown) field is cleared by choosing the blank '(clear)' option."""
+    r = api.patch("/companies/me/category-schema/book", json={"fields": [
+        {"key": "format", "label": "Format", "type": "select",
+         "options": ["Hardcover", "Paperback"], "required": False},
+    ]})
+    assert r.status_code in {200, 201}, r.text
+    eid = api.post("/items", json={
+        "sku": f"CLR-SEL-{uuid.uuid4().hex[:6]}", "sell_by": "piece",
+        "name": "Sel Item", "quantity": 1, "category": "book",
+    }).json()["id"]
+    r = api.patch(f"/items/{eid}", json={"fields_changed": {"format": {"old": None, "new": "Hardcover"}}})
+    assert r.status_code == 200, r.text
+    assert api.get(f"/items/{eid}").json().get("format") == "Hardcover"  # sanity: set
+
+    _open_editor(page, ui_server, eid, "format", td_only=False)
+    sel = page.locator('select[name="value"]').first
+    sel.wait_for(state="visible", timeout=5000)
+    sel.select_option(value="")          # the blank "(clear)" option (issue #202)
+    assert _poll_cleared(api, eid, "format"), "select field not cleared from UI"

--- a/tests/test_clear_fields.py
+++ b/tests/test_clear_fields.py
@@ -1,0 +1,116 @@
+# Copyright (c) 2026 Noah Severs
+# SPDX-License-Identifier: LicenseRef-Proprietary
+"""Regression tests for https://github.com/celerp/celerp/issues/202.
+
+An OPTIONAL field that an item can exist without must be clearable back to None. Today, once set, a
+field can't be returned to empty: a blank value is rejected (barcode), crashes (cost), or is stored
+as "" / null instead of being unset (prices, category, text). A "clear" (empty `new`) must unset the
+field — removing it (None/absent), not storing an empty string.
+
+These PATCH the data API with an empty value and assert the field reads back unset. They FAIL today
+(barcode 422, cost ValueError, price/category keep a value) and pass once "clear → None → unset" works.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+
+async def _token(client) -> str:
+    email = f"clear-{uuid.uuid4().hex[:8]}@example.com"
+    r = await client.post(
+        "/auth/register",
+        json={"company_name": "Acme", "email": email, "name": "Owner", "password": "pw"},
+    )
+    assert r.status_code == 200, r.text
+    return r.json()["access_token"]
+
+
+async def _seed(client, headers, **fields) -> str:
+    payload = {"sku": "CLR-1", "name": "Item", "quantity": 1, "sell_by": "piece", "category": "book"}
+    payload.update(fields)
+    r = await client.post("/items", json=payload, headers=headers)
+    assert r.status_code == 200, r.text
+    return r.json()["id"]
+
+
+async def _get(client, headers, item_id: str) -> dict:
+    r = await client.get(f"/items/{item_id}", headers=headers)
+    assert r.status_code == 200, r.text
+    return r.json()
+
+
+async def _clear(client, headers, item_id: str, field: str):
+    """Clear a field the way the UI does — PATCH with an empty `new`. Must succeed (200)."""
+    r = await client.patch(
+        f"/items/{item_id}",
+        json={"fields_changed": {field: {"old": None, "new": ""}}},
+        headers=headers,
+    )
+    assert r.status_code == 200, f"clearing {field} should succeed, got {r.status_code}: {r.text}"
+
+
+@pytest.mark.asyncio
+async def test_clear_retail_price(client):
+    h = {"Authorization": f"Bearer {await _token(client)}"}
+    iid = await _seed(client, h, retail_price=10)
+    assert (await _get(client, h, iid)).get("retail_price") == 10  # sanity: set
+    await _clear(client, h, iid, "retail_price")
+    assert (await _get(client, h, iid)).get("retail_price") is None
+
+
+@pytest.mark.asyncio
+async def test_clear_cost_total(client):
+    h = {"Authorization": f"Bearer {await _token(client)}"}
+    iid = await _seed(client, h, cost_total=5)
+    assert (await _get(client, h, iid)).get("cost_total") == 5  # sanity: set
+    await _clear(client, h, iid, "cost_total")
+    assert (await _get(client, h, iid)).get("cost_total") is None
+
+
+@pytest.mark.asyncio
+async def test_clear_barcode(client):
+    h = {"Authorization": f"Bearer {await _token(client)}"}
+    iid = await _seed(client, h, barcode="12345")
+    assert (await _get(client, h, iid)).get("barcode") == "12345"  # sanity: set
+    await _clear(client, h, iid, "barcode")
+    assert (await _get(client, h, iid)).get("barcode") is None
+
+
+@pytest.mark.asyncio
+async def test_clear_category(client):
+    h = {"Authorization": f"Bearer {await _token(client)}"}
+    iid = await _seed(client, h, category="book")
+    assert (await _get(client, h, iid)).get("category") == "book"  # sanity: set
+    await _clear(client, h, iid, "category")
+    assert (await _get(client, h, iid)).get("category") is None
+
+
+@pytest.mark.asyncio
+async def test_clear_select_field(client):
+    """A select-typed (dropdown) field must also be clearable back to None."""
+    h = {"Authorization": f"Bearer {await _token(client)}"}
+    # Define a select attribute on the `book` category.
+    r = await client.patch(
+        "/companies/me/category-schema/book",
+        json={"fields": [
+            {"key": "format", "label": "Format", "type": "select",
+             "options": ["Hardcover", "Paperback"], "required": False},
+        ]},
+        headers=h,
+    )
+    assert r.status_code == 200, r.text
+    iid = await _seed(client, h, category="book")
+    # Set the select value, then confirm it's set.
+    r = await client.patch(
+        f"/items/{iid}",
+        json={"fields_changed": {"format": {"old": None, "new": "Hardcover"}}},
+        headers=h,
+    )
+    assert r.status_code == 200, r.text
+    assert (await _get(client, h, iid)).get("format") == "Hardcover"  # sanity: set
+    # Clear it.
+    await _clear(client, h, iid, "format")
+    assert (await _get(client, h, iid)).get("format") is None

--- a/tests/test_merge_prices.py
+++ b/tests/test_merge_prices.py
@@ -1,0 +1,131 @@
+# Copyright (c) 2026 Noah Severs
+# SPDX-License-Identifier: LicenseRef-Proprietary
+"""Regression tests for https://github.com/celerp/celerp/issues/199.
+
+Merging items must reconcile money fields across the source items with an all-or-nothing rule,
+operating on the source **TOTALS** (not unit prices):
+
+- if **every** source has the value set  -> merged value = the SUM of the source totals;
+- if **at least one** source is unset    -> merged value = None (unevaluated), never 0/dropped.
+
+Two bugs this guards against:
+- the non-target source's price being silently dropped (merged total = target_unit x merged_qty),
+  e.g. total $50 + total $50,000 -> $100 instead of $50,050;
+- a missing source price/cost being treated as 0, so the merged price can land below cost.
+
+IMPORTANT — unit price vs total: `retail_price` / `wholesale_price` are *per-unit* prices (rates); the
+business **total** is `unit_price x quantity`. `cost_total` is already a total. These tests are written
+purely in **totals**: the seed helper converts a desired total into the stored unit price (÷ qty), and
+the asserts read totals back (`unit_price x quantity`). Quantities are >1 on purpose so unit != total
+and the "sum the totals" requirement is unambiguous.
+
+They FAIL against the current merge (prices copied from target only; cost summed with missing-as-0)
+and pass once the merge sums totals / drops to None.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+
+async def _token(client) -> str:
+    email = f"books-{uuid.uuid4().hex[:8]}@example.com"
+    r = await client.post(
+        "/auth/register",
+        json={"company_name": "Books & Media", "email": email, "name": "Owner", "password": "pw"},
+    )
+    assert r.status_code == 200, r.text
+    return r.json()["access_token"]
+
+
+async def _seed(client, headers, sku: str, *, qty: float,
+                retail_total=None, wholesale_total=None, cost_total=None) -> str:
+    """Create a piece-sold `book` item from desired **TOTAL** amounts.
+
+    retail/wholesale are stored per-unit, so we convert: unit = total / qty. cost_total is a total.
+    """
+    payload: dict = {"sku": sku, "name": sku, "quantity": qty, "sell_by": "piece", "category": "book"}
+    if retail_total is not None:
+        payload["retail_price"] = retail_total / qty
+    if wholesale_total is not None:
+        payload["wholesale_price"] = wholesale_total / qty
+    if cost_total is not None:
+        payload["cost_total"] = cost_total
+    r = await client.post("/items", json=payload, headers=headers)
+    assert r.status_code == 200, r.text
+    return r.json()["id"]
+
+
+async def _merge(client, headers, source_ids: list[str], target_id: str) -> str:
+    r = await client.post(
+        "/items/merge",
+        json={"source_entity_ids": source_ids, "target_sku_from": target_id},
+        headers=headers,
+    )
+    assert r.status_code == 200, r.text
+    return r.json()["id"]
+
+
+async def _get(client, headers, item_id: str) -> dict:
+    r = await client.get(f"/items/{item_id}", headers=headers)
+    assert r.status_code == 200, r.text
+    return r.json()
+
+
+def _unit_total(item: dict, unit_field: str):
+    """Business total for a per-unit-priced field = unit_price × quantity (None if unset)."""
+    unit = item.get(unit_field)
+    if unit is None:
+        return None
+    return round(float(unit) * float(item.get("quantity") or 0), 2)
+
+
+# ── All sources priced → merged TOTAL is the SUM of the source totals ───────────────────────────
+
+@pytest.mark.asyncio
+async def test_merge_sums_retail_total_when_all_set(client):
+    """Scenario B: total $50 (target) + total $50,000 → merged retail total $50,050, not $100."""
+    h = {"Authorization": f"Bearer {await _token(client)}"}
+    a = await _seed(client, h, "BOOK-A", qty=2, retail_total=50)       # unit 25 × 2 = 50
+    b = await _seed(client, h, "BOOK-B", qty=2, retail_total=50000)    # unit 25000 × 2 = 50000
+    merged = await _get(client, h, await _merge(client, h, [a, b], a))
+    assert _unit_total(merged, "retail_price") == 50050.0, f"got {_unit_total(merged, 'retail_price')!r}"
+
+
+@pytest.mark.asyncio
+async def test_merge_sums_wholesale_total_when_all_set(client):
+    h = {"Authorization": f"Bearer {await _token(client)}"}
+    a = await _seed(client, h, "BOOK-A", qty=2, wholesale_total=50)
+    b = await _seed(client, h, "BOOK-B", qty=2, wholesale_total=50000)
+    merged = await _get(client, h, await _merge(client, h, [a, b], a))
+    assert _unit_total(merged, "wholesale_price") == 50050.0, f"got {_unit_total(merged, 'wholesale_price')!r}"
+
+
+@pytest.mark.asyncio
+async def test_merge_sums_cost_total_when_all_set(client):
+    """Control: cost already sums when every source is costed (total $5 + total $20 → $25)."""
+    h = {"Authorization": f"Bearer {await _token(client)}"}
+    a = await _seed(client, h, "BOOK-A", qty=2, cost_total=5)
+    b = await _seed(client, h, "BOOK-B", qty=2, cost_total=20)
+    merged = await _get(client, h, await _merge(client, h, [a, b], a))
+    assert merged.get("cost_total") is not None and round(float(merged["cost_total"]), 2) == 25.0
+
+
+# ── At least one source unset → merged TOTAL is None (unevaluated), never 0 / target-only ────────
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("kind", ["retail", "wholesale", "cost"])
+async def test_merge_total_none_when_any_source_unset(client, kind):
+    """Target HAS the value, the other source does NOT → merged must be None, not the target's value
+    (Scenario A: a missing source price/cost must not be treated as 0)."""
+    h = {"Authorization": f"Bearer {await _token(client)}"}
+    seed_kw = {"retail": {"retail_total": 100}, "wholesale": {"wholesale_total": 100}, "cost": {"cost_total": 50}}[kind]
+    read_field = {"retail": "retail_price", "wholesale": "wholesale_price", "cost": "cost_total"}[kind]
+    a = await _seed(client, h, "BOOK-A", qty=2, **seed_kw)   # target, priced
+    b = await _seed(client, h, "BOOK-B", qty=2)              # other source, unpriced
+    merged = await _get(client, h, await _merge(client, h, [a, b], a))
+    assert merged.get(read_field) is None, (
+        f"{kind} total should be None when a source is unset, got {merged.get(read_field)!r}"
+    )

--- a/ui/components/table.py
+++ b/ui/components/table.py
@@ -822,7 +822,11 @@ def editable_cell(
         else:
             _opt_items = [(o, o) if isinstance(o, str) else o for o in options]
             input_el = Select(
-                *([] if display_val else [Option("", value="", disabled=True, selected=True)]),
+                # Offer a selectable blank "(clear)" option so a SET optional select can be unset
+                # (issue #202); `status` stays required. When empty, show a disabled placeholder.
+                *([Option("— clear —", value="")] if (display_val and cell_type == "select")
+                  else [] if display_val
+                  else [Option("", value="", disabled=True, selected=True)]),
                 *[Option(lbl, value=val, selected=(val == display_val)) for val, lbl in _opt_items],
                 name="value",
                 **swap,

--- a/ui/routes/inventory.py
+++ b/ui/routes/inventory.py
@@ -2027,27 +2027,41 @@ function celerpPrintLabel(entityId, templateId) {
         # Convert numeric fields from string to float
         elif field == "quantity" or field.endswith("_price") or field.endswith("_price_total"):
             raw_str = str(form.get("value", ""))
-            try:
-                value = float(value)
-            except (ValueError, TypeError):
-                # Return editable cell with error so user can correct without a page reload.
-                cell_type = "number" if field == "quantity" else "money"
-                patch_url = f"/api/items/{entity_id}/field/{field}"
-                restore_url = (
-                    f"/api/items/{entity_id}/field/{field}/paired-display"
-                    if field in _PAIRED_FIELDS
-                    else f"/api/items/{entity_id}/field/{field}/display"
-                )
-                from ui.components.table import editable_cell
-                edit_td = editable_cell(
-                    entity_id=entity_id, field=field, value=raw_str,
-                    cell_type=cell_type, restore_url=restore_url,
-                )
-                edit_td.attrs["class"] = (edit_td.attrs.get("class", "") + " cell--error").strip()
-                return edit_td
+            if raw_str.strip() == "" and field != "quantity":
+                value = None  # blanking an optional price/cost cell = clear it (issue #202)
+            else:
+                try:
+                    value = float(value)
+                except (ValueError, TypeError):
+                    # Return editable cell with error so user can correct without a page reload.
+                    cell_type = "number" if field == "quantity" else "money"
+                    patch_url = f"/api/items/{entity_id}/field/{field}"
+                    restore_url = (
+                        f"/api/items/{entity_id}/field/{field}/paired-display"
+                        if field in _PAIRED_FIELDS
+                        else f"/api/items/{entity_id}/field/{field}/display"
+                    )
+                    from ui.components.table import editable_cell
+                    edit_td = editable_cell(
+                        entity_id=entity_id, field=field, value=raw_str,
+                        cell_type=cell_type, restore_url=restore_url,
+                    )
+                    edit_td.attrs["class"] = (edit_td.attrs.get("class", "") + " cell--error").strip()
+                    return edit_td
 
         try:
-            if field == "location_name":
+            if value is None:
+                # Clearing an optional price/cost field (issue #202): unset it. A "<x>_price_total"
+                # cell is virtual — clear its underlying unit price (cost maps to cost_total, which is
+                # the canonical primitive for cost).
+                if field.endswith("_price_total"):
+                    _unit = field[: -len("_total")]          # retail_price_total -> retail_price
+                    clear_field = "cost_total" if _unit == "cost_price" else _unit
+                else:
+                    clear_field = "cost_total" if field == "cost_price" else field
+                old_item = await api.get_item(token, entity_id)
+                await api.patch_item(token, entity_id, {clear_field: {"old": old_item.get(clear_field), "new": None}})
+            elif field == "location_name":
                 # Transfer requires location_id; resolve name → id from locations list
                 locs = (await api.get_locations(token)).get("items", [])
                 loc = next((l for l in locs if l.get("name") == value), None)
@@ -3432,23 +3446,33 @@ function celerpPrintLabel(entityId, templateId) {
             for pl in price_lists:
                 pl_name = pl.get("name", "")
                 conventional_key = f"{pl_name.lower()}_price"
+                if conventional_key not in form:
+                    continue  # field not submitted — leave it untouched
                 val = str(form.get(conventional_key, "")).strip()
-                if val:
-                    try:
-                        price = float(val)
-                    except ValueError:
-                        continue
-                    # cost_price is a derived field; always save as cost_total to avoid being
-                    # overwritten by _flatten_item on the next read.
-                    # Use patch_item (not set_item_price) so price_type normalization doesn't mangle "cost_total".
-                    if conventional_key == "cost_price" and item_qty > 0:
-                        old_cost_total = item_for_price.get("cost_total")
-                        await api.patch_item(token, entity_id, {"cost_total": {"old": old_cost_total, "new": round(price * item_qty, 10)}})
+                if val == "":
+                    # Cleared price → unset it (issue #202). Cost is canonically cost_total. Use
+                    # patch_item with new=None so the field is removed, not stored as "" / 0.
+                    if conventional_key == "cost_price":
+                        await api.patch_item(token, entity_id, {"cost_total": {"old": item_for_price.get("cost_total"), "new": None}})
                         cost_changed = True
                     else:
-                        await api.set_item_price(token, entity_id, pl_name, price)
-                        if conventional_key == "cost_price":
-                            cost_changed = True
+                        await api.patch_item(token, entity_id, {conventional_key: {"old": item_for_price.get(conventional_key), "new": None}})
+                    continue
+                try:
+                    price = float(val)
+                except ValueError:
+                    continue
+                # cost_price is a derived field; always save as cost_total to avoid being
+                # overwritten by _flatten_item on the next read.
+                # Use patch_item (not set_item_price) so price_type normalization doesn't mangle "cost_total".
+                if conventional_key == "cost_price" and item_qty > 0:
+                    old_cost_total = item_for_price.get("cost_total")
+                    await api.patch_item(token, entity_id, {"cost_total": {"old": old_cost_total, "new": round(price * item_qty, 10)}})
+                    cost_changed = True
+                else:
+                    await api.set_item_price(token, entity_id, pl_name, price)
+                    if conventional_key == "cost_price":
+                        cost_changed = True
             # A cost change ripples into every recipe that uses this item — recost them now so
             # the Manufacturing tab and margins stay current without any manual step.
             if cost_changed:


### PR DESCRIPTION
## What this changes

The merge undervalued the merged item's money fields in two ways:
- retail/wholesale prices were copied from the target's unit price only and scaled by the merged qty, so a non-target source's price was dropped (e.g. total $50 + $50,000 -> $100 instead of $50,050);
- cost_total was summed with a missing source cost counted as 0, so an un-costed source silently understated the total.

Both let an item be priced below its true cost with nothing flagging it.

Fix, inside merge_items, applying one all-or-nothing rule on the source TOTALS (same shape as the pieces rule in #197):
- each *_price is a per-unit price -> reconcile on unit x qty totals: if every source has it set, merged total = sum (stored back as a unit = total / merged_qty); if any source lacks it, omit (merged item has no value);
- cost_total (already a total): sum only if every source has a cost, else None. payload.resulting_* overrides preserved.

Tests: new tests/test_merge_prices.py (written in totals, qty>1 so unit != total) covers retail/wholesale sum-when-all-set, cost sum control, and none-when-any-source-unset for retail/wholesale/cost.

## Also: clear optional fields back to None (#202)

Once set, an optional field couldn't be returned to empty: barcode rejected `""` (digit check), cost crashed on `float("")`, prices/category/text stored `""` instead of unsetting, selects had no blank option, and the Pricing tab autosave skipped empty inputs entirely.

Turns "clear" into "unset" end-to-end:
- `update_item` (data API): normalize an empty-string `new` value -> `None` for changed fields (required `name`/`sell_by`/`quantity` excepted), so barcode skips its digit check and the handler clears.
- `item.updated` projection handler: cost branch tolerates `""`; generic branch pops the key on `None` so the field reads as absent, not `""`.
- Pricing tab (`POST /api/items/{id}/price`): a submitted-but-empty price is cleared (`patch_item` `new=None`; cost -> `cost_total`), guarded so unrelated prices are left untouched.
- inline cell edit: a blank numeric/price cell -> `None` (no `float("")` error); `*_price_total` / `cost_price` clears map to the right underlying field.
- select cells: offer a selectable "— clear —" option once set (`status` stays required).

Tests:
- `tests/test_clear_fields.py`: backend set-then-clear for `retail_price`, `cost_total`, `barcode`, `category`, and a select field.
- `tests/test_browser/test_clear_fields_ui.py`: Playwright clear of `barcode` (inline), `retail_price` (Pricing tab), and a select field (blank option).

## Checklist

- [X] Tests added or updated, and the relevant suites pass locally
- [X] License headers are correct for the paths touched (see `LICENSING.md`; enforced by `scripts/licenses.py`)