### PR TITLE
fix(labels): print labels at the designer's field positions (#217)

### DIFF
--- a/default_modules/celerp-labels/celerp_labels/ui_routes.py
+++ b/default_modules/celerp-labels/celerp_labels/ui_routes.py
@@ -992,33 +992,43 @@ def _printable_label_sheet(items: list[dict], template: dict | None) -> object:
     from starlette.responses import HTMLResponse
     from celerp_labels.service import _make_barcode_image, _make_qr_image
 
-    def _barcode_img_tag(val: str, module_height: int = 8) -> str:
+    def _barcode_img_tag(val: str, module_height: int = 8, wrap_style: str = "", width_mm: float | None = None) -> str:
         buf = _make_barcode_image(val, module_height=module_height)
         h_px = max(4, int(module_height) * 4)
+        # Width mirrors the editor preview: a fixed mm width so the printed barcode matches the
+        # designed footprint (the preview clamps to 20–30mm — see BC_MIN_W_MM).
+        if width_mm is not None:
+            wrap_style = f"{wrap_style}width:{width_mm}mm;"
         if buf:
             b64 = base64.b64encode(buf.read()).decode()
             return (
-                f'<div class="label-field label-field--barcode">'
+                f'<div class="label-field label-field--barcode" style="{wrap_style}">'
                 f'<img src="data:image/png;base64,{b64}" alt="{val}"'
-                f' style="max-width:100%;height:{h_px}px;display:block;">'
+                f' style="width:100%;height:{h_px}px;display:block;">'
                 f'</div>'
             )
-        return f'<div class="label-field label-field--barcode">{val}</div>'
+        return f'<div class="label-field label-field--barcode" style="{wrap_style}">{val}</div>'
 
-    def _qr_img_tag(val: str) -> str:
+    def _qr_img_tag(val: str, wrap_style: str = "") -> str:
         buf = _make_qr_image(val)
+        # QR is a fixed 10mm square in the editor preview; match it here.
+        qr_style = f"{wrap_style}width:10mm;height:10mm;"
         if buf:
             b64 = base64.b64encode(buf.read()).decode()
             return (
-                f'<div class="label-field label-field--qr">'
-                f'<img src="data:image/png;base64,{b64}" alt="{val}" style="width:40px;height:40px;display:block;">'
+                f'<div class="label-field label-field--qr" style="{qr_style}">'
+                f'<img src="data:image/png;base64,{b64}" alt="{val}" style="width:100%;height:100%;display:block;">'
                 f'</div>'
             )
-        return f'<div class="label-field label-field--qr">{val}</div>'
+        return f'<div class="label-field label-field--qr" style="{qr_style}">{val}</div>'
+
+    # Auto-stack step (mm) per field type — only for legacy fields that carry no x/y.
+    _auto_step_mm = {"text": 4.0, "barcode_text": 4.0, "barcode": 8.0, "qr": 11.0}
 
     label_rows = []
     for item in items:
         field_lines = []
+        auto_y = 2.0  # top offset (mm) for the next coordinate-less field
         for f in fields:
             key = f.get("key", "")
             ftype = f.get("type", "text")
@@ -1030,16 +1040,27 @@ def _printable_label_sheet(items: list[dict], template: dict | None) -> object:
                 val = str(item.get(key, "") or (item.get("attributes") or {}).get(key, "") or "")
             if not val:
                 continue
+            # Honor the designer's saved coordinates: place each field absolutely at its (x, y) in mm.
+            # Fields with no coordinates (older/default templates) fall back to a top-to-bottom auto
+            # stack — matching the editor preview, which positions saved fields and auto-stacks the rest.
+            x, y = f.get("x"), f.get("y")
+            if x is not None and y is not None:
+                left_mm, top_mm = float(x), float(y)
+            else:
+                left_mm, top_mm = 2.0, auto_y
+                auto_y += _auto_step_mm.get(ftype, 4.0)
+            pos = f"left:{left_mm}mm;top:{top_mm}mm;"
             if ftype == "barcode":
                 bc_height = int(f.get("barcode_height") or 8)
-                field_lines.append(_barcode_img_tag(val, module_height=bc_height))
+                bc_w = max(20.0, min(w_mm - left_mm - 2.0, 30.0))
+                field_lines.append(_barcode_img_tag(val, module_height=bc_height, wrap_style=pos, width_mm=bc_w))
             elif ftype == "barcode_text":
-                field_lines.append(f'<div class="label-field label-field--barcode-text"><span class="bc-human">{val}</span></div>')
+                field_lines.append(f'<div class="label-field label-field--barcode-text" style="{pos}"><span class="bc-human">{val}</span></div>')
             elif ftype == "qr":
-                field_lines.append(_qr_img_tag(val))
+                field_lines.append(_qr_img_tag(val, wrap_style=pos))
             else:
                 display = f"{field_label}: {val}" if field_label else val
-                field_lines.append(f'<div class="label-field">{display}</div>')
+                field_lines.append(f'<div class="label-field" style="{pos}">{display}</div>')
         label_rows.append(f'<div class="label-item">{"".join(field_lines)}</div>')
 
     html = f"""<!DOCTYPE html>
@@ -1051,8 +1072,8 @@ def _printable_label_sheet(items: list[dict], template: dict | None) -> object:
 body {{ font-family: sans-serif; margin: 0; padding: 1rem; }}
 .label-sheet {{ display: flex; flex-wrap: wrap; gap: 0; }}
 .label-item {{
+  position: relative;
   border: 1px solid #999;
-  padding: 4px 6px;
   font-size: 11px;
   break-inside: avoid;
   width: {w_mm}mm;
@@ -1061,12 +1082,9 @@ body {{ font-family: sans-serif; margin: 0; padding: 1rem; }}
   overflow: hidden;
   flex-shrink: 0;
 }}
-.label-field {{ margin-bottom: 2px; overflow: hidden; }}
-.label-field--barcode {{ margin-bottom: 3px; }}
-.label-field--barcode img {{ max-width: 100%; display: block; }}
-.label-field--barcode-text {{ margin-bottom: 2px; }}
+.label-field {{ position: absolute; overflow: hidden; white-space: nowrap; line-height: 1.2; }}
+.label-field--barcode img {{ display: block; }}
 .bc-human {{ font-family: monospace; font-size: 9px; display: block; text-align: center; }}
-.label-field--qr {{ margin-bottom: 3px; }}
 .no-print {{ margin-bottom: 1rem; }}
 @media print {{
   .no-print {{ display: none; }}

--- a/tests/test_browser/test_label_print_positions.py
+++ b/tests/test_browser/test_label_print_positions.py
@@ -1,0 +1,85 @@
+# Copyright (c) 2026 Noah Severs. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-Proprietary
+"""Regression test for issue #217 — printed labels must honor the designer's field positions.
+
+The label designer saves each field with an (x, y) mm coordinate and the on-screen preview
+renders from those coordinates. The print page (`_printable_label_sheet` in
+`default_modules/celerp-labels/celerp_labels/ui_routes.py`) must place each field at the same
+coordinate. Before the fix it lays the fields out in normal top-to-bottom document flow and never
+reads x/y — so a field designed far to the RIGHT prints at the same left edge as a field designed
+on the LEFT.
+
+We build a template with two text fields deliberately placed in opposite corners (one at the far
+left, one at the far right), print it, and measure the rendered field boxes. If positions are
+honored the RIGHT field is rendered clearly to the right of the LEFT one; on the buggy stacked
+renderer both sit at the same left edge, so the horizontal-offset assertion fails.
+"""
+import uuid
+
+import pytest
+
+pytestmark = pytest.mark.browser
+
+
+@pytest.fixture(scope="module")
+def positioned_template(api):
+    """40x30mm template with two text fields at opposite corners.
+
+    LEFT  field -> top-left     (x = 1 mm)
+    RIGHT field -> bottom-right  (x = 28 mm)  — a large, unambiguous horizontal offset.
+    Distinct labels ("LBLLEFT" / "LBLRIGHT") make each field locatable by its printed text.
+    """
+    r = api.post("/api/labels/templates", json={
+        "name": f"pos-{uuid.uuid4().hex[:6]}",
+        "format": "40x30mm",
+        "fields": [
+            {"key": "sku",  "label": "LBLLEFT",  "type": "text", "x": 1.0,  "y": 1.0},
+            {"key": "name", "label": "LBLRIGHT", "type": "text", "x": 28.0, "y": 20.0},
+        ],
+    })
+    assert r.status_code in {200, 201}, f"template create failed: {r.text}"
+    return r.json()["id"]
+
+
+@pytest.fixture(scope="module")
+def labelled_item(api):
+    """An inventory item to render on the label (its sku/name fill the two text fields)."""
+    r = api.post("/items", json={
+        "sku": f"LBL-{uuid.uuid4().hex[:6]}",
+        "name": "PositionProbe",
+        "quantity": 1,
+        "sell_by": "piece",
+    })
+    assert r.status_code in {200, 201}, f"item create failed: {r.text}"
+    return r.json()["id"]
+
+
+def test_print_honors_designed_field_positions(page, ui_server, positioned_template, labelled_item):
+    """#217: a field designed at x=28mm must render to the RIGHT of a field designed at x=1mm.
+
+    Pre-fix the print renderer stacks both fields left-aligned at the same x (dx ~ 0), so the
+    horizontal-offset assertion below fails — pinning the regression. Post-fix each field is placed
+    at its stored coordinate, so the RIGHT field is clearly to the right of the LEFT one.
+    """
+    page.goto(
+        f"{ui_server}/labels/print/{labelled_item}?template_id={positioned_template}",
+        wait_until="domcontentloaded",
+    )
+    body = page.locator("body").inner_text()
+    assert "Internal Server Error" not in body, f"print page errored: {body!r}"
+
+    left = page.locator("div.label-field", has_text="LBLLEFT").first
+    right = page.locator("div.label-field", has_text="LBLRIGHT").first
+    assert left.count() > 0 and right.count() > 0, f"label fields not rendered; body={body!r}"
+
+    left_box = left.bounding_box()
+    right_box = right.bounding_box()
+    assert left_box and right_box, "could not measure field bounding boxes"
+
+    # 27 mm of designed horizontal separation (~100 px at ~3.78 px/mm). Require a clear rightward
+    # offset; the buggy stacked layout leaves both at the same left edge (dx ~ 0).
+    dx = right_box["x"] - left_box["x"]
+    assert dx > 30, (
+        f"RIGHT field not placed to the right of LEFT field (dx={dx:.1f}px): "
+        "the print renderer is ignoring the designer's x positions (issue #217)"
+    )


### PR DESCRIPTION
## What this changes

The label designer saves each field with an (x, y) mm coordinate and the on-screen preview renders from those coordinates, but the print renderer (_printable_label_sheet) ignored x/y and stacked fields top-to-bottom in document flow — so a printed label never matched the designed layout.

Render each field absolutely at its saved (x, y) inside a position:relative label box; fields without coordinates (older/default templates) auto-stack, mirroring the editor preview. QR/barcode are sized to match the preview (QR 10mm, barcode clamped 20-30mm) instead of a hard-coded 40px.

Add a Playwright regression test that places two fields in opposite corners and asserts the right-designed field renders to the right of the left one (fails on the old stacked renderer: dx=0px).

## Checklist

- [X] Tests added or updated, and the relevant suites pass locally
- [X] License headers are correct for the paths touched (see `LICENSING.md`; enforced by `scripts/licenses.py`)
