### PR TITLE
fix(inventory): keep category attributes canonical under attributes (merge reader + write normalization) (#208)

### DIFF
--- a/default_modules/celerp-inventory/celerp_inventory/projections.py
+++ b/default_modules/celerp-inventory/celerp_inventory/projections.py
@@ -19,6 +19,72 @@ _IMAGE_MIME_PREFIXES = ("image/",)
 # is_item_available() is the single source of truth — derive at read time, never store.
 _ACTIVE_STATUSES: frozenset[str] = frozenset({"available", "active"})
 
+# ── Core vs attribute partition (single source of truth for the WRITE side) ──────────────────────
+# Keys that live at the TOP LEVEL of item state: identity, quantities, cost bases, lifecycle markers,
+# relationships, files, and system fields. EVERYTHING ELSE is a category attribute and belongs under
+# state["attributes"] — including `pieces`. Per-price-list fields (`*_price` / `*_price_total`) also
+# stay top-level and are matched by suffix in `_is_core_key`.
+#
+# Reads flatten both locations, so top-level vs nested is invisible to normal consumers; only raw-state
+# readers (e.g. merge conflict resolution) care. Normalizing on write keeps storage canonical so those
+# readers stay correct. If a NEW top-level state key is ever added to the projection, add it here too —
+# otherwise it would be misclassified as an attribute and relocated.
+_CORE_ITEM_KEYS: frozenset[str] = frozenset({
+    # the attributes container itself is top-level (holds all category attributes); a field edit may
+    # replace it wholesale via fields_changed["attributes"], so it must NOT be treated as an attribute
+    "attributes",
+    # identity / system
+    "id", "entity_id", "company_id", "sku", "name", "barcode", "category", "status",
+    "created_at", "updated_at", "location_id", "location_name", "idempotency_key",
+    # quantities / measures  (NOTE: `pieces` is intentionally NOT core — it lives under attributes)
+    "quantity", "sell_by", "unit", "weight", "weight_unit", "gross_weight", "gross_weight_unit",
+    "reserved_quantity", "quantity_fulfilled",
+    # cost bases (per-list *_price fields are matched by suffix, not listed)
+    "cost_total", "cost_price", "cost_base", "cost_landed", "landed_contributions",
+    # reorder / planning
+    "reorder_point", "reorder_qty",
+    # flags / classification
+    "allow_splitting", "inventory_type", "pick_method", "consignment_flag", "item_type",
+    "is_expired", "expires_at", "landed_cost_kind", "recoverable",
+    # purchase side
+    "purchase_sku", "purchase_name", "purchase_unit", "purchase_conversion_factor",
+    # free-text core fields
+    "short_description", "description", "notes", "hs_code", "batch_no",
+    # relationships / lifecycle markers
+    "parent_id", "parent_sku", "children", "child_skus", "merged_into", "split_from",
+    "transformed_from", "transformed_into", "fulfilled_for_docs",
+    # files / media
+    "files", "attachments", "preview_image_id",
+    # other structured internals
+    "recipe", "workflow", "tax_codes",
+})
+
+
+def _is_core_key(key: str) -> bool:
+    """True if `key` stays at the top level of item state (core field or a per-list price field)."""
+    return key in _CORE_ITEM_KEYS or key.endswith("_price") or key.endswith("_price_total")
+
+
+def _normalize_attributes(current: dict) -> None:
+    """Relocate every non-core top-level field into state["attributes"] (in place).
+
+    Category attributes (grade, type, color, …) and `pieces` belong under `attributes`; only core
+    identity/quantity/cost/lifecycle/price fields stay top-level. Some producers put attributes
+    top-level (a field edit, `POST /items` extra fields), which this heals so storage is canonical.
+    A top-level value takes precedence over an existing nested one — it is the freshly written value.
+    """
+    movable = [k for k in current if k != "attributes" and not _is_core_key(k)]
+    if not movable:
+        return
+    attrs = dict(current.get("attributes") or {})
+    for k in movable:
+        val = current.pop(k)
+        if val is None:
+            attrs.pop(k, None)
+        else:
+            attrs[k] = val
+    current["attributes"] = attrs
+
 
 def is_item_available(state: dict) -> bool:
     """Derive availability from status. Single authoritative check — no stored flag."""
@@ -145,18 +211,11 @@ def apply_item_event(state: dict, event_type: str, data: dict) -> dict:
     current = deepcopy(state)
     if event_type in {"item.created", "item.snapshot"}:
         current.update(data)
-        # `pieces` is canonical under attributes["pieces"] (like item.updated normalizes). Some
-        # producers put it TOP-LEVEL in the create payload — POST /items via extra="allow", CIF
-        # imports, the UI CSV/XLSX builder. Relocate it so storage is uniform regardless of path,
-        # and so a snapshot self-heals any item that was stored top-level historically.
-        if "pieces" in current:
-            _pieces_val = current.pop("pieces")
-            _attrs = dict(current.get("attributes") or {})
-            if _pieces_val is None:
-                _attrs.pop("pieces", None)
-            else:
-                _attrs.setdefault("pieces", _pieces_val)  # never clobber an explicit attributes.pieces
-            current["attributes"] = _attrs
+        # Category attributes (incl. `pieces`) are canonical under attributes["<key>"]. Some producers
+        # put them TOP-LEVEL in the create payload — POST /items via extra="allow", CIF imports — so
+        # relocate every non-core top-level field into `attributes`. This makes storage uniform across
+        # producers and lets a snapshot self-heal any item stored top-level historically.
+        _normalize_attributes(current)
         current.setdefault("status", "available")
         current.setdefault("inventory_type", "stocked")
         # Default purchase unit = sell unit, conversion = 1 (most items bought in same unit as sold)
@@ -194,14 +253,26 @@ def apply_item_event(state: dict, event_type: str, data: dict) -> dict:
                     current.pop("cost_price", None)
                 else:  # cost_total
                     current["cost_base"] = round(float(new_val), 2)
-            else:
-                # Clearing any other field (None/"") unsets it — remove the key rather than storing
-                # an empty string or null, so the field reads as truly absent (issue #202).
+            elif _is_core_key(field):
+                # Core / price field — stays TOP-LEVEL. Clearing (None/"") unsets it — remove the key
+                # rather than storing an empty string or null, so it reads as truly absent (issue #202).
                 new_val = change.get("new")
                 if new_val in (None, ""):
                     current.pop(field, None)
                 else:
                     current[field] = new_val
+            else:
+                # Category attribute — canonical under attributes["<field>"], never top-level (like
+                # `pieces`). Clearing removes it from BOTH locations so nothing lingers if the value was
+                # historically stored top-level.
+                new_val = change.get("new")
+                attrs = dict(current.get("attributes") or {})
+                if new_val in (None, ""):
+                    attrs.pop(field, None)
+                else:
+                    attrs[field] = new_val
+                current["attributes"] = attrs
+                current.pop(field, None)
         current = _sync_expiry_from_attributes(current)
         _recompute_cost(current)
     elif event_type == "item.pricing.set":
@@ -295,6 +366,7 @@ def apply_item_event(state: dict, event_type: str, data: dict) -> dict:
     elif event_type == "item.patched":
         # CSV upsert: merge data fields into existing state, then re-run migrations
         current.update(data)
+        _normalize_attributes(current)  # keep attributes canonical if the upsert carried them top-level
         current = _migrate_sell_by(current)
         current = _sync_expiry_from_attributes(current)
         _recompute_cost(current)

--- a/default_modules/celerp-inventory/celerp_inventory/routes.py
+++ b/default_modules/celerp-inventory/celerp_inventory/routes.py
@@ -60,6 +60,25 @@ def _read_pieces(state: dict) -> float | None:
     return float(raw) if raw not in (None, "") else None
 
 
+def _has_attr(state: dict, key: str) -> bool:
+    """True if `key` is present as an attribute in EITHER storage location (top-level or attributes).
+
+    Category attributes can live top-level (a field edit / POST /items keeps them there — only
+    `pieces`/cost are normalized into `attributes`) or nested under `attributes` (create payload /
+    import). Consumers must treat both as the same attribute."""
+    return key in state or key in (state.get("attributes") or {})
+
+
+def _read_attr(state: dict, key: str):
+    """Read an attribute from top-level OR attributes (single source of truth for reads).
+
+    Top-level wins when present (that is where a field edit stores it); otherwise fall back to the
+    nested `attributes` dict."""
+    if key in state:
+        return state[key]
+    return (state.get("attributes") or {}).get(key)
+
+
 def _num_pieces(raw) -> Decimal | None:
     """Coerce a stored `pieces` value (int / float / numeric str) to a Decimal.
 
@@ -2093,11 +2112,24 @@ async def merge_items(payload: MergeBody, company_id=Depends(get_current_company
     # system value. Keying off the value shape (as before) misclassified custom attributes whose
     # values merely look numeric (free fields, or selects with numeric options) and silently dropped
     # them instead of showing "Mixed".
-    from celerp.services.field_schema import get_effective_field_schema, MIXED_VALUE
+    from celerp.services.field_schema import get_effective_field_schema, MIXED_VALUE, _BASE_FIELDS
     _merge_category = (next(iter(categories), "") or "").strip() or None
     _schema = await get_effective_field_schema(session, company_id, category=_merge_category)
     _dropdown_keys = {f["key"] for f in _schema if f.get("type") in ("select", "status")}
     _numeric_keys = {f["key"] for f in _schema if f.get("type") in ("number", "money", "rate")}
+    # A schema-defined category attribute (e.g. `type`, `grade`, `color`) may be stored TOP-LEVEL
+    # rather than under `attributes` — a field edit / POST /items keeps it there (only `pieces`/cost
+    # are normalized). The attributes-only scan above misses those keys, so the value is silently
+    # DROPPED on merge (no `Mixed` on conflict, and the shared value lost when sources agree). Add
+    # every schema attribute key so each is resolved below via a top-level-OR-`attributes` read.
+    # Base/core fields (quantity, weight, status, …) and price columns are handled separately and
+    # must NOT be treated as attributes.
+    _base_field_keys = frozenset(f["key"] for f in _BASE_FIELDS)
+    _schema_attr_keys = {
+        f["key"] for f in _schema
+        if f["key"] not in _base_field_keys and not f["key"].endswith("_price")
+    }
+    all_attr_keys |= (_schema_attr_keys - _EXPIRY_ATTR_KEYS)
 
     resolved_attrs: dict = {}
     for key in all_attr_keys:
@@ -2113,8 +2145,12 @@ async def merge_items(payload: MergeBody, company_id=Depends(get_current_company
                 resolved_attrs["pieces"] = int(total) if total == total.to_integral_value() else float(total)
             # else: at least one source lacks pieces → omit the key (no value)
             continue
-        # Collect raw attribute values (preserve original type for numeric fields)
-        raw_values = [(p.state.get("attributes") or {}).get(key) for p in source_projections if key in (p.state.get("attributes") or {})]
+        # Collect raw attribute values (preserve original type for numeric fields). Read from
+        # top-level OR `attributes` so a field-edited value (top-level) is seen just like a nested
+        # one — this is what makes conflicts resolve to "Mixed" and agreements keep their value.
+        raw_values = [_read_attr(p.state, key) for p in source_projections if _has_attr(p.state, key)]
+        if not raw_values:
+            continue  # no source carries this attribute in either location → nothing to resolve
         str_values = [str(v) for v in raw_values]
         unique_str_vals = set(str_values)
         if len(unique_str_vals) == 1:

--- a/tests/test_attr_stored_in_attributes.py
+++ b/tests/test_attr_stored_in_attributes.py
@@ -1,0 +1,105 @@
+# Copyright (c) 2026 Noah Severs
+# SPDX-License-Identifier: LicenseRef-Proprietary
+"""Regression tests: category attributes must be stored under ``attributes``, never top-level.
+
+`attributes["<key>"]` is the canonical location. `item.updated` already normalizes `pieces` there,
+but every OTHER attribute set via a **field edit** is written to the TOP of item state
+(`state["grade"]`), and `POST /items` keeps an arbitrary top-level attribute key top-level too
+(`ItemCreate` accepts extra fields). Import already does the right thing — the UI import builder nests
+non-core / non-price columns under `attributes` — so it is intentionally NOT covered here.
+
+Each test asserts the RAW stored projection state carries the attribute under `attributes` and NOT at
+top-level. They FAIL today (value left top-level) and pass once the write paths normalize non-core,
+non-price fields into `attributes` (generalizing the `pieces` handling).
+"""
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from sqlalchemy import select
+
+from celerp.models.projections import Projection
+
+
+async def _token(client) -> str:
+    email = f"attr-{uuid.uuid4().hex[:8]}@example.com"
+    r = await client.post(
+        "/auth/register",
+        json={"company_name": "Attr Co", "email": email, "name": "Owner", "password": "pw"},
+    )
+    assert r.status_code == 200, r.text
+    return r.json()["access_token"]
+
+
+async def _state(session, entity_id: str) -> dict:
+    """Return the RAW stored projection state (not the flattened read model)."""
+    row = (await session.execute(
+        select(Projection).where(Projection.entity_id == entity_id)
+    )).scalar_one()
+    return dict(row.state)
+
+
+def _assert_attr_nested(state: dict, key: str, expected) -> None:
+    """`key` lives under attributes and NOT at top-level."""
+    assert key not in state, f"{key!r} must not be stored top-level, got state[{key!r}]={state.get(key)!r}"
+    attrs = state.get("attributes") or {}
+    assert attrs.get(key) == expected, f"expected attributes[{key!r}]={expected!r}, got {attrs.get(key)!r}"
+
+
+# ── Scenario 1: field edit (the reproduction) ─────────────────────────────────
+@pytest.mark.asyncio
+async def test_field_edit_stores_attribute_in_attributes(client, session) -> None:
+    headers = {"Authorization": f"Bearer {await _token(client)}"}
+    r = await client.post(
+        "/items",
+        json={"sku": "FE-1", "name": "Bag", "quantity": 1, "sell_by": "piece", "category": "DD"},
+        headers=headers,
+    )
+    assert r.status_code == 200, r.text
+    eid = r.json()["id"]
+    # Set a category attribute via a FIELD EDIT — the normal UI path.
+    r2 = await client.patch(
+        f"/items/{eid}",
+        json={"fields_changed": {"grade": {"old": None, "new": "A"}}},
+        headers=headers,
+    )
+    assert r2.status_code == 200, r2.text
+    _assert_attr_nested(await _state(session, eid), "grade", "A")
+
+
+# ── Scenario 2: POST /items with a top-level attribute (extra="allow") ─────────
+@pytest.mark.asyncio
+async def test_post_items_top_level_attribute_is_nested(client, session) -> None:
+    headers = {"Authorization": f"Bearer {await _token(client)}"}
+    r = await client.post(
+        "/items",
+        json={
+            "sku": "PC-1", "name": "Bag", "quantity": 1, "sell_by": "piece",
+            "category": "DD", "grade": "A",   # top-level extra field (accepted via extra="allow")
+        },
+        headers=headers,
+    )
+    assert r.status_code == 200, r.text
+    _assert_attr_nested(await _state(session, r.json()["id"]), "grade", "A")
+
+
+# ── Scenario 3: clearing a field-edited attribute removes it from attributes ───
+@pytest.mark.asyncio
+async def test_field_edit_clear_removes_attribute_everywhere(client, session) -> None:
+    """Clearing the attribute must leave it unset in BOTH locations (no orphan top-level or nested)."""
+    headers = {"Authorization": f"Bearer {await _token(client)}"}
+    r = await client.post(
+        "/items",
+        json={"sku": "FC-1", "name": "Bag", "quantity": 1, "sell_by": "piece", "category": "DD"},
+        headers=headers,
+    )
+    assert r.status_code == 200, r.text
+    eid = r.json()["id"]
+    await client.patch(f"/items/{eid}", json={"fields_changed": {"grade": {"old": None, "new": "A"}}}, headers=headers)
+    # Now clear it.
+    r3 = await client.patch(f"/items/{eid}", json={"fields_changed": {"grade": {"old": "A", "new": None}}}, headers=headers)
+    assert r3.status_code == 200, r3.text
+    state = await _state(session, eid)
+    assert "grade" not in state, f"cleared grade must not remain top-level: {state.get('grade')!r}"
+    assert "grade" not in (state.get("attributes") or {}), f"cleared grade must not remain nested: {state.get('attributes')}"

--- a/tests/test_merge_attr_field_edit.py
+++ b/tests/test_merge_attr_field_edit.py
@@ -1,0 +1,116 @@
+# Copyright (c) 2026 Noah Severs
+# SPDX-License-Identifier: LicenseRef-Proprietary
+"""Regression test: merging must not drop a category attribute that was set via a FIELD EDIT.
+
+A field edit (`PATCH /items/{id}` with `fields_changed={"grade": ...}`) stores the attribute
+**top-level** (`state["grade"]`), because `item.updated` writes generic fields to the top of item
+state — only `pieces`/cost are normalized into `attributes`. The merge, however, resolves attribute
+conflicts by scanning `attributes` **only**, so it never sees a field-edited value. The key is
+therefore never processed at all, which drops it in BOTH cases:
+
+- sources **conflict** (grade A vs B)  -> merged should be "Mixed", is dropped (None);
+- sources **agree**    (grade A and A) -> merged should keep "A", is dropped (None).
+
+These tests FAIL against the current merge (value dropped) and pass once the merge reads each
+attribute from top-level OR `attributes` and includes schema/top-level keys in its candidate set.
+
+Contrast with tests/test_routers/test_items.py::test_merge_dropdown_fields_use_value_or_mixed_never_sum,
+which seeds the attribute *nested* in the create payload — the one path where the merge already sees
+it — and so does not exercise this bug.
+"""
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+
+async def _token(client) -> str:
+    email = f"attr-{uuid.uuid4().hex[:8]}@example.com"
+    r = await client.post(
+        "/auth/register",
+        json={"company_name": "Attr Co", "email": email, "name": "Owner", "password": "pw"},
+    )
+    assert r.status_code == 200, r.text
+    return r.json()["access_token"]
+
+
+async def _set_grade_schema(client, headers) -> None:
+    """Give category 'DD' a 'grade' select attribute so a conflict must resolve to 'Mixed'."""
+    r = await client.patch(
+        "/companies/me",
+        headers=headers,
+        json={"settings": {"category_schemas": {"DD": [
+            {"key": "grade", "label": "Grade", "type": "select",
+             "options": ["A", "B", "C"], "editable": True, "required": False},
+        ]}}},
+    )
+    assert r.status_code == 200, r.text
+
+
+async def _mk_item_then_edit_grade(client, headers, sku: str, grade: str) -> str:
+    """Create an item WITHOUT grade, then set grade via a FIELD EDIT so it lands TOP-LEVEL
+    (state['grade']), exactly like normal UI usage — not nested under attributes."""
+    r = await client.post(
+        "/items",
+        json={"sku": sku, "name": sku, "quantity": 1, "sell_by": "piece", "category": "DD"},
+        headers=headers,
+    )
+    assert r.status_code == 200, r.text
+    eid = r.json()["id"]
+    r2 = await client.patch(
+        f"/items/{eid}",
+        json={"fields_changed": {"grade": {"old": None, "new": grade}}},
+        headers=headers,
+    )
+    assert r2.status_code == 200, r2.text
+    return eid
+
+
+def _read_grade(item: dict):
+    """Flattened read — grade may sit top-level or under attributes."""
+    return (item.get("attributes") or {}).get("grade", item.get("grade"))
+
+
+async def _merge(client, headers, sources: list[str], target: str) -> dict:
+    r = await client.post(
+        "/items/merge",
+        json={"source_entity_ids": sources, "target_sku_from": target},
+        headers=headers,
+    )
+    assert r.status_code == 200, r.text
+    merged = (await client.get(f"/items/{r.json()['id']}", headers=headers)).json()
+    return merged
+
+
+@pytest.mark.asyncio
+async def test_merge_conflicting_field_edited_attr_becomes_mixed(client) -> None:
+    """grade A vs grade B, both set via field edit -> merged grade must be 'Mixed' (issue: it is dropped)."""
+    headers = {"Authorization": f"Bearer {await _token(client)}"}
+    await _set_grade_schema(client, headers)
+    a = await _mk_item_then_edit_grade(client, headers, "GA", "A")
+    b = await _mk_item_then_edit_grade(client, headers, "GB", "B")
+
+    # Sanity: each source really shows its grade (proves the value was set, just top-level).
+    ia = (await client.get(f"/items/{a}", headers=headers)).json()
+    ib = (await client.get(f"/items/{b}", headers=headers)).json()
+    assert _read_grade(ia) == "A" and _read_grade(ib) == "B", (_read_grade(ia), _read_grade(ib))
+
+    merged = await _merge(client, headers, [a, b], a)
+    assert _read_grade(merged) == "Mixed", (
+        f"conflicting field-edited attr must merge to 'Mixed', got {_read_grade(merged)!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_merge_agreeing_field_edited_attr_is_kept(client) -> None:
+    """grade A and grade A, both set via field edit -> merged grade must stay 'A' (issue: it is dropped)."""
+    headers = {"Authorization": f"Bearer {await _token(client)}"}
+    await _set_grade_schema(client, headers)
+    a = await _mk_item_then_edit_grade(client, headers, "GA", "A")
+    b = await _mk_item_then_edit_grade(client, headers, "GB", "A")
+
+    merged = await _merge(client, headers, [a, b], a)
+    assert _read_grade(merged) == "A", (
+        f"agreeing field-edited attr must be kept ('A'), got {_read_grade(merged)!r}"
+    )


### PR DESCRIPTION
## What this changes


A category attribute could be stored in two places depending on how it was set: **top-level**
`state["grade"]` (a field edit, or `POST /items` via `extra="allow"`) or the canonical
`state["attributes"]["grade"]` (a nested create payload / import). Reads flatten both, so the divergence
is invisible in normal use — but raw-state consumers (the merge) read `attributes` only, so a
field-edited attribute was silently **dropped** on merge (no `Mixed` on conflict, and the shared value
lost even when sources agree). This PR fixes both the reader and the storage.

- **Merge reader — tolerate attributes stored either way (#208).** `merge_items` now builds its conflict
  key-set from the category schema (plus each source's `attributes` keys) and reads every source's value
  via a top-level-OR-`attributes` helper (`_read_attr`, the generalization of `_read_pieces`). A genuine
  conflict resolves to `Mixed`; agreeing sources keep the value — regardless of where each source stored
  it. This fixes existing data with attributes already top-level.

- **Write normalization — never store attributes top-level.** `item.created` / `item.snapshot`,
  `item.updated`, and `item.patched` now relocate non-core fields into `attributes` (generalizing the
  `pieces` handling). A single authoritative `_CORE_ITEM_KEYS` set (derived from `_BASE_FIELDS`, every
  `apply_item_event` write, and the `ItemCreate` fields) plus the `*_price` / `*_price_total` suffix rule
  defines what stays top-level; everything else — including `pieces` — is a category attribute. Field
  edits nest on set and clear from `attributes` on clear; core/price fields stay top-level; imports were
  already correct. Snapshots self-heal legacy top-level attributes.

Together: readers stay correct for legacy items, and new items stop creating the divergence.

Closes #208.

## Checklist

- [X] Tests added or updated, and the relevant suites pass locally
- [X] License headers are correct for the paths touched (see `LICENSING.md`; enforced by `scripts/licenses.py`)
