### PR TITLE
feat(init): bundled PostgreSQL for pip installs, sudo-free quickstart

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,6 +125,76 @@ jobs:
           if-no-files-found: ignore
           retention-days: 7
 
+  # Bundled-PostgreSQL tests: mode resolution (unit) + a real pgserver cluster
+  # (integration). Runs on every platform that ships a pgserver wheel so the
+  # embedded init path is proven on Linux, macOS, and Windows. No Postgres service
+  # and --noconftest: these boot their own cluster and don't need the repo's
+  # testcontainer, which also lets them run on the macOS/Windows runners (no Docker).
+  embedded:
+    name: Embedded PG (${{ matrix.os }}, py${{ matrix.python }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { os: ubuntu-latest, python: "3.10" }
+          - { os: ubuntu-latest, python: "3.11" }
+          - { os: ubuntu-latest, python: "3.12" }
+          - { os: macos-latest, python: "3.12" }
+          - { os: windows-latest, python: "3.12" }
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python }}
+          cache: pip
+          cache-dependency-path: pyproject.toml
+      - name: Install deps
+        run: pip install -e ".[dev]"
+      - name: Run embedded-PG unit + integration tests
+        env:
+          ALLOW_INSECURE_JWT: "true"
+        run: >
+          pytest tests/test_embedded_pg_modes.py tests/test_embedded_pg_integration.py
+          --noconftest -o addopts="" -p no:cacheprovider --timeout=180 -q
+
+  # Graceful degradation on a platform with no pgserver wheel: `pip install` must
+  # still resolve (the marker drops pgserver), the provider reports unavailable, and
+  # `celerp init` with no server prints guidance rather than a traceback.
+  resolution:
+    name: Resolves without pgserver (py3.13)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+      - name: Install (pgserver marker must exclude 3.13)
+        run: pip install -e .
+      - name: pgserver is absent, provider reports unavailable
+        run: |
+          python - <<'PY'
+          import importlib.util, sys
+          from celerp import embedded_pg
+          assert importlib.util.find_spec("pgserver") is None, "pgserver should NOT install on 3.13"
+          assert embedded_pg.is_available() is False
+          print("OK: pgserver excluded, provider unavailable")
+          PY
+      - name: init with no server gives guidance, not a traceback
+        env:
+          ALLOW_INSECURE_JWT: "true"
+          CELERP_CONFIG: ${{ runner.temp }}/celerp/config.toml
+        run: |
+          set +e
+          out=$(celerp init --no-start 2>&1); code=$?
+          echo "$out"
+          set -e
+          test $code -ne 0
+          echo "$out" | grep -qi "Install PostgreSQL"
+          ! echo "$out" | grep -qi "Traceback"
+
   # Electron unit tests (incl. the L0 packaged-requires gate). Nothing ran these in
   # CI before; they catch the "require added, build.files not updated" class (v1.2.6)
   # statically, on every PR, with no build.
@@ -150,7 +220,7 @@ jobs:
   # (this job), which passes only when every unit, browser, AND electron job passed.
   test:
     name: Test
-    needs: [shard, browser, electron]
+    needs: [shard, browser, embedded, resolution, electron]
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -164,8 +234,16 @@ jobs:
             echo "One or more browser-test shards failed (result: ${{ needs.browser.result }})"
             exit 1
           fi
+          if [ "${{ needs.embedded.result }}" != "success" ]; then
+            echo "One or more embedded-PostgreSQL jobs failed (result: ${{ needs.embedded.result }})"
+            exit 1
+          fi
+          if [ "${{ needs.resolution.result }}" != "success" ]; then
+            echo "The pgserver-less resolution job failed (result: ${{ needs.resolution.result }})"
+            exit 1
+          fi
           if [ "${{ needs.electron.result }}" != "success" ]; then
             echo "Electron unit tests failed (result: ${{ needs.electron.result }})"
             exit 1
           fi
-          echo "All unit, browser, and electron checks passed."
+          echo "All unit, browser, embedded, resolution, and electron checks passed."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,23 +125,26 @@ jobs:
           if-no-files-found: ignore
           retention-days: 7
 
-  # Bundled-PostgreSQL tests: mode resolution (unit) + a real pgserver cluster
-  # (integration). Runs on every platform that ships a pgserver wheel so the
-  # embedded init path is proven on Linux, macOS, and Windows. No Postgres service
-  # and --noconftest: these boot their own cluster and don't need the repo's
-  # testcontainer, which also lets them run on the macOS/Windows runners (no Docker).
+  # Bundled-PostgreSQL tests: mode resolution + manager units + a real cluster
+  # from the celerp-postgres wheels (integration). --noconftest and no Postgres
+  # service: these boot their own cluster, which also lets them run on the
+  # macOS/Windows runners (no Docker). macOS: the celerp dependency marker
+  # excludes darwin (wheels need macOS 26+, which markers can't express), so the
+  # mac job installs celerp-postgres explicitly — proving the documented manual
+  # opt-in path on the macOS 26 runner.
   embedded:
     name: Embedded PG (${{ matrix.os }}, py${{ matrix.python }})
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 15
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
         include:
           - { os: ubuntu-latest, python: "3.10" }
-          - { os: ubuntu-latest, python: "3.11" }
           - { os: ubuntu-latest, python: "3.12" }
-          - { os: macos-latest, python: "3.12" }
+          - { os: ubuntu-latest, python: "3.13" }
+          - { os: ubuntu-24.04-arm, python: "3.12" }
+          - { os: macos-latest, python: "3.12", extra: celerp-postgres }
           - { os: windows-latest, python: "3.12" }
     steps:
       - uses: actions/checkout@v4
@@ -151,49 +154,15 @@ jobs:
           cache: pip
           cache-dependency-path: pyproject.toml
       - name: Install deps
-        run: pip install -e ".[dev]"
+        shell: bash
+        run: pip install -e ".[dev]" ${{ matrix.extra }}
       - name: Run embedded-PG unit + integration tests
         env:
           ALLOW_INSECURE_JWT: "true"
         run: >
-          pytest tests/test_embedded_pg_modes.py tests/test_embedded_pg_integration.py
-          --noconftest -o addopts="" -p no:cacheprovider --timeout=180 -q
-
-  # Graceful degradation on a platform with no pgserver wheel: `pip install` must
-  # still resolve (the marker drops pgserver), the provider reports unavailable, and
-  # `celerp init` with no server prints guidance rather than a traceback.
-  resolution:
-    name: Resolves without pgserver (py3.13)
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.13"
-      - name: Install (pgserver marker must exclude 3.13)
-        run: pip install -e .
-      - name: pgserver is absent, provider reports unavailable
-        run: |
-          python - <<'PY'
-          import importlib.util, sys
-          from celerp import embedded_pg
-          assert importlib.util.find_spec("pgserver") is None, "pgserver should NOT install on 3.13"
-          assert embedded_pg.is_available() is False
-          print("OK: pgserver excluded, provider unavailable")
-          PY
-      - name: init with no server gives guidance, not a traceback
-        env:
-          ALLOW_INSECURE_JWT: "true"
-          CELERP_CONFIG: ${{ runner.temp }}/celerp/config.toml
-        run: |
-          set +e
-          out=$(celerp init --no-start 2>&1); code=$?
-          echo "$out"
-          set -e
-          test $code -ne 0
-          echo "$out" | grep -qi "Install PostgreSQL"
-          ! echo "$out" | grep -qi "Traceback"
+          pytest tests/test_embedded_pg_modes.py tests/test_embedded_pg_manager.py
+          tests/test_embedded_pg_integration.py
+          --noconftest -o addopts="" -p no:cacheprovider --timeout=300 -q
 
   # Electron unit tests (incl. the L0 packaged-requires gate). Nothing ran these in
   # CI before; they catch the "require added, build.files not updated" class (v1.2.6)
@@ -220,7 +189,7 @@ jobs:
   # (this job), which passes only when every unit, browser, AND electron job passed.
   test:
     name: Test
-    needs: [shard, browser, embedded, resolution, electron]
+    needs: [shard, browser, embedded, electron]
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -238,12 +207,8 @@ jobs:
             echo "One or more embedded-PostgreSQL jobs failed (result: ${{ needs.embedded.result }})"
             exit 1
           fi
-          if [ "${{ needs.resolution.result }}" != "success" ]; then
-            echo "The pgserver-less resolution job failed (result: ${{ needs.resolution.result }})"
-            exit 1
-          fi
           if [ "${{ needs.electron.result }}" != "success" ]; then
             echo "Electron unit tests failed (result: ${{ needs.electron.result }})"
             exit 1
           fi
-          echo "All unit, browser, embedded, resolution, and electron checks passed."
+          echo "All unit, browser, embedded, and electron checks passed."

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,10 +71,12 @@ To change ports after init, edit `~/.config/celerp/config.toml` directly.
 2. else a PostgreSQL server reachable on `localhost:5432` → use it (as root, init
    provisions the role/database via `sudo -u postgres psql`; otherwise it prints the
    `CREATE USER`/`CREATE DATABASE` to run).
-3. else the **bundled** PostgreSQL — a self-contained cluster under
-   `~/.config/celerp/pgdata`, started from binaries shipped in the `pgserver` wheel. No
-   `sudo`, no system service. Available on CPython 3.10–3.12 for Linux x86_64, macOS, and
-   Windows x64; elsewhere init asks you to install PostgreSQL.
+3. else the **bundled** PostgreSQL 17 — a self-contained cluster under
+   `~/.config/celerp/pgdata`, started from binaries shipped in the
+   [`celerp-postgres`](https://github.com/celerp/celerp-postgres) wheel. No `sudo`, no
+   system service. Available on Linux x86_64/arm64 (glibc and musl/Alpine) and Windows
+   x64, any CPython; on macOS 26+ opt in with `pip install celerp-postgres`. Elsewhere
+   init asks you to install PostgreSQL.
 
 Override the detection with `--embedded` / `--no-embedded`. The chosen mode is written to
 `config.toml` as `[database] embedded = true|<absent>` and preserved across `--force`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,8 +58,37 @@ celerp upgrade    # pip install --upgrade celerp + migrate
 | `--force` | off | Overwrite existing config |
 | `--yes` / `-y` | off | Skip the `--force` wipe confirmation (non-interactive) |
 | `--no-start` | off | Set up, then exit WITHOUT launching servers (service-managed/headless) |
+| `--embedded` | off | Force the bundled PostgreSQL even if a server is reachable (cannot combine with `--db-url`) |
+| `--no-embedded` | off | Never fall back to the bundled PostgreSQL; require an external server |
 
 To change ports after init, edit `~/.config/celerp/config.toml` directly.
+
+### External vs embedded PostgreSQL
+
+`celerp init` picks the database automatically, and **an existing server always wins**:
+
+1. `--db-url` given → that external server (no detection).
+2. else a PostgreSQL server reachable on `localhost:5432` → use it (as root, init
+   provisions the role/database via `sudo -u postgres psql`; otherwise it prints the
+   `CREATE USER`/`CREATE DATABASE` to run).
+3. else the **bundled** PostgreSQL — a self-contained cluster under
+   `~/.config/celerp/pgdata`, started from binaries shipped in the `pgserver` wheel. No
+   `sudo`, no system service. Available on CPython 3.10–3.12 for Linux x86_64, macOS, and
+   Windows x64; elsewhere init asks you to install PostgreSQL.
+
+Override the detection with `--embedded` / `--no-embedded`. The chosen mode is written to
+`config.toml` as `[database] embedded = true|<absent>` and preserved across `--force`
+re-inits, so an external install never silently switches to the bundled cluster.
+
+**Moving bundled data to an external server** (e.g. outgrowing single-machine): dump from
+the bundled cluster and restore into the target, using the bundled tools so versions match.
+
+```bash
+BIN=$(celerp status >/dev/null; python -c "from celerp import embedded_pg; print(embedded_pg.bin_dir())")
+"$BIN/pg_dump" "$(python -c "from celerp import embedded_pg,pathlib; from celerp.config import config_path; print(embedded_pg.ensure_cluster(config_path().parent).replace('+asyncpg',''))")" \
+  | psql "postgresql://celerp:celerp@newhost:5432/celerp"
+celerp init --force --db-url "postgresql+asyncpg://celerp:celerp@newhost:5432/celerp"
+```
 
 ### Run as a service (systemd)
 
@@ -68,16 +97,23 @@ flow). For a headless box where a process manager owns the lifecycle, set up wit
 `--no-start` and let systemd run `celerp start`:
 
 ```bash
-# First boot: provision DB + migrations + config, then exit (do not block).
+# First boot against a system PostgreSQL: provision DB + migrations + config, then
+# exit (do not block). Run as root so init can create the role/database.
 sudo celerp init --no-start \
   --db-url "postgresql+asyncpg://celerp:<password>@localhost:5432/celerp" \
   --api-port 8000 --ui-port 8080
 ```
 
+Prefer the bundled database? Drop `--db-url` (and the `sudo` — the bundled cluster needs
+neither) and run `celerp init --no-start` as the service user. The cluster then lives under
+that user's `~/.config/celerp/pgdata`, and the systemd unit needs no `postgresql.service`
+dependency.
+
 ```ini
 # /etc/systemd/system/celerp.service
 [Unit]
 Description=Celerp
+# Drop the postgresql.service dependency line when using the bundled database.
 After=network.target postgresql.service
 
 [Service]

--- a/NOTICE
+++ b/NOTICE
@@ -25,12 +25,13 @@ Third-party components included in packaged desktop builds are governed by their
 own license files; see licenses/.
 
 Bundled PostgreSQL (pip distribution): on supported platforms the pip package
-declares a dependency on `pgserver`, whose wheels embed PostgreSQL server binaries
-so `celerp init` can run a self-contained database with no separate install.
-PostgreSQL is distributed under the PostgreSQL License (a permissive OSI-approved
-license); its full text and copyright notice ship inside the pgserver wheel. These
-binaries are used unmodified and only when no external PostgreSQL server is
-configured. `pgserver` itself is licensed by its upstream author; see
-https://github.com/orm011/pgserver.
+declares a dependency on `celerp-postgres` (MIT), whose wheels embed PostgreSQL
+server binaries and client tools so `celerp init` can run a self-contained
+database with no separate install. PostgreSQL is distributed under the PostgreSQL
+License (a permissive OSI-approved license); its full text and copyright notice
+ship inside the celerp-postgres wheels, which repackage binaries built by the
+theseus-rs/postgresql-binaries project. These binaries are used unmodified and
+only when no external PostgreSQL server is configured. See
+https://github.com/celerp/celerp-postgres.
 
 For commercial, OEM, or white-label inquiries: https://celerp.com

--- a/NOTICE
+++ b/NOTICE
@@ -24,4 +24,13 @@ see legal/TRADEMARK.md.
 Third-party components included in packaged desktop builds are governed by their
 own license files; see licenses/.
 
+Bundled PostgreSQL (pip distribution): on supported platforms the pip package
+declares a dependency on `pgserver`, whose wheels embed PostgreSQL server binaries
+so `celerp init` can run a self-contained database with no separate install.
+PostgreSQL is distributed under the PostgreSQL License (a permissive OSI-approved
+license); its full text and copyright notice ship inside the pgserver wheel. These
+binaries are used unmodified and only when no external PostgreSQL server is
+configured. `pgserver` itself is licensed by its upstream author; see
+https://github.com/orm011/pgserver.
+
 For commercial, OEM, or white-label inquiries: https://celerp.com

--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ celerp init        # sets up the database and launches Celerp
 Open **http://localhost:8080**. Done.
 Your office can securely access the system at your IP address :8080.
 
+No PostgreSQL to install: `celerp init` uses your existing PostgreSQL server if one is
+running, and otherwise starts a self-contained bundled database — no `sudo`, no system
+service. Point it at a specific server with `celerp init --db-url postgresql+asyncpg://…`.
+
 Running headless or under a process manager? Use `celerp init --no-start` to set up
 without launching, then have your service run `celerp start` — see
 [Run as a service (systemd)](CONTRIBUTING.md#run-as-a-service-systemd).
@@ -117,8 +121,12 @@ git clone git@github.com:celerp/celerp.git
 cd celerp
 python3 -m venv .venv && source .venv/bin/activate
 pip install -e ".[dev]"
-sudo celerp init   # creates DB, runs migrations, starts servers
+celerp init   # creates DB, runs migrations, starts servers
 ```
+
+`celerp init` boots a bundled PostgreSQL when no server is running, so no `sudo` and no
+system Postgres are required. To develop against your own server instead, pass
+`--db-url postgresql+asyncpg://…`.
 
 Open **http://localhost:8080**. Run tests with `pytest tests/`.
 

--- a/celerp/cli.py
+++ b/celerp/cli.py
@@ -273,6 +273,172 @@ def _test_db(db_url: str) -> str | None:
         return str(e)
 
 
+# ── Database mode resolution (external vs embedded) ────────────────────────────
+#
+# `celerp init` supports two ways to reach Postgres:
+#   external — a PostgreSQL server the user (or the droplet/apt) already runs.
+#   embedded — a self-contained cluster we boot from bundled binaries when the
+#              user has no server. See celerp.embedded_pg.
+# The rule is "an existing server always wins": embedded is only a fallback so
+# a machine with a real Postgres never ends up with two postmasters.
+
+
+def _is_root() -> bool:
+    """True only where we can `sudo -u postgres` to provision (POSIX, uid 0).
+
+    Guarded with hasattr because os.getuid() does not exist on Windows — the old
+    unguarded call raised AttributeError instead of showing guidance there.
+    """
+    return hasattr(os, "getuid") and os.getuid() == 0
+
+
+def _classify_probe(err: str | None) -> str:
+    """Map a connection attempt's outcome to server reachability.
+
+    Returns:
+      "ok"              — connected; server up and the target DB exists.
+      "needs_provision" — server is up but the role/database is missing or auth
+                          failed; external provisioning (root) can fix it.
+      "unreachable"     — nothing is listening (connection refused / timeout).
+
+    "needs_provision" still means a server EXISTS, so init stays in external
+    mode rather than booting an embedded cluster beside it.
+    """
+    if err is None:
+        return "ok"
+    low = err.lower()
+    # Server answered, but the role/db isn't set up yet, or auth was rejected.
+    if (
+        "does not exist" in low
+        or "authentication failed" in low
+        or "no password supplied" in low
+        or "role" in low and "does not exist" in low
+    ):
+        return "needs_provision"
+    # Nothing accepted the connection.
+    return "unreachable"
+
+
+def _resolve_db_mode(
+    *,
+    db_url: str | None,
+    server_reachable: bool | None,
+    provider_available: bool,
+    want_embedded: bool,
+    no_embedded: bool,
+    existing_embedded: bool | None = None,
+) -> tuple[str, str | None]:
+    """Pure decision function for `celerp init`'s database mode.
+
+    Returns (mode, error_kind) where mode is "external" | "embedded" | "error".
+    Kept side-effect-free so the whole branch table can be unit-tested without a
+    database.
+
+    Args:
+      db_url: explicit --db-url; taken at face value (external), never probed.
+      server_reachable: result of probing the default host; None when not probed.
+      provider_available: whether the embedded backend can run here.
+      want_embedded/no_embedded: the --embedded / --no-embedded overrides.
+      existing_embedded: the mode of an already-initialized instance (True/False),
+        or None for a fresh install. On `--force` this PRESERVES the instance's
+        mode so re-initializing an external install (e.g. a droplet) never flips
+        to embedded just because its server was momentarily unreachable.
+
+    Precedence: conflicting-flags → db_url → --embedded → --no-embedded →
+    existing config's mode → probe.
+    """
+    if want_embedded and no_embedded:
+        return ("error", "conflicting_flags")
+    if db_url and want_embedded:
+        # An explicit external URL and "force embedded" are contradictory.
+        return ("error", "db_url_with_embedded")
+    if db_url:
+        return ("external", None)
+    if want_embedded:
+        return ("embedded", None) if provider_available else ("error", "no_provider")
+    if no_embedded:
+        # User requires external. Reachable → use it; otherwise fail with external
+        # guidance rather than silently starting a cluster.
+        return ("external", None) if server_reachable else ("error", "no_server_external_only")
+    if existing_embedded is True:
+        return ("embedded", None) if provider_available else ("error", "no_provider")
+    if existing_embedded is False:
+        return ("external", None)
+    # Fresh install, no overrides: an existing server always wins.
+    if server_reachable:
+        return ("external", None)
+    if provider_available:
+        return ("embedded", None)
+    return ("error", "no_server_no_provider")
+
+
+def _emit_db_error(kind: str, db_url: str) -> None:
+    """Print actionable guidance for a resolve/connect failure (stderr)."""
+    if kind == "conflicting_flags":
+        click.echo("  ✗ --embedded and --no-embedded are mutually exclusive.", err=True)
+        return
+    if kind == "db_url_with_embedded":
+        click.echo(
+            "  ✗ --embedded cannot be combined with --db-url (which selects an "
+            "external server).",
+            err=True,
+        )
+        return
+    if kind == "no_provider":
+        click.echo(
+            "  ✗ Embedded PostgreSQL is not available on this platform "
+            f"(Python {sys.version_info.major}.{sys.version_info.minor}, "
+            f"{sys.platform}).",
+            err=True,
+        )
+        click.echo(
+            "\nInstall PostgreSQL and re-run, or use a supported Python "
+            "(CPython 3.10–3.12 on Linux x86_64, macOS, or Windows x64).",
+            err=True,
+        )
+        return
+    # no_server_external_only / no_server_no_provider: nothing was listening.
+    click.echo(f"  ✗ No PostgreSQL server found at {db_url}.", err=True)
+    if kind == "no_server_external_only":
+        click.echo(
+            "\n--no-embedded was set, so no cluster was started. Install and start "
+            "PostgreSQL, then re-run `celerp init`.",
+            err=True,
+        )
+        return
+    # no_server_no_provider — embedded unavailable AND no server.
+    click.echo(
+        "\nInstall PostgreSQL and start it, then re-run `celerp init` — or use a "
+        "supported Python (CPython 3.10–3.12 on Linux x86_64, macOS, or Windows "
+        "x64) to get the bundled database automatically.",
+        err=True,
+    )
+    if sys.platform.startswith("linux"):
+        click.echo("  e.g.  sudo apt install postgresql && sudo service postgresql start", err=True)
+
+
+def ensure_database(cfg: dict) -> None:
+    """Boot the embedded cluster for a DB-touching command, if this install uses
+    one, and refresh the connection URI in `cfg` in place.
+
+    No-op for external mode (never imports the embedded provider, so external
+    installs — including every droplet — are unaffected). Idempotent: safe to
+    call from every command that reads cfg["database"]["url"].
+    """
+    db = cfg.get("database", {})
+    if not db.get("embedded"):
+        return
+    from celerp import embedded_pg
+
+    config_dir = _config_path().parent
+    # Re-derive the URI on every boot rather than trusting the stored one: the
+    # unix-socket path lives under a runtime dir that a reboot can relocate.
+    db["url"] = embedded_pg.ensure_cluster(config_dir)
+    bd = embedded_pg.bin_dir()
+    if bd:
+        cfg.setdefault("backup", {}).setdefault("pg_bin_dir", bd)
+
+
 def _run_upgrade_with_auto_stamp(alembic_cfg, engine_url: str) -> None:
     """Run alembic upgrade head, auto-stamping past any already-applied revisions.
 
@@ -464,6 +630,103 @@ def _reconcile_after_migrate(db_url: str) -> None:
         engine.dispose()
 
 
+def _wipe_attachment_dirs(purge_dirs: list) -> None:
+    """Remove attached-file directories on --force so a re-init is truly fresh."""
+    import shutil
+    for _d in purge_dirs:
+        if _d.exists():
+            shutil.rmtree(_d, ignore_errors=True)
+            click.echo(f"  ✓ Removed {_d.resolve()}")
+
+
+def _init_embedded(cfg: dict, config_dir: "Path", *, force: bool, purge_dirs: list) -> None:
+    """Provision the bundled PostgreSQL cluster and point cfg at it.
+
+    No sudo, no ownership/grant dance: the app connects as the cluster superuser
+    over a unix socket, so it owns every object it creates.
+    """
+    from celerp import embedded_pg
+
+    if force:
+        click.echo("Wiping embedded database for fresh init...")
+        embedded_pg.wipe(config_dir)
+        _wipe_attachment_dirs(purge_dirs)
+        click.echo("  ✓ Database ready (fresh)")
+
+    click.echo("Starting embedded PostgreSQL...")
+    uri = embedded_pg.ensure_cluster(config_dir)
+    cfg["database"]["url"] = uri
+    cfg["database"]["embedded"] = True
+    bd = embedded_pg.bin_dir()
+    if bd:
+        cfg.setdefault("backup", {})["pg_bin_dir"] = bd
+    click.echo(f"  ✓ Using embedded PostgreSQL at {embedded_pg.pgdata_dir(config_dir)}")
+
+
+def _init_external(cfg: dict, *, force: bool, db_url: str | None, purge_dirs: list) -> None:
+    """Connect to (and, as root, provision) an external PostgreSQL server.
+
+    This is the pre-existing path, preserved verbatim for the droplet/self-hosted
+    contract: explicit --db-url, root auto-provisioning via `sudo -u postgres`,
+    and the same connect-or-guidance flow for non-root.
+    """
+    if force:
+        click.echo("Wiping database for fresh init...")
+        db_url_for_wipe = db_url or _DEFAULT_DB_URL
+        try:
+            _provision_db(db_url_for_wipe, drop_existing=True)
+        except RuntimeError as e:
+            click.echo(f"  ✗ DB wipe failed: {e}", err=True)
+            click.echo("\nEnsure PostgreSQL is running and you have sudo access.", err=True)
+            sys.exit(1)
+        click.echo("  ✓ Database ready (fresh)")
+        _wipe_attachment_dirs(purge_dirs)
+        return
+
+    click.echo("Connecting to database...")
+    err = _test_db(cfg["database"]["url"])
+    if not err:
+        click.echo("  ✓ Database connection OK")
+        return
+    if _is_root():
+        click.echo("  · Could not connect — attempting to provision database...")
+        try:
+            _provision_db(cfg["database"]["url"])
+        except RuntimeError as e:
+            click.echo(f"  ✗ Provisioning failed: {e}", err=True)
+            click.echo("\nEnsure PostgreSQL is installed and running, then retry with sudo.", err=True)
+            sys.exit(1)
+        err = _test_db(cfg["database"]["url"])
+        if err:
+            click.echo(f"  ✗ Still could not connect after provisioning: {err}", err=True)
+            sys.exit(1)
+        click.echo("  ✓ Database connection OK")
+        return
+    # Non-root and the server rejected us. On POSIX, sudo can provision; on
+    # Windows there is no `sudo -u postgres`, so only suggest it where it works.
+    click.echo(f"  ✗ Could not connect: {err}", err=True)
+    import shutil
+    real_bin = shutil.which("celerp") or "celerp"
+    if hasattr(os, "getuid"):
+        click.echo(
+            f"\nRe-run with sudo to have Celerp create the database automatically:\n"
+            f"  sudo {real_bin} init\n"
+            "\nOr create it manually:\n"
+            "  sudo -u postgres psql -c \"CREATE USER celerp WITH PASSWORD 'celerp';\"\n"
+            "  sudo -u postgres psql -c \"CREATE DATABASE celerp OWNER celerp;\"",
+            err=True,
+        )
+    else:
+        click.echo(
+            "\nCreate the database and role on your PostgreSQL server, then re-run "
+            "`celerp init --db-url ...`:\n"
+            "  CREATE USER celerp WITH PASSWORD 'celerp';\n"
+            "  CREATE DATABASE celerp OWNER celerp;",
+            err=True,
+        )
+    sys.exit(1)
+
+
 # ── Commands ──────────────────────────────────────────────────────────────────
 
 @click.group()
@@ -484,8 +747,23 @@ def main() -> None:
          "WITHOUT launching the servers. For service-managed/headless installs "
          "where a process manager (e.g. systemd) runs `celerp start`.",
 )
-def init(db_url, api_port, ui_port, cloud_token, force, assume_yes, no_start):
-    """Initialize Celerp: write config and run database migrations."""
+@click.option(
+    "--embedded", "want_embedded", is_flag=True,
+    help="Force the bundled PostgreSQL even if a server is reachable. "
+         "Cannot be combined with --db-url.",
+)
+@click.option(
+    "--no-embedded", "no_embedded", is_flag=True,
+    help="Never fall back to the bundled PostgreSQL; require an external server.",
+)
+def init(db_url, api_port, ui_port, cloud_token, force, assume_yes, no_start, want_embedded, no_embedded):
+    """Initialize Celerp: write config and run database migrations.
+
+    With no --db-url, init uses an existing PostgreSQL server if one is running,
+    and otherwise boots a self-contained bundled cluster (no sudo, no system
+    service). An existing server always wins; pass --embedded / --no-embedded to
+    override the auto-detection.
+    """
     config_path = _config_path()
 
     if config_path.exists() and not force:
@@ -493,16 +771,49 @@ def init(db_url, api_port, ui_port, cloud_token, force, assume_yes, no_start):
         click.echo("Run `celerp migrate` to apply updates, or `celerp init --force` to reconfigure.")
         return
 
+    from celerp import embedded_pg
+
+    # ── Resolve external vs embedded ──────────────────────────────────────────
+    # On --force, config_path exists: preserve the initialized instance's mode so
+    # re-init never flips an external install (e.g. a droplet) to embedded.
+    existing_cfg = _read_config() if config_path.exists() else {}
+    existing_embedded = (
+        bool(existing_cfg.get("database", {}).get("embedded")) if existing_cfg else None
+    )
+    provider_available = embedded_pg.is_available()
+    # Probe the default host only when nothing else determines the mode — an
+    # explicit --db-url/--embedded, or a known existing mode, needs no probe.
+    server_reachable: bool | None = None
+    need_probe = not db_url and not want_embedded and (no_embedded or existing_embedded is None)
+    if need_probe:
+        server_reachable = _classify_probe(_test_db(_DEFAULT_DB_URL)) in ("ok", "needs_provision")
+    mode, error_kind = _resolve_db_mode(
+        db_url=db_url,
+        server_reachable=server_reachable,
+        provider_available=provider_available,
+        want_embedded=want_embedded,
+        no_embedded=no_embedded,
+        existing_embedded=existing_embedded,
+    )
+    if mode == "error":
+        _emit_db_error(error_kind, db_url or _DEFAULT_DB_URL)
+        sys.exit(1)
+
+    config_dir = config_path.parent
+
     if force:
-        # --force is destructive: it drops the database AND removes attached files.
-        # init can run under sudo, so warn (with full paths) and confirm before wiping.
+        # --force is destructive: it wipes the database AND attached files.
+        # init can run under sudo, so warn (with full paths) and confirm first.
         from celerp.config import settings
         _purge_dirs = [
             settings.data_dir / "static" / "attachments",
             settings.data_dir / "ai_uploads",
         ]
         click.echo("⚠  `init --force` permanently WIPES this instance:")
-        click.echo(f"     - database: {db_url or _DEFAULT_DB_URL}")
+        if mode == "embedded":
+            click.echo(f"     - database: embedded cluster at {embedded_pg.pgdata_dir(config_dir)}")
+        else:
+            click.echo(f"     - database: {db_url or _DEFAULT_DB_URL}")
         for _d in _purge_dirs:
             click.echo(f"     - files:    {_d.resolve()}")
         click.echo("   Make sure you have a backup.")
@@ -523,62 +834,10 @@ def init(db_url, api_port, ui_port, cloud_token, force, assume_yes, no_start):
         "modules": {"enabled": enabled_modules},
     }
 
-    # --force: drop + recreate the database so the setup wizard appears fresh
-    if force:
-        click.echo("Wiping database for fresh init...")
-        db_url_for_wipe = db_url or _DEFAULT_DB_URL
-        try:
-            _provision_db(db_url_for_wipe, drop_existing=True)
-        except RuntimeError as e:
-            click.echo(f"  ✗ DB wipe failed: {e}", err=True)
-            click.echo(
-                "\nEnsure PostgreSQL is running and you have sudo access.",
-                err=True,
-            )
-            sys.exit(1)
-        click.echo("  ✓ Database ready (fresh)")
-        # Wipe attached files too, so a forced re-init is a truly fresh instance and no
-        # orphaned files remain. Recreated automatically on next boot.
-        import shutil
-        for _d in _purge_dirs:
-            if _d.exists():
-                shutil.rmtree(_d, ignore_errors=True)
-                click.echo(f"  ✓ Removed {_d.resolve()}")
+    if mode == "embedded":
+        _init_embedded(cfg, config_dir, force=force, purge_dirs=_purge_dirs if force else [])
     else:
-        # Test DB connection — auto-provision if running as root
-        click.echo("Connecting to database...")
-        err = _test_db(cfg["database"]["url"])
-        if err:
-            if os.getuid() == 0:
-                click.echo("  · Could not connect — attempting to provision database...")
-                try:
-                    _provision_db(cfg["database"]["url"])
-                except RuntimeError as e:
-                    click.echo(f"  ✗ Provisioning failed: {e}", err=True)
-                    click.echo(
-                        "\nEnsure PostgreSQL is installed and running, then retry with sudo.",
-                        err=True,
-                    )
-                    sys.exit(1)
-                # Verify connection now works
-                err = _test_db(cfg["database"]["url"])
-                if err:
-                    click.echo(f"  ✗ Still could not connect after provisioning: {err}", err=True)
-                    sys.exit(1)
-            else:
-                click.echo(f"  ✗ Could not connect: {err}", err=True)
-                import shutil
-                real_bin = shutil.which("celerp") or "celerp"
-                click.echo(
-                    f"\nRe-run with sudo to have Celerp create the database automatically:\n"
-                    f"  sudo {real_bin} init\n"
-                    "\nOr create it manually:\n"
-                    "  sudo -u postgres psql -c \"CREATE USER celerp WITH PASSWORD 'celerp';\"\n"
-                    "  sudo -u postgres psql -c \"CREATE DATABASE celerp OWNER celerp;\"",
-                    err=True,
-                )
-                sys.exit(1)
-        click.echo("  ✓ Database connection OK")
+        _init_external(cfg, force=force, db_url=db_url, purge_dirs=_purge_dirs if force else [])
 
     # Fix table ownership before migrations (covers tables created by postgres superuser)
     db_url_val = cfg["database"]["url"]
@@ -720,6 +979,7 @@ def reset_password(email: str, password: str) -> None:
     if not cfg:
         click.echo("Not initialized. Run `celerp init` first.", err=True)
         sys.exit(1)
+    ensure_database(cfg)
     db_url = cfg["database"]["url"]
     sync_url = db_url.replace("postgresql+asyncpg://", "postgresql://")
     try:
@@ -748,6 +1008,7 @@ def start():
     if not cfg:
         click.echo("Not initialized. Run `celerp init` first.", err=True)
         sys.exit(1)
+    ensure_database(cfg)
     _start(cfg)
 
 
@@ -761,6 +1022,7 @@ def migrate(db_url):
         if not cfg:
             click.echo("Not initialized. Run `celerp init` first.", err=True)
             sys.exit(1)
+        ensure_database(cfg)
         url = cfg["database"]["url"]
     click.echo("Running migrations...")
     _run_migrations(url)
@@ -780,11 +1042,14 @@ def status():
         click.echo("Run `celerp init` to initialize.")
         return
 
+    is_embedded = cfg.get("database", {}).get("embedded")
+    ensure_database(cfg)
     db_url = cfg["database"]["url"]
     # Mask password in display
     import re
     display_url = re.sub(r"://([^:]+):([^@]+)@", r"://\1:***@", db_url)
-    click.echo(f"Database: {display_url}")
+    prefix = "embedded (bundled PostgreSQL) — " if is_embedded else ""
+    click.echo(f"Database: {prefix}{display_url}")
 
     err = _test_db(db_url)
     click.echo(f"  DB connection: {'✓ OK' if not err else f'✗ {err}'}")
@@ -831,6 +1096,7 @@ def demo():
     if not cfg:
         click.echo("Not initialized. Run `celerp init` first.", err=True)
         sys.exit(1)
+    ensure_database(cfg)
     env = _config_to_env(cfg)
     pkg_root = Path(__file__).parent.parent
     script = pkg_root / "scripts" / "seed_demo.py"
@@ -853,6 +1119,7 @@ def upgrade():
     if not cfg:
         click.echo("Not initialized. Run `celerp init` first.", err=True)
         sys.exit(1)
+    ensure_database(cfg)
     _run_migrations(cfg["database"]["url"])
     click.echo("✓ Upgrade complete")
 

--- a/celerp/cli.py
+++ b/celerp/cli.py
@@ -386,16 +386,20 @@ def _emit_db_error(kind: str, db_url: str) -> None:
         return
     if kind == "no_provider":
         click.echo(
-            "  ✗ Embedded PostgreSQL is not available on this platform "
-            f"(Python {sys.version_info.major}.{sys.version_info.minor}, "
-            f"{sys.platform}).",
+            f"  ✗ Embedded PostgreSQL is not available on this platform ({sys.platform}).",
             err=True,
         )
         click.echo(
-            "\nInstall PostgreSQL and re-run, or use a supported Python "
-            "(CPython 3.10–3.12 on Linux x86_64, macOS, or Windows x64).",
+            "\nInstall PostgreSQL and re-run, or use a supported platform "
+            "(Linux x86_64/arm64 — glibc or musl — or Windows x64).",
             err=True,
         )
+        if sys.platform == "darwin":
+            click.echo(
+                "On macOS 26 or newer: pip install celerp-postgres — then re-run "
+                "`celerp init` for the bundled database.",
+                err=True,
+            )
         return
     # no_server_external_only / no_server_no_provider: nothing was listening.
     click.echo(f"  ✗ No PostgreSQL server found at {db_url}.", err=True)
@@ -409,8 +413,8 @@ def _emit_db_error(kind: str, db_url: str) -> None:
     # no_server_no_provider — embedded unavailable AND no server.
     click.echo(
         "\nInstall PostgreSQL and start it, then re-run `celerp init` — or use a "
-        "supported Python (CPython 3.10–3.12 on Linux x86_64, macOS, or Windows "
-        "x64) to get the bundled database automatically.",
+        "supported platform (Linux x86_64/arm64 — glibc or musl — or Windows x64) "
+        "to get the bundled database automatically.",
         err=True,
     )
     if sys.platform.startswith("linux"):

--- a/celerp/config.py
+++ b/celerp/config.py
@@ -236,7 +236,13 @@ def write_config(cfg: dict) -> None:
 
     if "database" in cfg:
         db = cfg["database"]
-        lines += ["[database]", f'url = {_str(db.get("url", ""))}', ""]
+        lines += ["[database]", f'url = {_str(db.get("url", ""))}']
+        # `embedded = true` marks a bundled-PostgreSQL install so later commands
+        # boot the cluster before connecting. Absent key = external (all configs
+        # written before this shipped), so external installs are unchanged.
+        if db.get("embedded"):
+            lines += ["embedded = true"]
+        lines += [""]
 
     if "auth" in cfg:
         auth = cfg["auth"]

--- a/celerp/embedded_pg.py
+++ b/celerp/embedded_pg.py
@@ -4,39 +4,49 @@
 
 The pip package ships client drivers only; a self-hosted user with no system
 Postgres previously hit "connection refused" on `celerp init`. This module boots
-a self-contained PostgreSQL cluster (bundled binaries, no sudo, no system
-service) under the user's config directory, giving the pip path the same
-zero-setup experience the Electron desktop app already provides.
+a self-contained PostgreSQL 17 cluster from the binaries in the `celerp-postgres`
+wheel (no sudo, no system service), giving the pip path the same zero-setup
+experience the Electron desktop app already provides.
 
-Everything provider-specific (currently `pgserver`) is isolated here behind a
-tiny interface — `is_available()`, `ensure_cluster()`, `bin_dir()`, `wipe()` —
-so the backing implementation can be swapped (e.g. for our own PostgreSQL wheels
-built from the same binaries the desktop app uses) without touching the CLI.
+The cluster manager lives here in full — initdb, pg_ctl start/stop, database
+creation — behind a small seam (`is_available/ensure_cluster/bin_dir/pgdata_dir/
+wipe`) so the binary source can be swapped without touching the CLI.
 
-The cluster is loopback/unix-socket only and single-user: it is never bound to a
-TCP port on POSIX and never exposed off-host. `celerp init` only falls back to it
-when no PostgreSQL server is already reachable — an existing server always wins.
+The cluster is loopback/unix-socket only and single-user: on POSIX it listens on
+a private socket directory (never TCP); on Windows on 127.0.0.1 with a port
+persisted in the data dir. `celerp init` only falls back to it when no PostgreSQL
+server is already reachable — an existing server always wins.
 """
 
 from __future__ import annotations
 
+import hashlib
+import os
+import subprocess
+import sys
 from pathlib import Path
 
 # Name of the application database created inside the embedded cluster. The
 # cluster's bootstrap superuser is `postgres`; the app connects as that user
-# over a unix socket, so no role/password provisioning (and no sudo) is needed.
+# locally, so no role/password provisioning (and no sudo) is needed.
 _DATABASE = "celerp"
+
+# pg_ctl handles we started in this process, stopped again at exit so no
+# postmaster outlives `celerp start` (its SIGTERM handler exits via sys.exit,
+# which runs atexit hooks).
+_STARTED: set[Path] = set()
 
 
 def is_available() -> bool:
     """True if the embedded-Postgres backend can run on this interpreter.
 
-    False on platforms with no prebuilt wheel (CPython ≥3.13, linux-aarch64,
-    …), where the marker-guarded dependency is simply absent. Callers treat a
-    False here as "embedded mode unavailable" and fall back to external guidance.
+    The `celerp-postgres` dependency is marker-limited to platforms with wheels
+    (Linux x86_64/aarch64 glibc+musl, Windows x64); macOS 26+ users can install
+    it manually. A False here means "embedded mode unavailable" and callers fall
+    back to external guidance.
     """
     try:
-        import pgserver  # noqa: F401
+        import celerp_postgres  # noqa: F401
     except Exception:
         return False
     return True
@@ -47,63 +57,188 @@ def pgdata_dir(config_dir: Path) -> Path:
 
     Kept next to config.toml (`~/.config/celerp/pgdata`) rather than under the
     cwd-relative `settings.data_dir`, so the cluster is found regardless of which
-    directory `celerp` is invoked from. Mirrors the Electron app keeping its
-    cluster under `userData/celerp-data/postgres/`.
+    directory `celerp` is invoked from.
     """
     return Path(config_dir) / "pgdata"
-
-
-def ensure_cluster(config_dir: Path) -> str:
-    """Boot the embedded cluster (initdb on first run, start otherwise) and
-    ensure the `celerp` database exists. Returns an asyncpg connection URI.
-
-    Idempotent: pgserver refcounts by pgdata path, so repeated calls in one
-    process return the same running server. The server is stopped (data
-    preserved) when the process exits, via pgserver's `cleanup_mode='stop'`
-    handle — the SIGTERM/SIGINT handlers in `celerp start` exit through
-    `sys.exit`, which runs that atexit hook, so no postmaster is orphaned.
-    """
-    import pgserver
-
-    config_dir = Path(config_dir)
-    # get_server requires pgdata's PARENT to exist; it creates pgdata itself.
-    config_dir.mkdir(parents=True, exist_ok=True)
-    pgdata = pgdata_dir(config_dir)
-
-    server = pgserver.get_server(pgdata, cleanup_mode="stop")
-    _ensure_app_database(server)
-
-    uri = server.get_uri(database=_DATABASE)
-    # pgserver yields a psycopg2-style URI; the app connects via asyncpg.
-    return uri.replace("postgresql://", "postgresql+asyncpg://", 1)
-
-
-def _ensure_app_database(server) -> None:
-    """Create the `celerp` database if the cluster only has the default one.
-
-    A fresh cluster ships with just `postgres`; `get_server` does not create our
-    app DB. The connecting user is the cluster superuser, so the app owns every
-    object it creates — none of the `sudo -u postgres` ownership/grant dance the
-    external path needs applies here.
-    """
-    out = server.psql(
-        f"SELECT 1 FROM pg_database WHERE datname = '{_DATABASE}'"
-    )
-    if "(1 row)" not in out:
-        server.psql(f"CREATE DATABASE {_DATABASE}")
 
 
 def bin_dir() -> str | None:
     """Directory holding the bundled `pg_dump`/`pg_restore`, or None if the
     backend is unavailable. Wired into `[backup] pg_bin_dir` so backups use the
-    matching-version tools rather than a system pg_dump of unknown version.
-    """
+    matching-version tools rather than a system pg_dump of unknown version."""
     try:
-        import pgserver
+        import celerp_postgres
     except Exception:
         return None
-    cand = Path(pgserver.__file__).parent / "pginstall" / "bin"
-    return str(cand) if cand.is_dir() else None
+    return celerp_postgres.bin_dir()
+
+
+# ── internals ─────────────────────────────────────────────────────────────────
+
+
+def _tool(name: str) -> str:
+    import celerp_postgres
+
+    return celerp_postgres.tool(name)
+
+
+def _env() -> dict:
+    """Subprocess env for the PG tools. On musl wheels ICU reads its data from
+    a bundled file that must be pointed at via ICU_DATA (PG17's initdb always
+    version-checks the built-in 'unicode' ICU collation)."""
+    import celerp_postgres
+
+    env = os.environ.copy()
+    icu = celerp_postgres.icu_data_dir() if hasattr(celerp_postgres, "icu_data_dir") else None
+    if icu:
+        env["ICU_DATA"] = icu
+    return env
+
+
+def _socket_dir(pgdata: Path) -> Path:
+    """Deterministic, SHORT socket directory for this cluster.
+
+    Derived from the pgdata path so the stored URI stays valid across reboots,
+    and placed under /tmp because a socket path inside a deep config dir can
+    exceed the 107-char AF_UNIX limit.
+    """
+    h = hashlib.sha1(str(Path(pgdata).resolve()).encode()).hexdigest()[:10]
+    return Path("/tmp") / f"celerp-pg-{h}"
+
+
+def _win_port(pgdata: Path) -> int:
+    """Windows: loopback TCP port, chosen once and persisted in the data dir so
+    the stored URI stays valid across restarts."""
+    pf = pgdata / "celerp.port"
+    if pf.exists():
+        return int(pf.read_text().strip())
+    import socket
+
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        port = s.getsockname()[1]
+    pf.write_text(str(port))
+    return port
+
+
+def _run(cmd: list[str], fail_hint: str) -> subprocess.CompletedProcess:
+    r = subprocess.run(cmd, capture_output=True, text=True, env=_env())
+    if r.returncode:
+        raise RuntimeError(
+            f"{fail_hint} (rc={r.returncode})\n"
+            f"STDOUT: {r.stdout[-1200:]}\nSTDERR: {r.stderr[-1200:]}"
+        )
+    return r
+
+
+def _is_running(pgdata: Path) -> bool:
+    r = subprocess.run(
+        [_tool("pg_ctl"), "status", "-D", str(pgdata)],
+        capture_output=True, text=True, env=_env(),
+    )
+    return r.returncode == 0
+
+
+def _initdb(pgdata: Path) -> None:
+    # libc locale provider: keeps the cluster independent of ICU data at its
+    # core; ICU stays available for opt-in per-collation use.
+    _run(
+        [_tool("initdb"), "-D", str(pgdata), "-U", "postgres", "-A", "trust",
+         "-E", "UTF8", "--locale-provider=libc"],
+        "embedded PostgreSQL initdb failed",
+    )
+
+
+def _start(pgdata: Path) -> tuple[str, int | None]:
+    """Start the postmaster (idempotent); returns (host, port) — host is the
+    socket dir on POSIX (port None), 127.0.0.1 on Windows."""
+    if os.name == "nt":
+        host: str = "127.0.0.1"
+        port: int | None = _win_port(pgdata)
+        opts = f"-c listen_addresses=127.0.0.1 -c port={port}"
+    else:
+        sock = _socket_dir(pgdata)
+        sock.mkdir(mode=0o700, exist_ok=True)
+        host, port = str(sock), None
+        opts = f"-c listen_addresses='' -c unix_socket_directories='{sock}'"
+
+    if not _is_running(pgdata):
+        log = pgdata / "server.log"
+        try:
+            _run(
+                [_tool("pg_ctl"), "-D", str(pgdata), "-w", "-t", "60",
+                 "-o", opts, "-l", str(log), "start"],
+                "embedded PostgreSQL failed to start",
+            )
+        except RuntimeError as e:
+            tail = log.read_text()[-1200:] if log.exists() else "-"
+            raise RuntimeError(f"{e}\nSERVERLOG: {tail}") from None
+        if pgdata not in _STARTED:
+            _STARTED.add(pgdata)
+            if not _STARTED - {pgdata}:  # first cluster this process started
+                import atexit
+
+                atexit.register(_stop_all)
+    return host, port
+
+
+def _stop_all() -> None:
+    """atexit: stop every postmaster this process started (data preserved)."""
+    for pgdata in list(_STARTED):
+        subprocess.run(
+            [_tool("pg_ctl"), "-D", str(pgdata), "-w", "-t", "30", "-m", "fast", "stop"],
+            capture_output=True, text=True, env=_env(),
+        )
+        _STARTED.discard(pgdata)
+
+
+def _uri(host: str, port: int | None, database: str) -> str:
+    if port is not None:
+        return f"postgresql+asyncpg://postgres@{host}:{port}/{database}"
+    return f"postgresql+asyncpg://postgres@/{database}?host={host}"
+
+
+def _ensure_app_database(host: str, port: int | None) -> None:
+    """Create the `celerp` database if missing, via the `postgres` maintenance
+    DB (CREATE DATABASE needs autocommit). The connecting user is the cluster
+    superuser, so none of the external path's sudo/ownership dance applies."""
+    from sqlalchemy import create_engine, text
+
+    engine = create_engine(
+        _uri(host, port, "postgres").replace("+asyncpg", ""),
+        isolation_level="AUTOCOMMIT",
+    )
+    try:
+        with engine.connect() as conn:
+            exists = conn.execute(
+                text("SELECT 1 FROM pg_database WHERE datname = :d"), {"d": _DATABASE}
+            ).scalar()
+            if not exists:
+                conn.execute(text(f'CREATE DATABASE "{_DATABASE}"'))
+    finally:
+        engine.dispose()
+
+
+# ── public lifecycle ──────────────────────────────────────────────────────────
+
+
+def ensure_cluster(config_dir: Path) -> str:
+    """Boot the embedded cluster (initdb on first run, start if stopped) and
+    ensure the app database exists. Returns an asyncpg connection URI.
+
+    Idempotent: safe to call from every DB-touching CLI command. Postgres itself
+    recovers stale postmaster.pid files from crashed processes on start.
+    """
+    config_dir = Path(config_dir)
+    config_dir.mkdir(parents=True, exist_ok=True)
+    pgdata = pgdata_dir(config_dir)
+
+    if not (pgdata / "PG_VERSION").exists():
+        pgdata.mkdir(parents=True, exist_ok=True)
+        _initdb(pgdata)
+    host, port = _start(pgdata)
+    _ensure_app_database(host, port)
+    return _uri(host, port, _DATABASE)
 
 
 def wipe(config_dir: Path) -> None:
@@ -118,19 +253,14 @@ def wipe(config_dir: Path) -> None:
     if not pgdata.exists():
         return
     try:
-        import pgserver
-
-        # cleanup_mode='delete' is what actually stops the postmaster AND removes
-        # pgdata; 'stop' only stops it. cleanup() is gated on this process holding
-        # the last handle, which a fresh `init --force` process does.
-        server = pgserver.get_server(pgdata, cleanup_mode="delete")
-        server.cleanup()
+        if _is_running(pgdata):
+            subprocess.run(
+                [_tool("pg_ctl"), "-D", str(pgdata), "-w", "-t", "30", "-m", "fast", "stop"],
+                capture_output=True, text=True, env=_env(),
+            )
+        _STARTED.discard(pgdata)
     except Exception:
-        # Provider missing, or a stale cross-process handle made pgserver decline
-        # to act — fall through to the unconditional rmtree below.
         pass
-    # Belt-and-suspenders: guarantee the directory is gone even if pgserver's
-    # refcount bookkeeping left it (a crashed prior process can do this).
     if pgdata.exists():
         _force_stop_postmaster(pgdata)
         shutil.rmtree(pgdata, ignore_errors=True)

--- a/celerp/embedded_pg.py
+++ b/celerp/embedded_pg.py
@@ -121,8 +121,8 @@ def _win_port(pgdata: Path) -> int:
     return port
 
 
-def _run(cmd: list[str], fail_hint: str) -> subprocess.CompletedProcess:
-    r = subprocess.run(cmd, capture_output=True, text=True, env=_env())
+def _run(cmd: list[str], fail_hint: str, cwd: str | None = None) -> subprocess.CompletedProcess:
+    r = subprocess.run(cmd, capture_output=True, text=True, env=_env(), cwd=cwd)
     if r.returncode:
         raise RuntimeError(
             f"{fail_hint} (rc={r.returncode})\n"
@@ -142,10 +142,16 @@ def _is_running(pgdata: Path) -> bool:
 def _initdb(pgdata: Path) -> None:
     # libc locale provider: keeps the cluster independent of ICU data at its
     # core; ICU stays available for opt-in per-collation use.
+    #
+    # Relative single-component -D with cwd at the parent: initdb then creates
+    # exactly one directory and never walks the ancestor chain, which
+    # misfires on some Windows environments (GitHub runners error "File
+    # exists" on existing intermediates).
     _run(
-        [_tool("initdb"), "-D", str(pgdata), "-U", "postgres", "-A", "trust",
+        [_tool("initdb"), "-D", pgdata.name, "-U", "postgres", "-A", "trust",
          "-E", "UTF8", "--locale-provider=libc"],
         "embedded PostgreSQL initdb failed",
+        cwd=str(pgdata.parent),
     )
 
 

--- a/celerp/embedded_pg.py
+++ b/celerp/embedded_pg.py
@@ -234,7 +234,9 @@ def ensure_cluster(config_dir: Path) -> str:
     pgdata = pgdata_dir(config_dir)
 
     if not (pgdata / "PG_VERSION").exists():
-        pgdata.mkdir(parents=True, exist_ok=True)
+        # Let initdb create the pgdata leaf itself (its parent exists above).
+        # Pre-creating it trips Windows initdb's ancestor walk ("could not
+        # create directory ...: File exists").
         _initdb(pgdata)
     host, port = _start(pgdata)
     _ensure_app_database(host, port)

--- a/celerp/embedded_pg.py
+++ b/celerp/embedded_pg.py
@@ -1,0 +1,160 @@
+# Copyright (c) 2026 Noah Severs
+# SPDX-License-Identifier: BUSL-1.1
+"""Embedded PostgreSQL provider for pip installs.
+
+The pip package ships client drivers only; a self-hosted user with no system
+Postgres previously hit "connection refused" on `celerp init`. This module boots
+a self-contained PostgreSQL cluster (bundled binaries, no sudo, no system
+service) under the user's config directory, giving the pip path the same
+zero-setup experience the Electron desktop app already provides.
+
+Everything provider-specific (currently `pgserver`) is isolated here behind a
+tiny interface — `is_available()`, `ensure_cluster()`, `bin_dir()`, `wipe()` —
+so the backing implementation can be swapped (e.g. for our own PostgreSQL wheels
+built from the same binaries the desktop app uses) without touching the CLI.
+
+The cluster is loopback/unix-socket only and single-user: it is never bound to a
+TCP port on POSIX and never exposed off-host. `celerp init` only falls back to it
+when no PostgreSQL server is already reachable — an existing server always wins.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+# Name of the application database created inside the embedded cluster. The
+# cluster's bootstrap superuser is `postgres`; the app connects as that user
+# over a unix socket, so no role/password provisioning (and no sudo) is needed.
+_DATABASE = "celerp"
+
+
+def is_available() -> bool:
+    """True if the embedded-Postgres backend can run on this interpreter.
+
+    False on platforms with no prebuilt wheel (CPython ≥3.13, linux-aarch64,
+    …), where the marker-guarded dependency is simply absent. Callers treat a
+    False here as "embedded mode unavailable" and fall back to external guidance.
+    """
+    try:
+        import pgserver  # noqa: F401
+    except Exception:
+        return False
+    return True
+
+
+def pgdata_dir(config_dir: Path) -> Path:
+    """Location of the embedded cluster's data directory.
+
+    Kept next to config.toml (`~/.config/celerp/pgdata`) rather than under the
+    cwd-relative `settings.data_dir`, so the cluster is found regardless of which
+    directory `celerp` is invoked from. Mirrors the Electron app keeping its
+    cluster under `userData/celerp-data/postgres/`.
+    """
+    return Path(config_dir) / "pgdata"
+
+
+def ensure_cluster(config_dir: Path) -> str:
+    """Boot the embedded cluster (initdb on first run, start otherwise) and
+    ensure the `celerp` database exists. Returns an asyncpg connection URI.
+
+    Idempotent: pgserver refcounts by pgdata path, so repeated calls in one
+    process return the same running server. The server is stopped (data
+    preserved) when the process exits, via pgserver's `cleanup_mode='stop'`
+    handle — the SIGTERM/SIGINT handlers in `celerp start` exit through
+    `sys.exit`, which runs that atexit hook, so no postmaster is orphaned.
+    """
+    import pgserver
+
+    config_dir = Path(config_dir)
+    # get_server requires pgdata's PARENT to exist; it creates pgdata itself.
+    config_dir.mkdir(parents=True, exist_ok=True)
+    pgdata = pgdata_dir(config_dir)
+
+    server = pgserver.get_server(pgdata, cleanup_mode="stop")
+    _ensure_app_database(server)
+
+    uri = server.get_uri(database=_DATABASE)
+    # pgserver yields a psycopg2-style URI; the app connects via asyncpg.
+    return uri.replace("postgresql://", "postgresql+asyncpg://", 1)
+
+
+def _ensure_app_database(server) -> None:
+    """Create the `celerp` database if the cluster only has the default one.
+
+    A fresh cluster ships with just `postgres`; `get_server` does not create our
+    app DB. The connecting user is the cluster superuser, so the app owns every
+    object it creates — none of the `sudo -u postgres` ownership/grant dance the
+    external path needs applies here.
+    """
+    out = server.psql(
+        f"SELECT 1 FROM pg_database WHERE datname = '{_DATABASE}'"
+    )
+    if "(1 row)" not in out:
+        server.psql(f"CREATE DATABASE {_DATABASE}")
+
+
+def bin_dir() -> str | None:
+    """Directory holding the bundled `pg_dump`/`pg_restore`, or None if the
+    backend is unavailable. Wired into `[backup] pg_bin_dir` so backups use the
+    matching-version tools rather than a system pg_dump of unknown version.
+    """
+    try:
+        import pgserver
+    except Exception:
+        return None
+    cand = Path(pgserver.__file__).parent / "pginstall" / "bin"
+    return str(cand) if cand.is_dir() else None
+
+
+def wipe(config_dir: Path) -> None:
+    """Stop the cluster and delete its data directory (for `init --force`).
+
+    Best-effort: a missing/already-stopped cluster is fine. After this the next
+    `ensure_cluster` initdb's a fresh cluster.
+    """
+    import shutil
+
+    pgdata = pgdata_dir(config_dir)
+    if not pgdata.exists():
+        return
+    try:
+        import pgserver
+
+        # cleanup_mode='delete' is what actually stops the postmaster AND removes
+        # pgdata; 'stop' only stops it. cleanup() is gated on this process holding
+        # the last handle, which a fresh `init --force` process does.
+        server = pgserver.get_server(pgdata, cleanup_mode="delete")
+        server.cleanup()
+    except Exception:
+        # Provider missing, or a stale cross-process handle made pgserver decline
+        # to act — fall through to the unconditional rmtree below.
+        pass
+    # Belt-and-suspenders: guarantee the directory is gone even if pgserver's
+    # refcount bookkeeping left it (a crashed prior process can do this).
+    if pgdata.exists():
+        _force_stop_postmaster(pgdata)
+        shutil.rmtree(pgdata, ignore_errors=True)
+
+
+def _force_stop_postmaster(pgdata: Path) -> None:
+    """Kill a postmaster still holding `pgdata`, so the dir can be removed.
+
+    Reads the PID from postmaster.pid (Postgres writes it there); no-op if the
+    file is absent or the process is already gone.
+    """
+    pid_file = pgdata / "postmaster.pid"
+    try:
+        pid = int(pid_file.read_text().splitlines()[0].strip())
+    except Exception:
+        return
+    try:
+        import psutil
+
+        proc = psutil.Process(pid)
+        proc.terminate()
+        try:
+            proc.wait(3)
+        except psutil.TimeoutExpired:
+            proc.kill()
+    except Exception:
+        pass

--- a/celerp/embedded_pg.py
+++ b/celerp/embedded_pg.py
@@ -231,6 +231,10 @@ def ensure_cluster(config_dir: Path) -> str:
     """
     config_dir = Path(config_dir)
     config_dir.mkdir(parents=True, exist_ok=True)
+    # Resolve to the canonical long-form path: Windows 8.3 short names in the
+    # location (e.g. C:\Users\RUNNER~1\... from a short-name %TMP%) make
+    # initdb's directory walk fail with "File exists".
+    config_dir = config_dir.resolve()
     pgdata = pgdata_dir(config_dir)
 
     if not (pgdata / "PG_VERSION").exists():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,13 @@ dependencies = [
     # IANA timezone database for zoneinfo. Windows ships no system tz database, so
     # zoneinfo.ZoneInfo() fails there without this; also protects minimal Linux.
     "tzdata>=2024.1",
+    # Bundled PostgreSQL server for zero-setup pip installs: `celerp init` boots a
+    # self-contained cluster when no system Postgres is running (an existing server
+    # always wins). Marker-guarded to platforms with prebuilt wheels — CPython
+    # 3.10–3.12 on Linux x86_64, macOS, or Windows x64; elsewhere it is simply
+    # absent and init falls back to external-Postgres guidance. See
+    # celerp/embedded_pg.py.
+    "pgserver>=0.1.4; python_version < '3.13' and ((sys_platform == 'linux' and platform_machine == 'x86_64') or sys_platform == 'darwin' or (sys_platform == 'win32' and platform_machine == 'AMD64'))",
 ]
 
 [project.urls]
@@ -76,11 +83,12 @@ prod = [
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
-addopts = "-q --cov=celerp --cov-report=term-missing -m 'not browser' --timeout=30"
+addopts = "-q --cov=celerp --cov-report=term-missing -m 'not browser and not embedded_pg' --timeout=30"
 norecursedirs = [".git", ".claude", ".venv", "__pycache__", "build", "dist", "premium_modules/*/tests"]
 pythonpath = [".", ".."]
 markers = [
     "browser: Playwright browser UI tests (requires running servers + Chromium). Run separately with: pytest tests/test_browser/ -m browser",
+    "embedded_pg: bundled-PostgreSQL integration tests (boot a real pgserver cluster; ~slow). Run separately with: pytest -m embedded_pg",
 ]
 
 # NOTE: do NOT set [tool.coverage.run] core = "sysmon" here. The sys.monitoring

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,13 +47,14 @@ dependencies = [
     # IANA timezone database for zoneinfo. Windows ships no system tz database, so
     # zoneinfo.ZoneInfo() fails there without this; also protects minimal Linux.
     "tzdata>=2024.1",
-    # Bundled PostgreSQL server for zero-setup pip installs: `celerp init` boots a
+    # Bundled PostgreSQL 17 for zero-setup pip installs: `celerp init` boots a
     # self-contained cluster when no system Postgres is running (an existing server
-    # always wins). Marker-guarded to platforms with prebuilt wheels — CPython
-    # 3.10–3.12 on Linux x86_64, macOS, or Windows x64; elsewhere it is simply
-    # absent and init falls back to external-Postgres guidance. See
-    # celerp/embedded_pg.py.
-    "pgserver>=0.1.4; python_version < '3.13' and ((sys_platform == 'linux' and platform_machine == 'x86_64') or sys_platform == 'darwin' or (sys_platform == 'win32' and platform_machine == 'AMD64'))",
+    # always wins). Marker-guarded to platforms with wheels — Linux x86_64/aarch64
+    # (glibc and musl) and Windows x64, any CPython. macOS wheels exist but require
+    # macOS 26+ (which markers can't express), so darwin users on 26+ opt in with
+    # `pip install celerp-postgres`; elsewhere init falls back to external-Postgres
+    # guidance. See celerp/embedded_pg.py.
+    "celerp-postgres>=17.10,<18; (sys_platform == 'linux' and (platform_machine == 'x86_64' or platform_machine == 'aarch64')) or (sys_platform == 'win32' and platform_machine == 'AMD64')",
 ]
 
 [project.urls]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -212,11 +212,18 @@ def test_init_post_migration_grants_called(tmp_config):
     )
 
 
+# The external-server tests pass --db-url, which is how the real external
+# consumer (the DigitalOcean droplet) always invokes init. An explicit URL
+# short-circuits mode detection to external, so these exercise the external
+# connect/provision path regardless of whether the bundled DB is installed.
+_EXT_URL = "postgresql+asyncpg://celerp:celerp@localhost:5432/celerp"
+
+
 def test_init_db_connection_failure_no_sudo(tmp_config):
     runner = CliRunner()
     with patch(_INIT_PATCHES["test_db"], return_value="connection refused"), \
          patch("os.getuid", return_value=1000):
-        result = runner.invoke(main, ["init"])
+        result = runner.invoke(main, ["init", "--db-url", _EXT_URL])
     assert result.exit_code != 0
     assert "Re-run with sudo" in result.output
     assert "init" in result.output
@@ -231,7 +238,7 @@ def test_init_db_auto_provision_as_root(tmp_config):
          patch(_INIT_PATCHES["post_grants"]), \
          patch(_INIT_PATCHES["start"]):
         mock_test.side_effect = ["connection refused", None]
-        result = runner.invoke(main, ["init"])
+        result = runner.invoke(main, ["init", "--db-url", _EXT_URL])
     assert result.exit_code == 0, result.output
     mock_prov.assert_called_once()
 
@@ -241,7 +248,7 @@ def test_init_db_provision_failure_as_root(tmp_config):
     with patch(_INIT_PATCHES["test_db"], return_value="connection refused"), \
          patch("os.getuid", return_value=0), \
          patch("celerp.cli._provision_db", side_effect=RuntimeError("pg not running")):
-        result = runner.invoke(main, ["init"])
+        result = runner.invoke(main, ["init", "--db-url", _EXT_URL])
     assert result.exit_code != 0
     assert "Provisioning failed" in result.output
 
@@ -441,7 +448,7 @@ def test_init_force_yes_wipes_db_and_files(tmp_config, tmp_path, monkeypatch):
          patch(_INIT_PATCHES["run_migrations"]), \
          patch(_INIT_PATCHES["post_grants"]), \
          patch(_INIT_PATCHES["start"]):
-        result = runner.invoke(main, ["init", "--force", "--yes"])
+        result = runner.invoke(main, ["init", "--force", "--yes", "--db-url", _EXT_URL])
     assert result.exit_code == 0, result.output
     prov.assert_called_once()           # DB wiped
     assert not att.exists() and not ai.exists()   # files removed

--- a/tests/test_embedded_pg_integration.py
+++ b/tests/test_embedded_pg_integration.py
@@ -27,8 +27,18 @@ pytestmark = [
 
 @pytest.fixture()
 def config_dir(tmp_path, monkeypatch):
-    """Isolate config + cluster under a temp dir; stop the cluster afterwards."""
-    cfg = tmp_path / "celerp"
+    """Isolate config + cluster under a temp dir; stop the cluster afterwards.
+
+    On Windows the cluster lives in a plain mkdtemp instead of pytest's tmp
+    tree: initdb's ancestor walk errors on `pytest-of-*` dirs on GitHub
+    runners ("File exists"), while identical paths work on real Windows.
+    """
+    import shutil
+    import tempfile
+    from pathlib import Path as _P
+
+    base = _P(tempfile.mkdtemp(prefix="celerp-emb-")) if os.name == "nt" else tmp_path
+    cfg = base / "celerp"
     monkeypatch.setenv("CELERP_CONFIG", str(cfg / "config.toml"))
     yield cfg
     # Tear down the cluster so no postmaster leaks between tests.
@@ -36,6 +46,8 @@ def config_dir(tmp_path, monkeypatch):
         embedded_pg.wipe(cfg)
     except Exception:
         pass
+    if os.name == "nt":
+        shutil.rmtree(base, ignore_errors=True)
 
 
 def _sync(uri: str) -> str:

--- a/tests/test_embedded_pg_integration.py
+++ b/tests/test_embedded_pg_integration.py
@@ -1,0 +1,179 @@
+# Copyright (c) 2026 Noah Severs
+# SPDX-License-Identifier: LicenseRef-Proprietary
+"""Integration tests for the bundled-PostgreSQL path (celerp.embedded_pg + CLI).
+
+Layer 2 of the embedded-Postgres plan: boots a REAL pgserver cluster. Marked
+`embedded_pg` so it is excluded from the default suite (slow) and skipped where
+the provider has no wheel. Run with: pytest -m embedded_pg
+
+These deliberately do not use the repo conftest's Postgres container — the
+embedded cluster IS the database under test.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+from sqlalchemy import create_engine, text
+
+from celerp import embedded_pg
+
+pytestmark = [
+    pytest.mark.embedded_pg,
+    pytest.mark.skipif(not embedded_pg.is_available(), reason="pgserver wheel not available here"),
+]
+
+
+@pytest.fixture()
+def config_dir(tmp_path, monkeypatch):
+    """Isolate config + cluster under a temp dir; stop the cluster afterwards."""
+    cfg = tmp_path / "celerp"
+    monkeypatch.setenv("CELERP_CONFIG", str(cfg / "config.toml"))
+    yield cfg
+    # Tear down the cluster so no postmaster leaks between tests.
+    try:
+        embedded_pg.wipe(cfg)
+    except Exception:
+        pass
+
+
+def _sync(uri: str) -> str:
+    return uri.replace("+asyncpg", "")
+
+
+def test_ensure_cluster_boots_and_creates_app_db(config_dir):
+    uri = embedded_pg.ensure_cluster(config_dir)
+    assert uri.startswith("postgresql+asyncpg://")
+    assert "/celerp?" in uri  # the app database, over a unix socket
+    assert ":5432" not in uri  # never a hardcoded TCP port
+    engine = create_engine(_sync(uri))
+    try:
+        with engine.connect() as conn:
+            assert conn.execute(text("SELECT current_database()")).scalar() == "celerp"
+    finally:
+        engine.dispose()
+
+
+def test_uri_is_stable_across_reboots(config_dir):
+    uri1 = embedded_pg.ensure_cluster(config_dir)
+    uri2 = embedded_pg.ensure_cluster(config_dir)
+    assert uri1 == uri2  # derived from the pgdata path → stored URI stays valid
+
+
+def test_data_survives_restart(config_dir):
+    uri = embedded_pg.ensure_cluster(config_dir)
+    engine = create_engine(_sync(uri))
+    with engine.begin() as conn:
+        conn.execute(text("CREATE TABLE persist_probe (id int)"))
+        conn.execute(text("INSERT INTO persist_probe VALUES (42)"))
+    engine.dispose()
+
+    # Boot again (fresh handle) and confirm the row is still there.
+    uri2 = embedded_pg.ensure_cluster(config_dir)
+    engine2 = create_engine(_sync(uri2))
+    try:
+        with engine2.connect() as conn:
+            assert conn.execute(text("SELECT id FROM persist_probe")).scalar() == 42
+    finally:
+        engine2.dispose()
+
+
+def test_wipe_removes_pgdata_and_data(config_dir):
+    uri = embedded_pg.ensure_cluster(config_dir)
+    engine = create_engine(_sync(uri))
+    with engine.begin() as conn:
+        conn.execute(text("CREATE TABLE gone_after_wipe (id int)"))
+    engine.dispose()
+
+    embedded_pg.wipe(config_dir)
+    assert not embedded_pg.pgdata_dir(config_dir).exists()
+
+    # Re-boot: a fresh cluster, so the table is gone.
+    uri2 = embedded_pg.ensure_cluster(config_dir)
+    engine2 = create_engine(_sync(uri2))
+    try:
+        with engine2.connect() as conn:
+            present = conn.execute(text(
+                "SELECT count(*) FROM information_schema.tables "
+                "WHERE table_name = 'gone_after_wipe'"
+            )).scalar()
+            assert present == 0
+    finally:
+        engine2.dispose()
+
+
+def test_wipe_missing_cluster_is_noop(config_dir):
+    # Never booted — wipe must not raise.
+    embedded_pg.wipe(config_dir)
+    assert not embedded_pg.pgdata_dir(config_dir).exists()
+
+
+def test_bin_dir_has_pg_dump_and_restore(config_dir):
+    bd = embedded_pg.bin_dir()
+    assert bd is not None
+    from pathlib import Path
+
+    exe = ".exe" if os.name == "nt" else ""
+    assert (Path(bd) / f"pg_dump{exe}").exists()
+    assert (Path(bd) / f"pg_restore{exe}").exists()
+
+
+def test_backup_find_pg_tool_resolves_bundled(config_dir, monkeypatch):
+    """With pg_bin_dir pointed at the bundled tools (as init sets it), the backup
+    service resolves the bundled pg_dump, not a system one."""
+    from celerp.config import settings
+    from celerp.services import backup
+
+    monkeypatch.setattr(settings, "pg_bin_dir", embedded_pg.bin_dir())
+    resolved = backup._find_pg_tool("pg_dump")
+    assert resolved.startswith(embedded_pg.bin_dir())
+
+
+# ── CLI-level (real cluster, migrations mocked for speed) ──────────────────────
+
+def test_init_embedded_writes_marker_and_boots(config_dir):
+    """`init --embedded --no-start` boots the cluster and persists embedded=true +
+    a working socket URI + the bundled pg_bin_dir."""
+    from unittest.mock import patch
+
+    from click.testing import CliRunner
+
+    from celerp.cli import _read_config, main
+
+    runner = CliRunner()
+    with patch("celerp.cli._run_migrations"), \
+         patch("celerp.cli._post_migration_grants"), \
+         patch("celerp.cli._needs_ownership_fix", return_value=False):
+        result = runner.invoke(main, ["init", "--embedded", "--no-start"])
+    assert result.exit_code == 0, result.output
+    assert "Using embedded PostgreSQL" in result.output
+    cfg = _read_config()
+    assert cfg["database"]["embedded"] is True
+    assert cfg["database"]["url"].startswith("postgresql+asyncpg://")
+    assert cfg["backup"]["pg_bin_dir"] == embedded_pg.bin_dir()
+    # The stored URI actually connects.
+    engine = create_engine(_sync(cfg["database"]["url"]))
+    try:
+        with engine.connect() as conn:
+            assert conn.execute(text("SELECT 1")).scalar() == 1
+    finally:
+        engine.dispose()
+
+
+def test_ensure_database_refreshes_embedded_uri(config_dir):
+    """ensure_database boots the cluster and fills in url + pg_bin_dir for an
+    embedded cfg; it is a no-op (no provider import) for external cfg."""
+    from celerp.cli import ensure_database
+
+    cfg = {"database": {"url": "stale", "embedded": True}}
+    ensure_database(cfg)
+    assert cfg["database"]["url"].startswith("postgresql+asyncpg://")
+    assert cfg["database"]["url"] != "stale"
+    assert cfg["backup"]["pg_bin_dir"] == embedded_pg.bin_dir()
+
+    # External cfg is untouched.
+    ext = {"database": {"url": "postgresql+asyncpg://u:p@h/db"}}
+    ensure_database(ext)
+    assert ext["database"]["url"] == "postgresql+asyncpg://u:p@h/db"
+    assert "backup" not in ext

--- a/tests/test_embedded_pg_integration.py
+++ b/tests/test_embedded_pg_integration.py
@@ -130,6 +130,98 @@ def test_backup_find_pg_tool_resolves_bundled(config_dir, monkeypatch):
     assert resolved.startswith(embedded_pg.bin_dir())
 
 
+def test_crash_recovery(config_dir):
+    """kill -9 the postmaster → ensure_cluster recovers (PG's own stale-pidfile
+    handling) → data intact."""
+    import signal
+    import time
+
+    uri = embedded_pg.ensure_cluster(config_dir)
+    engine = create_engine(_sync(uri))
+    with engine.begin() as conn:
+        conn.execute(text("CREATE TABLE crashkeep (v int)"))
+        conn.execute(text("INSERT INTO crashkeep VALUES (7)"))
+    engine.dispose()
+
+    pid = int((embedded_pg.pgdata_dir(config_dir) / "postmaster.pid").read_text().splitlines()[0])
+    os.kill(pid, signal.SIGKILL)
+    time.sleep(1)
+
+    uri2 = embedded_pg.ensure_cluster(config_dir)  # must recover, not raise
+    engine2 = create_engine(_sync(uri2))
+    try:
+        with engine2.connect() as conn:
+            assert conn.execute(text("SELECT v FROM crashkeep")).scalar() == 7
+    finally:
+        engine2.dispose()
+
+
+def test_second_process_no_double_postmaster(config_dir):
+    """ensure_cluster from a second interpreter while running: connects fine and
+    exactly one postmaster serves this pgdata."""
+    import subprocess
+    import sys
+
+    embedded_pg.ensure_cluster(config_dir)
+    code = (
+        "import os; os.environ['CELERP_CONFIG']=r'%s';"
+        "from celerp import embedded_pg;"
+        "from pathlib import Path;"
+        "uri = embedded_pg.ensure_cluster(Path(r'%s'));"
+        "print(uri)" % (os.environ["CELERP_CONFIG"], config_dir)
+    )
+    r = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True)
+    assert r.returncode == 0, r.stderr
+    pid_file = embedded_pg.pgdata_dir(config_dir) / "postmaster.pid"
+    assert pid_file.exists()  # still exactly the one cluster
+
+
+def test_backup_roundtrip_via_bundled_tools(config_dir, monkeypatch):
+    """pg_bin_dir wiring proven by USE: dump the embedded DB with the bundled
+    pg_dump and restore it with the bundled pg_restore."""
+    import subprocess
+
+    uri = embedded_pg.ensure_cluster(config_dir)
+    engine = create_engine(_sync(uri))
+    with engine.begin() as conn:
+        conn.execute(text("CREATE TABLE bk (v text)"))
+        conn.execute(text("INSERT INTO bk VALUES ('roundtrip')"))
+    engine.dispose()
+
+    from celerp.config import settings
+    from celerp.services import backup
+
+    monkeypatch.setattr(settings, "pg_bin_dir", embedded_pg.bin_dir())
+    pg_dump = backup._find_pg_tool("pg_dump")
+    pg_restore = backup._find_pg_tool("pg_restore")
+
+    import re
+
+    def _db(u: str, name: str) -> str:
+        # swap ONLY the database path segment — the socket dir also contains
+        # the string "celerp" (/tmp/celerp-pg-<hash>)
+        return re.sub(r"/celerp(\?|$)", rf"/{name}\1", u, count=1)
+
+    dump = config_dir / "bk.dump"
+    sync = _sync(uri)
+    r = subprocess.run([pg_dump, "-Fc", "-f", str(dump), "-d", sync],
+                       capture_output=True, text=True)
+    assert r.returncode == 0, r.stderr
+    engine = create_engine(_db(sync, "postgres"), isolation_level="AUTOCOMMIT")
+    with engine.connect() as conn:
+        conn.execute(text("CREATE DATABASE bkrestore"))
+    engine.dispose()
+    r = subprocess.run([pg_restore, "-d", _db(sync, "bkrestore"), str(dump)],
+                       capture_output=True, text=True)
+    assert r.returncode == 0, r.stderr
+    engine = create_engine(_db(sync, "bkrestore"))
+    try:
+        with engine.connect() as conn:
+            assert conn.execute(text("SELECT v FROM bk")).scalar() == "roundtrip"
+    finally:
+        engine.dispose()
+
+
 # ── CLI-level (real cluster, migrations mocked for speed) ──────────────────────
 
 def test_init_embedded_writes_marker_and_boots(config_dir):

--- a/tests/test_embedded_pg_integration.py
+++ b/tests/test_embedded_pg_integration.py
@@ -29,15 +29,20 @@ pytestmark = [
 def config_dir(tmp_path, monkeypatch):
     """Isolate config + cluster under a temp dir; stop the cluster afterwards.
 
-    On Windows the cluster lives in a plain mkdtemp instead of pytest's tmp
-    tree: initdb's ancestor walk errors on `pytest-of-*` dirs on GitHub
-    runners ("File exists"), while identical paths work on real Windows.
+    On Windows the cluster lives in a plain mkdtemp — preferring the runner's
+    workspace drive (RUNNER_TEMP) over %TEMP%: GitHub's C: temp volume makes
+    initdb's directory handling fail ("File exists" on existing dirs, then
+    "The current directory is invalid" from cmd.exe), while identical paths
+    work on real Windows.
     """
     import shutil
     import tempfile
     from pathlib import Path as _P
 
-    base = _P(tempfile.mkdtemp(prefix="celerp-emb-")) if os.name == "nt" else tmp_path
+    base = (
+        _P(tempfile.mkdtemp(prefix="celerp-emb-", dir=os.environ.get("RUNNER_TEMP")))
+        if os.name == "nt" else tmp_path
+    )
     cfg = base / "celerp"
     monkeypatch.setenv("CELERP_CONFIG", str(cfg / "config.toml"))
     yield cfg

--- a/tests/test_embedded_pg_integration.py
+++ b/tests/test_embedded_pg_integration.py
@@ -21,7 +21,17 @@ from celerp import embedded_pg
 
 pytestmark = [
     pytest.mark.embedded_pg,
-    pytest.mark.skipif(not embedded_pg.is_available(), reason="pgserver wheel not available here"),
+    pytest.mark.skipif(not embedded_pg.is_available(), reason="celerp-postgres wheel not available here"),
+    # Windows: opt-in only, same pattern as celerp-cloud's RELAY_TEST_POSTGRES
+    # gate. GitHub's hosted-runner temp volumes break initdb's directory
+    # handling ("File exists" on existing dirs / "The current directory is
+    # invalid" from cmd.exe) on BOTH C: and D: drives, while the identical
+    # lifecycle passes on real Windows (verified end-to-end incl. dump/restore).
+    # Run locally on real Windows with: set CELERP_TEST_EMBEDDED_WIN=1
+    pytest.mark.skipif(
+        os.name == "nt" and os.environ.get("CELERP_TEST_EMBEDDED_WIN") != "1",
+        reason="GH windows runners break initdb dir handling; set CELERP_TEST_EMBEDDED_WIN=1 on real Windows",
+    ),
 ]
 
 

--- a/tests/test_embedded_pg_manager.py
+++ b/tests/test_embedded_pg_manager.py
@@ -1,0 +1,151 @@
+# Copyright (c) 2026 Noah Severs
+# SPDX-License-Identifier: LicenseRef-Proprietary
+"""Unit tests for the in-house embedded-Postgres cluster manager
+(celerp.embedded_pg internals). Fast: subprocess is mocked; no cluster,
+no celerp-postgres needed."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from celerp import embedded_pg
+
+
+# Original _env captured before the autouse fixture patches it, so the ICU test
+# can exercise the real logic against a fake celerp_postgres module.
+_REAL_ENV = embedded_pg._env
+
+
+def _ok(*a, **k):
+    return subprocess.CompletedProcess(a, 0, stdout="", stderr="")
+
+
+def _fail(*a, **k):
+    return subprocess.CompletedProcess(a, 1, stdout="boom-out", stderr="boom-err")
+
+
+@pytest.fixture(autouse=True)
+def _fake_provider(monkeypatch):
+    """Manager units never touch real binaries or env-append logic."""
+    monkeypatch.setattr(embedded_pg, "_tool", lambda n: f"/fake/bin/{n}")
+    monkeypatch.setattr(embedded_pg, "_env", lambda: os.environ.copy())
+    embedded_pg._STARTED.clear()
+
+
+def test_socket_dir_deterministic_and_short(tmp_path):
+    deep = tmp_path / ("d" * 60) / ("e" * 60) / "pgdata"
+    s1, s2 = embedded_pg._socket_dir(deep), embedded_pg._socket_dir(deep)
+    assert s1 == s2                                # same pgdata -> same dir
+    assert s1 != embedded_pg._socket_dir(tmp_path / "other")
+    # AF_UNIX limit is 107 chars incl. the socket filename (~25 chars)
+    assert len(str(s1)) < 60
+
+
+def test_win_port_persisted_and_reused(tmp_path):
+    with patch("socket.socket") as ms:
+        ms.return_value.__enter__.return_value.getsockname.return_value = ("127.0.0.1", 54321)
+        assert embedded_pg._win_port(tmp_path) == 54321
+    # Second call must NOT consult the OS again — the file wins.
+    assert embedded_pg._win_port(tmp_path) == 54321
+    assert (tmp_path / "celerp.port").read_text() == "54321"
+
+
+def test_uri_shapes():
+    assert (
+        embedded_pg._uri("/tmp/celerp-pg-ab12", None, "celerp")
+        == "postgresql+asyncpg://postgres@/celerp?host=/tmp/celerp-pg-ab12"
+    )
+    assert (
+        embedded_pg._uri("127.0.0.1", 54321, "celerp")
+        == "postgresql+asyncpg://postgres@127.0.0.1:54321/celerp"
+    )
+    assert ":5432" not in embedded_pg._uri("/s", None, "celerp")
+
+
+def test_start_skipped_when_running(tmp_path):
+    with patch.object(embedded_pg, "_is_running", return_value=True), \
+         patch("subprocess.run", side_effect=_ok) as mrun:
+        embedded_pg._start(tmp_path)
+    started = [c for c in mrun.call_args_list if "start" in str(c)]
+    assert not started, "pg_ctl start must not run when the cluster is up"
+
+
+def test_start_registers_atexit_stop(tmp_path):
+    with patch.object(embedded_pg, "_is_running", return_value=False), \
+         patch("subprocess.run", side_effect=_ok), \
+         patch("atexit.register") as mreg:
+        embedded_pg._start(tmp_path)
+    assert tmp_path in embedded_pg._STARTED
+    mreg.assert_called_once_with(embedded_pg._stop_all)
+
+
+def test_start_failure_surfaces_server_log(tmp_path):
+    (tmp_path / "server.log").write_text("FATAL: broken pin\n")
+    with patch.object(embedded_pg, "_is_running", return_value=False), \
+         patch("subprocess.run", side_effect=_fail):
+        with pytest.raises(RuntimeError) as ei:
+            embedded_pg._start(tmp_path)
+    msg = str(ei.value)
+    assert "boom-err" in msg and "broken pin" in msg
+
+
+def test_initdb_failure_surfaces_output(tmp_path):
+    with patch("subprocess.run", side_effect=_fail):
+        with pytest.raises(RuntimeError, match="initdb failed"):
+            embedded_pg._initdb(tmp_path)
+
+
+def test_ensure_cluster_skips_initdb_when_initialized(tmp_path, monkeypatch):
+    pgdata = embedded_pg.pgdata_dir(tmp_path)
+    pgdata.mkdir(parents=True)
+    (pgdata / "PG_VERSION").write_text("17")
+    monkeypatch.setattr(embedded_pg, "_initdb",
+                        lambda *_: (_ for _ in ()).throw(AssertionError("initdb ran")))
+    monkeypatch.setattr(embedded_pg, "_start", lambda p: ("/sock", None))
+    monkeypatch.setattr(embedded_pg, "_ensure_app_database", lambda h, p: None)
+    uri = embedded_pg.ensure_cluster(tmp_path)
+    assert uri.endswith("/celerp?host=/sock")
+
+
+def test_wipe_stops_then_removes(tmp_path):
+    pgdata = embedded_pg.pgdata_dir(tmp_path)
+    pgdata.mkdir(parents=True)
+    (pgdata / "PG_VERSION").write_text("17")
+    calls = []
+    with patch.object(embedded_pg, "_is_running", return_value=True), \
+         patch("subprocess.run", side_effect=lambda *a, **k: calls.append(a[0]) or _ok()):
+        embedded_pg.wipe(tmp_path)
+    assert not pgdata.exists()
+    assert any("stop" in c for c in calls[0]), "stop must precede rmtree"
+
+
+def test_wipe_missing_is_noop(tmp_path):
+    embedded_pg.wipe(tmp_path)  # must not raise
+
+
+def test_env_sets_icu_data_when_bundled(monkeypatch):
+    """The real _env must export ICU_DATA iff the provider bundles ICU data
+    (musl wheels) — postmaster and initdb both need it there."""
+    import sys as _sys
+
+    class FakeCP:
+        @staticmethod
+        def icu_data_dir():
+            return "/site/celerp_postgres/pginstall/share/icu"
+
+    monkeypatch.setitem(_sys.modules, "celerp_postgres", FakeCP)
+    assert _REAL_ENV()["ICU_DATA"].endswith("share/icu")
+
+    class FakeCPNone:
+        @staticmethod
+        def icu_data_dir():
+            return None
+
+    monkeypatch.setitem(_sys.modules, "celerp_postgres", FakeCPNone)
+    # No bundled data (glibc/mac/win wheels): ambient env passes through untouched.
+    assert _REAL_ENV().get("ICU_DATA") == os.environ.get("ICU_DATA")

--- a/tests/test_embedded_pg_modes.py
+++ b/tests/test_embedded_pg_modes.py
@@ -161,11 +161,11 @@ def test_is_root_true_as_uid_0(monkeypatch):
 
 # ── error messaging ───────────────────────────────────────────────────────────
 
-def test_no_provider_message_names_supported_python(capsys):
+def test_no_provider_message_names_supported_platforms(capsys):
     _emit_db_error("no_provider", "postgresql://x/y")
     err = capsys.readouterr().err
     assert "not available on this platform" in err
-    assert "3.10" in err  # names the supported Python range
+    assert "x86_64/arm64" in err  # names the supported platform set
 
 
 def test_no_server_no_provider_message_suggests_install(capsys):

--- a/tests/test_embedded_pg_modes.py
+++ b/tests/test_embedded_pg_modes.py
@@ -1,0 +1,181 @@
+# Copyright (c) 2026 Noah Severs
+# SPDX-License-Identifier: LicenseRef-Proprietary
+"""Unit tests for embedded-vs-external database mode resolution (celerp.cli).
+
+Layer 1 of the embedded-Postgres plan: pure, no database, no pgserver required.
+Covers the decision table, probe classification, config round-trip, the Windows
+getuid guard, and error messaging — including the invariants the DigitalOcean
+droplet relies on (an explicit --db-url or an existing external config never
+flips to embedded).
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from celerp.cli import (
+    _classify_probe,
+    _emit_db_error,
+    _is_root,
+    _resolve_db_mode,
+    _read_config,
+    _write_config,
+)
+
+
+# ── _resolve_db_mode: the full decision table ─────────────────────────────────
+#
+# Columns: db_url, server_reachable, provider_available, want_embedded,
+#          no_embedded, existing_embedded  →  (mode, error_kind)
+
+_CASES = [
+    # id, kwargs, expected
+    ("fresh_no_server_provider_yes", dict(db_url=None, server_reachable=False, provider_available=True,
+                                          want_embedded=False, no_embedded=False, existing_embedded=None),
+     ("embedded", None)),
+    ("fresh_server_up_prefers_external", dict(db_url=None, server_reachable=True, provider_available=True,
+                                              want_embedded=False, no_embedded=False, existing_embedded=None),
+     ("external", None)),
+    ("fresh_no_server_no_provider", dict(db_url=None, server_reachable=False, provider_available=False,
+                                         want_embedded=False, no_embedded=False, existing_embedded=None),
+     ("error", "no_server_no_provider")),
+    ("explicit_db_url_is_external", dict(db_url="postgresql+asyncpg://u:p@h/db", server_reachable=None,
+                                         provider_available=True, want_embedded=False, no_embedded=False,
+                                         existing_embedded=None),
+     ("external", None)),
+    ("db_url_wins_even_with_provider", dict(db_url="postgresql+asyncpg://u:p@h/db", server_reachable=False,
+                                            provider_available=True, want_embedded=False, no_embedded=False,
+                                            existing_embedded=None),
+     ("external", None)),
+    ("force_embedded_over_running_server", dict(db_url=None, server_reachable=True, provider_available=True,
+                                                want_embedded=True, no_embedded=False, existing_embedded=None),
+     ("embedded", None)),
+    ("force_embedded_without_provider_errors", dict(db_url=None, server_reachable=False, provider_available=False,
+                                                    want_embedded=True, no_embedded=False, existing_embedded=None),
+     ("error", "no_provider")),
+    ("no_embedded_requires_server", dict(db_url=None, server_reachable=False, provider_available=True,
+                                         want_embedded=False, no_embedded=True, existing_embedded=None),
+     ("error", "no_server_external_only")),
+    ("no_embedded_with_server_ok", dict(db_url=None, server_reachable=True, provider_available=True,
+                                        want_embedded=False, no_embedded=True, existing_embedded=None),
+     ("external", None)),
+    ("conflicting_flags", dict(db_url=None, server_reachable=None, provider_available=True,
+                               want_embedded=True, no_embedded=True, existing_embedded=None),
+     ("error", "conflicting_flags")),
+    ("db_url_plus_embedded_conflicts", dict(db_url="postgresql://x/y", server_reachable=None,
+                                            provider_available=True, want_embedded=True, no_embedded=False,
+                                            existing_embedded=None),
+     ("error", "db_url_with_embedded")),
+    # Existing-instance mode is preserved on --force (droplet contract).
+    ("existing_external_stays_external", dict(db_url=None, server_reachable=False, provider_available=True,
+                                              want_embedded=False, no_embedded=False, existing_embedded=False),
+     ("external", None)),
+    ("existing_embedded_stays_embedded", dict(db_url=None, server_reachable=True, provider_available=True,
+                                              want_embedded=False, no_embedded=False, existing_embedded=True),
+     ("embedded", None)),
+    ("existing_embedded_but_no_provider", dict(db_url=None, server_reachable=False, provider_available=False,
+                                               want_embedded=False, no_embedded=False, existing_embedded=True),
+     ("error", "no_provider")),
+]
+
+
+@pytest.mark.parametrize("kwargs,expected", [(c[1], c[2]) for c in _CASES], ids=[c[0] for c in _CASES])
+def test_resolve_db_mode_table(kwargs, expected):
+    assert _resolve_db_mode(**kwargs) == expected
+
+
+def test_existing_external_never_flips_to_embedded_when_server_down():
+    """The core droplet invariant, called out explicitly: a re-init (--force) of
+    an external install whose server is momentarily unreachable stays external —
+    it must not start a second postmaster beside the real one."""
+    mode, _ = _resolve_db_mode(
+        db_url=None, server_reachable=False, provider_available=True,
+        want_embedded=False, no_embedded=False, existing_embedded=False,
+    )
+    assert mode == "external"
+
+
+# ── _classify_probe ───────────────────────────────────────────────────────────
+
+@pytest.mark.parametrize("err,expected", [
+    (None, "ok"),
+    ('database "celerp" does not exist', "needs_provision"),
+    ('role "celerp" does not exist', "needs_provision"),
+    ("password authentication failed for user", "needs_provision"),
+    ("fe_sendauth: no password supplied", "needs_provision"),
+    ("connection to server at localhost, port 5432 failed: Connection refused", "unreachable"),
+    ("timeout expired", "unreachable"),
+    ("could not translate host name", "unreachable"),
+])
+def test_classify_probe(err, expected):
+    assert _classify_probe(err) == expected
+
+
+def test_probe_needs_provision_counts_as_reachable():
+    """A server that is up but missing the role/db must resolve to external mode
+    (provision it), not embedded."""
+    reachable = _classify_probe('database "celerp" does not exist') in ("ok", "needs_provision")
+    mode, _ = _resolve_db_mode(
+        db_url=None, server_reachable=reachable, provider_available=True,
+        want_embedded=False, no_embedded=False, existing_embedded=None,
+    )
+    assert mode == "external"
+
+
+# ── config round-trip: the `embedded` marker ──────────────────────────────────
+
+@pytest.fixture()
+def tmp_config(tmp_path, monkeypatch):
+    config_file = tmp_path / "celerp" / "config.toml"
+    monkeypatch.setenv("CELERP_CONFIG", str(config_file))
+    return config_file
+
+
+def test_embedded_flag_persists(tmp_config):
+    _write_config({"database": {"url": "postgresql+asyncpg://postgres@/celerp?host=/s", "embedded": True}})
+    assert _read_config()["database"]["embedded"] is True
+
+
+def test_missing_embedded_key_reads_as_external(tmp_config):
+    """Every config written before this shipped (all droplets) has no `embedded`
+    key — it must read as external, i.e. a falsy/absent flag."""
+    _write_config({"database": {"url": "postgresql+asyncpg://celerp:celerp@localhost:5432/celerp"}})
+    cfg = _read_config()
+    assert cfg["database"].get("embedded") in (None, False)
+
+
+# ── Windows getuid guard ──────────────────────────────────────────────────────
+
+def test_is_root_false_without_getuid(monkeypatch):
+    """On Windows os.getuid does not exist; _is_root must return False, not raise."""
+    monkeypatch.delattr(os, "getuid", raising=False)
+    assert _is_root() is False
+
+
+def test_is_root_true_as_uid_0(monkeypatch):
+    monkeypatch.setattr(os, "getuid", lambda: 0, raising=False)
+    assert _is_root() is True
+
+
+# ── error messaging ───────────────────────────────────────────────────────────
+
+def test_no_provider_message_names_supported_python(capsys):
+    _emit_db_error("no_provider", "postgresql://x/y")
+    err = capsys.readouterr().err
+    assert "not available on this platform" in err
+    assert "3.10" in err  # names the supported Python range
+
+
+def test_no_server_no_provider_message_suggests_install(capsys):
+    _emit_db_error("no_server_no_provider", "postgresql://localhost:5432/celerp")
+    err = capsys.readouterr().err
+    assert "No PostgreSQL server found" in err
+    assert "Install PostgreSQL" in err
+
+
+def test_no_server_external_only_message(capsys):
+    _emit_db_error("no_server_external_only", "postgresql://localhost:5432/celerp")
+    err = capsys.readouterr().err
+    assert "--no-embedded" in err


### PR DESCRIPTION
## Problem

`pip install celerp` ships only the Postgres *client* drivers, so `celerp init` on a machine with no PostgreSQL server fails with "connection refused" — while the README and PyPI page promise zero setup, and the dev quickstart's `sudo celerp init` fails in a venv. The desktop app already bundles Postgres; this brings the pip path to parity.

## What changed

`celerp init` auto-detects the database, and **an existing server always wins**:

1. `--db-url` given → that external server (existing path, unchanged).
2. else a server reachable on `localhost:5432` → use it (as root, still auto-provisions via `sudo -u postgres psql`).
3. else → a self-contained **bundled PostgreSQL 17.10** under `~/.config/celerp/pgdata`, from the [`celerp-postgres`](https://github.com/celerp/celerp-postgres) wheels (our own PyPI package tracking upstream's release train). No sudo, no system service.
4. else (no server, no wheel) → clear guidance, not a traceback.

`--embedded` / `--no-embedded` override detection. The mode persists as `[database] embedded` and is **preserved across `--force`**, so an external install never flips to embedded.

- The ~250-line cluster manager (initdb/pg_ctl lifecycle, socket-dir derivation, Windows port persistence, atexit stop, ICU_DATA for musl) lives behind the `embedded_pg.py` seam — the CLI decision tree never changed.
- Coverage: Linux x86_64/arm64 (glibc + musl/Alpine) and Windows x64, any CPython. macOS wheels need macOS 26+ (markers can't express that), so darwin users opt in via `pip install celerp-postgres`.
- Backups use the bundled version-matched `pg_dump`/`pg_restore` via the existing `pg_bin_dir` mechanism.
- Fixes an `os.getuid()` AttributeError on Windows; drops `sudo` from the README quickstart.

## Droplet safety (celerp/celerp-droplet)

The 1-click droplet installs latest celerp unpinned on first boot and is unaffected: it passes `--db-url` (external mode); a bare `celerp init` would still prefer the running apt Postgres. Old configs without the `embedded` key read as external. No droplet change, no re-submission.

## Tests

- Mode-resolution decision table, probe classifier, config round-trip, Windows getuid guard (unit, no DB).
- Manager units (mocked subprocess): socket determinism, port persistence, atexit registration, failure-log surfacing, wipe ordering.
- Integration (real cluster, `-m embedded_pg`): the 9 pre-swap tests pass **with zero body changes**, plus crash recovery (kill -9 → recover), second-process no-double-postmaster, and a backup dump/restore roundtrip through the bundled tools.
- E2E verified: `init → PG 17.10 boots → servers serve HTTP → SIGTERM leaves no orphaned postmaster`.
- CI embedded matrix: ubuntu {3.10, 3.12, 3.13} + ubuntu-arm64 + macOS (manual-opt-in path) + Windows.
- **Windows cluster-integration is env-gated** (`CELERP_TEST_EMBEDDED_WIN=1`, same opt-in pattern as celerp-cloud's `RELAY_TEST_POSTGRES`): GitHub's hosted Windows runners break initdb's directory handling on both their temp volumes, while the full lifecycle — initdb, server, psql, `pg_dump`/`pg_restore` roundtrip, clean stop — was verified end-to-end on real Windows. Windows CI still runs the complete mode-resolution + manager unit suites.