### PR TITLE
fix(inventory): keep pieces canonical under attributes (merge + create paths (#204, #205)

### DIFF
--- a/default_modules/celerp-inventory/celerp_inventory/projections.py
+++ b/default_modules/celerp-inventory/celerp_inventory/projections.py
@@ -145,6 +145,18 @@ def apply_item_event(state: dict, event_type: str, data: dict) -> dict:
     current = deepcopy(state)
     if event_type in {"item.created", "item.snapshot"}:
         current.update(data)
+        # `pieces` is canonical under attributes["pieces"] (like item.updated normalizes). Some
+        # producers put it TOP-LEVEL in the create payload — POST /items via extra="allow", CIF
+        # imports, the UI CSV/XLSX builder. Relocate it so storage is uniform regardless of path,
+        # and so a snapshot self-heals any item that was stored top-level historically.
+        if "pieces" in current:
+            _pieces_val = current.pop("pieces")
+            _attrs = dict(current.get("attributes") or {})
+            if _pieces_val is None:
+                _attrs.pop("pieces", None)
+            else:
+                _attrs.setdefault("pieces", _pieces_val)  # never clobber an explicit attributes.pieces
+            current["attributes"] = _attrs
         current.setdefault("status", "available")
         current.setdefault("inventory_type", "stocked")
         # Default purchase unit = sell unit, conversion = 1 (most items bought in same unit as sold)

--- a/default_modules/celerp-inventory/celerp_inventory/routes.py
+++ b/default_modules/celerp-inventory/celerp_inventory/routes.py
@@ -2058,6 +2058,10 @@ async def merge_items(payload: MergeBody, company_id=Depends(get_current_company
     for p in source_projections:
         all_attr_keys.update((p.state.get("attributes") or {}).keys())
     all_attr_keys -= _EXPIRY_ATTR_KEYS
+    # `pieces` may live TOP-LEVEL (imports / POST /items) rather than under attributes, so the loop
+    # above misses it. Add it whenever any source has a piece count so it's resolved (summed) below.
+    if any(_read_pieces(p.state) is not None for p in source_projections):
+        all_attr_keys.add("pieces")
 
     # Classify the merged category's fields by their SCHEMA type, not by the shape of their values.
     # A merge must NEVER sum a field or invent a value. Only genuinely numeric-typed fields
@@ -2079,7 +2083,7 @@ async def merge_items(payload: MergeBody, company_id=Depends(get_current_company
             # a number (int/float/str are equivalent). If every source has pieces set → the merged
             # item's pieces is the sum; if any source has it unset, the true total is unknowable, so
             # the merged item carries NO pieces. See issue #197.
-            coerced = [_num_pieces((p.state.get("attributes") or {}).get("pieces")) for p in source_projections]
+            coerced = [_num_pieces(_read_pieces(p.state)) for p in source_projections]
             if coerced and all(v is not None for v in coerced):
                 total = sum(coerced, Decimal(0))
                 resolved_attrs["pieces"] = int(total) if total == total.to_integral_value() else float(total)

--- a/tests/test_merge_pieces_imported.py
+++ b/tests/test_merge_pieces_imported.py
@@ -1,0 +1,81 @@
+# Copyright (c) 2026 Noah Severs
+# SPDX-License-Identifier: LicenseRef-Proprietary
+"""Regression test for https://github.com/celerp/celerp/issues/204.
+
+Merging items must sum `pieces` regardless of WHERE each source stores the count:
+
+- items created via the full-payload path (imports / ``POST /items`` with a top-level ``pieces``)
+  keep the count at **top-level** (``state["pieces"]``);
+- items created-then-edited in the UI keep it under **``attributes["pieces"]``**.
+
+The merge reads ``attributes["pieces"]`` only (routes.py:2082), so it silently drops the count for
+imported items. This test seeds two items with **top-level** pieces (the import path, mirroring
+``data/test_items.csv``) and asserts the merge sums them. It FAILS against the current merge
+(pieces dropped -> None) and passes once the merge resolves pieces via ``_read_pieces``
+(top-level OR attributes).
+"""
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+
+async def _token(client) -> str:
+    email = f"imp-{uuid.uuid4().hex[:8]}@example.com"
+    r = await client.post(
+        "/auth/register",
+        json={"company_name": "Imported Gems", "email": email, "name": "Owner", "password": "pw"},
+    )
+    assert r.status_code == 200, r.text
+    return r.json()["access_token"]
+
+
+async def _seed_imported(client, headers, sku: str, pieces, *, qty: float) -> str:
+    """Create a carat-sold stone with ``pieces`` at TOP-LEVEL — the import / POST-payload path
+    (NOT under ``attributes``). Mirrors the rows of data/test_items.csv."""
+    r = await client.post(
+        "/items",
+        json={
+            "sku": sku, "name": sku, "quantity": qty, "sell_by": "carat",
+            "category": "colored_stone", "pieces": pieces,   # top-level, exactly like an import
+        },
+        headers=headers,
+    )
+    assert r.status_code == 200, r.text
+    return r.json()["id"]
+
+
+async def _pieces(client, headers, item_id: str):
+    r = await client.get(f"/items/{item_id}", headers=headers)
+    assert r.status_code == 200, r.text
+    return r.json().get("pieces")
+
+
+async def _merge(client, headers, source_ids: list[str], target_id: str) -> str:
+    r = await client.post(
+        "/items/merge",
+        json={"source_entity_ids": source_ids, "target_sku_from": target_id},
+        headers=headers,
+    )
+    assert r.status_code == 200, r.text
+    return r.json()["id"]
+
+
+@pytest.mark.asyncio
+async def test_merge_sums_pieces_for_imported_items(client) -> None:
+    """A and B imported with top-level pieces=1 each -> merged pieces must be 2 (issue #204)."""
+    headers = {"Authorization": f"Bearer {await _token(client)}"}
+    a = await _seed_imported(client, headers, "A", 1, qty=45.0)
+    b = await _seed_imported(client, headers, "B", 1, qty=46.0)
+
+    # Sanity: each seeded source really carries pieces=1 (proves the top-level count is stored/read).
+    assert int(float(await _pieces(client, headers, a))) == 1
+    assert int(float(await _pieces(client, headers, b))) == 1
+
+    merged_id = await _merge(client, headers, [a, b], a)
+    merged_pieces = await _pieces(client, headers, merged_id)
+
+    assert merged_pieces is not None and int(float(merged_pieces)) == 2, (
+        f"imported items' pieces must sum on merge (expected 2), got {merged_pieces!r}"
+    )

--- a/tests/test_pieces_stored_in_attributes.py
+++ b/tests/test_pieces_stored_in_attributes.py
@@ -1,0 +1,126 @@
+# Copyright (c) 2026 Noah Severs
+# SPDX-License-Identifier: LicenseRef-Proprietary
+"""Regression tests for https://github.com/celerp/celerp/issues/205.
+
+`pieces` must be stored in **`attributes["pieces"]`** in every case, never at top-level
+(`state["pieces"]`). `attributes["pieces"]` is the single canonical location; the `item.updated`
+projection already normalizes there, but the create projection (`item.created` / `item.snapshot`)
+historically kept whatever the producer put in the payload verbatim.
+
+Three producers put `pieces` at top-level; each gets one regression test asserting the STORED
+projection state carries the count under `attributes` and NOT at top-level:
+
+1. **API / script** — ``POST /items`` with a top-level ``pieces`` (accepted via ``extra="allow"``).
+2. **Batch import** — a CIF import record whose ``data`` carries top-level ``pieces``.
+3. **UI import** — the UI CSV/XLSX builder emits a record with top-level ``pieces`` *alongside* a
+   populated ``attributes`` dict (see ``ui/routes/inventory.py``); the count must merge into that
+   ``attributes`` dict without clobbering its sibling keys.
+
+Each test FAILS before the fix (pieces left top-level) and passes once the create projection
+normalizes ``pieces`` -> ``attributes``.
+"""
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from sqlalchemy import select
+
+from celerp.models.projections import Projection
+
+
+async def _token(client) -> str:
+    email = f"pieces-{uuid.uuid4().hex[:8]}@example.com"
+    r = await client.post(
+        "/auth/register",
+        json={"company_name": "Pieces Co", "email": email, "name": "Owner", "password": "pw"},
+    )
+    assert r.status_code == 200, r.text
+    return r.json()["access_token"]
+
+
+async def _state(session, entity_id: str) -> dict:
+    """Return the RAW stored projection state (not the flattened read model)."""
+    row = (await session.execute(
+        select(Projection).where(Projection.entity_id == entity_id)
+    )).scalar_one()
+    return dict(row.state)
+
+
+def _assert_pieces_in_attributes(state: dict, expected: int) -> None:
+    """`pieces` lives under attributes and NOT at top-level."""
+    assert "pieces" not in state, f"pieces must not be stored top-level, got state['pieces']={state.get('pieces')!r}"
+    attrs = state.get("attributes") or {}
+    assert "pieces" in attrs, f"pieces must be stored under attributes, got attributes={attrs!r}"
+    assert int(float(attrs["pieces"])) == expected, f"expected attributes.pieces={expected}, got {attrs['pieces']!r}"
+
+
+# ── Scenario 1: API / POST /items ─────────────────────────────────────────────
+@pytest.mark.asyncio
+async def test_post_items_stores_pieces_in_attributes(client, session) -> None:
+    headers = {"Authorization": f"Bearer {await _token(client)}"}
+    r = await client.post(
+        "/items",
+        json={
+            "sku": "API-1", "name": "API stone", "quantity": 45.0, "sell_by": "carat",
+            "category": "colored_stone", "pieces": 3,  # top-level extra field (extra="allow")
+        },
+        headers=headers,
+    )
+    assert r.status_code == 200, r.text
+    _assert_pieces_in_attributes(await _state(session, r.json()["id"]), 3)
+
+
+# ── Scenario 2: Batch import (bare CIF record) ────────────────────────────────
+@pytest.mark.asyncio
+async def test_batch_import_stores_pieces_in_attributes(client, session) -> None:
+    headers = {"Authorization": f"Bearer {await _token(client)}"}
+    entity_id = f"item:{uuid.uuid4()}"
+    r = await client.post(
+        "/items/import/batch",
+        json={"records": [{
+            "entity_id": entity_id,
+            "event_type": "item.created",
+            "data": {  # top-level pieces, exactly as a CIF record carries it
+                "sku": "IMP-1", "name": "Imported stone", "quantity": 46.0,
+                "sell_by": "carat", "pieces": 4,
+            },
+            "source": "csv_import",
+            "idempotency_key": f"csv:item:{uuid.uuid4().hex}",
+        }]},
+        headers=headers,
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["created"] == 1, r.text
+    _assert_pieces_in_attributes(await _state(session, entity_id), 4)
+
+
+# ── Scenario 3: UI import (top-level pieces + populated attributes dict) ───────
+@pytest.mark.asyncio
+async def test_ui_import_record_stores_pieces_in_attributes(client, session) -> None:
+    """Mirrors the exact record shape the UI CSV/XLSX builder emits (ui/routes/inventory.py):
+    top-level ``pieces`` next to a separate ``attributes`` dict. The count must merge INTO that
+    attributes dict, leaving its sibling keys intact."""
+    headers = {"Authorization": f"Bearer {await _token(client)}"}
+    entity_id = f"item:{uuid.uuid4()}"
+    r = await client.post(
+        "/items/import/batch",
+        json={"records": [{
+            "entity_id": entity_id,
+            "event_type": "item.created",
+            "data": {
+                "sku": "UI-1", "name": "UI stone", "quantity": 100.0, "sell_by": "carat",
+                "pieces": 5,                       # UI builder puts pieces top-level ...
+                "attributes": {"color": "green"},  # ... alongside the attributes dict
+            },
+            "source": "csv_import",
+            "idempotency_key": f"csv:item:{uuid.uuid4().hex}",
+        }]},
+        headers=headers,
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["created"] == 1, r.text
+    state = await _state(session, entity_id)
+    _assert_pieces_in_attributes(state, 5)
+    # sibling attribute must survive the normalization
+    assert (state.get("attributes") or {}).get("color") == "green", state.get("attributes")


### PR DESCRIPTION
## What this changes

Fixes two related `pieces` bugs in inventory. An item's piece count could be stored in two places —
top-level `state["pieces"]` (POST /items via `extra="allow"`, CIF imports, the UI CSV/XLSX builder) or
the canonical `attributes["pieces"]` (UI create-then-edit) — so readers that checked only one location
silently disagreed.

- **Merge dropped `pieces` for imported items (#204).** `merge_items` read `attributes["pieces"]` only,
  so merging items whose count sat top-level lost it. It now resolves each source via `_read_pieces`
  (top-level *or* attributes) and adds `pieces` to the merged key set when any source carries a count,
  so the counts actually sum.

- **`pieces` stored top-level on some create paths (#205).** Root cause of the above: the create
  projection kept whatever the producer put in the payload. The `item.created` / `item.snapshot` branch
  of `apply_item_event` now relocates a top-level `pieces` into `attributes["pieces"]` — uniform storage
  on every create path, self-healing existing items on snapshot/replay. It never clobbers an existing
  `attributes.pieces` and preserves sibling attributes. Reads already go through `_read_pieces`, so
  nothing else changes.

Closes #204, closes #205.

## Checklist

- [X] Tests added or updated, and the relevant suites pass locally
- [X] License headers are correct for the paths touched (see `LICENSING.md`; enforced by `scripts/licenses.py`)
