### PR TITLE
feat(start): announce servers only when they actually accept connections

### DIFF
--- a/celerp/cli.py
+++ b/celerp/cli.py
@@ -897,6 +897,33 @@ def init(db_url, api_port, ui_port, cloud_token, force, assume_yes, no_start, wa
     _start(cfg)
 
 
+def _wait_ready(servers: dict, timeout: float = 180.0) -> None:
+    """Print '✓ ready → URL' for each server as its port starts accepting
+    connections. Returns early for a server whose process dies (the supervisor
+    loop reports the crash); after `timeout` prints a still-starting note
+    rather than blocking forever on a very slow machine."""
+    import socket
+
+    pending = dict(servers)
+    deadline = time.time() + timeout
+    while pending and time.time() < deadline:
+        for name, (proc, port) in list(pending.items()):
+            if proc.poll() is not None:
+                del pending[name]  # crashed — supervisor loop reports it
+                continue
+            try:
+                with socket.create_connection(("127.0.0.1", port), timeout=0.25):
+                    pass
+            except OSError:
+                continue
+            click.echo(f"  ✓ {name} ready → http://localhost:{port}")
+            del pending[name]
+        if pending:
+            time.sleep(0.3)
+    for name, (_proc, port) in pending.items():
+        click.echo(f"  … {name} is still starting on port {port} — hang tight.")
+
+
 def _start(cfg: dict) -> None:
     """Launch API and UI servers and block until one exits or Ctrl+C.
 
@@ -928,12 +955,17 @@ def _start(cfg: dict) -> None:
     ui_port = cfg["server"]["ui_port"]
 
     click.echo("Starting Celerp...")
-    click.echo(f"  API → http://localhost:{api_port}")
-    click.echo(f"  UI  → http://localhost:{ui_port}")
-    click.echo("Press Ctrl+C to stop.\n")
+    click.echo(f"  API starting on port {api_port} ...")
+    click.echo(f"  UI  starting on port {ui_port} ...")
 
     api_proc = _spawn_api(env, api_port)
     ui_proc = _spawn_ui(env, ui_port)
+
+    # Announce each server only once it actually accepts connections — printing
+    # the URLs up front sent users to a dead localhost:8080 while the UI was
+    # still importing modules.
+    _wait_ready({"API": (api_proc, api_port), "UI ": (ui_proc, ui_port)})
+    click.echo("Press Ctrl+C to stop.\n")
 
     def _shutdown(sig, frame):
         click.echo("\nShutting down...")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -374,6 +374,9 @@ def test_start_respawns_api_on_sentinel(tmp_path):
         patch("celerp.cli._config_to_env", return_value={}),
         patch("celerp.config.config_path", return_value=tmp_path / "config.toml"),
         patch("celerp.cli.time.sleep", side_effect=fake_sleep),
+        # readiness probing is not under test here, and its sleeps would
+        # consume fake_sleep's budget before the supervisor loop runs
+        patch("celerp.cli._wait_ready"),
         patch("signal.signal"),
     ):
         with pytest.raises(SystemExit) as exc:
@@ -414,6 +417,7 @@ def test_start_exits_without_sentinel(tmp_path):
         patch("celerp.cli._config_to_env", return_value={}),
         patch("celerp.config.config_path", return_value=tmp_path / "config.toml"),
         patch("celerp.cli.time.sleep"),
+        patch("celerp.cli._wait_ready"),  # not under test; would spin on closed ports
         patch("signal.signal"),
     ):
         with pytest.raises(SystemExit) as exc:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -467,6 +467,49 @@ def test_init_force_aborts_on_no_keeps_everything(tmp_config, tmp_path, monkeypa
     assert att.exists() and ai.exists() # files kept
 
 
+# ── _wait_ready ───────────────────────────────────────────────────────────────
+
+def test_wait_ready_announces_when_port_opens(capsys):
+    """The ready line appears only once the port actually accepts connections."""
+    import socket
+    import threading
+    import time as _time
+
+    from celerp.cli import _wait_ready
+
+    srv = socket.socket()
+    srv.bind(("127.0.0.1", 0))
+    port = srv.getsockname()[1]
+
+    class FakeProc:
+        def poll(self):
+            return None
+
+    def _listen_later():
+        _time.sleep(0.6)
+        srv.listen(1)
+
+    t = threading.Thread(target=_listen_later)
+    t.start()
+    _wait_ready({"UI ": (FakeProc(), port)}, timeout=10)
+    t.join()
+    srv.close()
+    out = capsys.readouterr().out
+    assert "✓ UI  ready → http://localhost:" in out
+
+
+def test_wait_ready_skips_dead_process(capsys):
+    """A crashed server never gets a ready line (the supervisor reports it)."""
+    from celerp.cli import _wait_ready
+
+    class DeadProc:
+        def poll(self):
+            return 1
+
+    _wait_ready({"API": (DeadProc(), 1)}, timeout=2)
+    assert "ready" not in capsys.readouterr().out
+
+
 # ── `python -m celerp` module entrypoint ────────────────────────────────────
 # The packaged Electron launcher invokes the bundled Python by module
 # (`python -m celerp migrate`), not via the console script. These tests prove


### PR DESCRIPTION
`celerp start` printed the API/UI URLs before uvicorn was listening, so visiting http://localhost:8080 during the ~20 s the UI spends importing modules returned connection refused, with no hint anything was still loading.

New output:

```
Starting Celerp...
  API starting on port 8000 ...
  UI  starting on port 8080 ...
  ✓ API ready → http://localhost:8000
  ✓ UI  ready → http://localhost:8080
Press Ctrl+C to stop.
```

Each ready line prints the moment that port accepts connections (socket probe in the supervisor). A crashed process skips its ready line and hits the existing exit-code error path; after 180 s a still-starting note prints instead of blocking forever.

Verified live: the ready line lands exactly when uvicorn binds (previously a 20-second dead window on this machine). Unit tests cover the port-open announcement and the dead-process skip.