### PR TITLE
feat(labels): per-field font size in the label designer (#221)

### DIFF
--- a/default_modules/celerp-labels/celerp_labels/ui_routes.py
+++ b/default_modules/celerp-labels/celerp_labels/ui_routes.py
@@ -404,7 +404,10 @@ def _field_row_compact(
             f'<input type="hidden" name="fields[{idx}][type]" value="{ftype}" class="fld-type">'
             f'<input type="hidden" name="fields[{idx}][x]" value="{x_val}" class="fld-x">'
             f'<input type="hidden" name="fields[{idx}][y]" value="{y_val}" class="fld-y">'
-            f'<input type="hidden" name="fields[{idx}][fontSize]" value="{font_size}" class="fld-fs">'
+            f'<input type="number" name="fields[{idx}][fontSize]" value="{font_size}" class="form-input form-input--sm fld-fs"'
+            f' min="4" max="72" placeholder="Font" title="Text size in points (4-72)"'
+            f' style="display:{("" if ftype in ("text", "barcode_text") else "none")};width:60px;"'
+            f' oninput="labelEditorUpdatePreview()">'
             f'<input type="number" name="fields[{idx}][barcode_height]" value="{barcode_height}" class="form-input form-input--sm fld-bh"'
             f' min="1" max="30" placeholder="Bar H" title="Barcode bar height (1-30)"'
             f' style="display:{("" if ftype == "barcode" else "none")};width:60px;"'
@@ -583,7 +586,7 @@ def _editor_panel(
       currentVal = k;
       display.value = v || '';
       if (hiddenIn) hiddenIn.value = k;
-      // Sync fld-type, fld-label, and fld-bh visibility in the parent row
+      // Sync fld-type, fld-label, and the fld-fs / fld-bh control visibility in the parent row
       var row = wrapper.closest('.field-row-compact');
       if (row) {{
         var typeIn = row.querySelector('.fld-type');
@@ -591,6 +594,8 @@ def _editor_panel(
         if (typeIn) typeIn.value = ft;
         var labelIn = row.querySelector('.fld-label');
         if (labelIn && !labelIn._userEdited) labelIn.value = v || k;
+        var fsIn = row.querySelector('.fld-fs');
+        if (fsIn) fsIn.style.display = (ft === 'text' || ft === 'barcode_text') ? '' : 'none';  // font size: text + barcode number
         var bhIn = row.querySelector('.fld-bh');
         if (bhIn) bhIn.style.display = ft === 'barcode' ? '' : 'none';
       }}
@@ -665,7 +670,9 @@ def _editor_panel(
         '<input type="hidden" name="fields[' + idx + '][type]" value="text" class="fld-type">' +
         '<input type="hidden" name="fields[' + idx + '][x]" value="" class="fld-x">' +
         '<input type="hidden" name="fields[' + idx + '][y]" value="" class="fld-y">' +
-        '<input type="hidden" name="fields[' + idx + '][fontSize]" value="" class="fld-fs">' +
+        '<input type="number" name="fields[' + idx + '][fontSize]" value="" class="form-input form-input--sm fld-fs"' +
+        ' min="4" max="72" placeholder="Font" title="Text size in points (4-72)"' +
+        ' style="width:60px;" oninput="labelEditorUpdatePreview()">' +
         '<input type="number" name="fields[' + idx + '][barcode_height]" value="" class="form-input form-input--sm fld-bh"' +
         ' min="1" max="30" placeholder="Bar H" title="Barcode bar height (1-30)"' +
         ' style="display:none;width:60px;" oninput="labelEditorUpdatePreview()">';
@@ -782,7 +789,8 @@ def _editor_panel(
       }} else if (ftype === 'barcode_text') {{
         block.className = 'label-field-block label-field-block--barcode-text';
         block.style.fontFamily = 'monospace';
-        block.style.fontSize = '11px';
+        // Honor a chosen font size; keep the 11px default when none is set.
+        block.style.fontSize = (fsEl && fsEl.value !== '') ? (scaledFs + 'px') : '11px';
         block.textContent = sample;
       }} else if (ftype === 'qr') {{
         block.className = 'label-field-block label-field-block--qr';
@@ -1055,12 +1063,18 @@ def _printable_label_sheet(items: list[dict], template: dict | None) -> object:
                 bc_w = max(20.0, min(w_mm - left_mm - 2.0, 30.0))
                 field_lines.append(_barcode_img_tag(val, module_height=bc_height, wrap_style=pos, width_mm=bc_w))
             elif ftype == "barcode_text":
-                field_lines.append(f'<div class="label-field label-field--barcode-text" style="{pos}"><span class="bc-human">{val}</span></div>')
+                fs = f.get("fontSize")
+                span_style = f' style="font-size:{float(fs)}pt;"' if fs not in (None, "") else ""
+                field_lines.append(f'<div class="label-field label-field--barcode-text" style="{pos}"><span class="bc-human"{span_style}>{val}</span></div>')
             elif ftype == "qr":
                 field_lines.append(_qr_img_tag(val, wrap_style=pos))
             else:
+                # Honor the designer's per-field font size (points) when set; otherwise the
+                # label-item default applies, so existing labels look exactly as before.
+                fs = f.get("fontSize")
+                fs_style = f"font-size:{float(fs)}pt;" if fs not in (None, "") else ""
                 display = f"{field_label}: {val}" if field_label else val
-                field_lines.append(f'<div class="label-field" style="{pos}">{display}</div>')
+                field_lines.append(f'<div class="label-field" style="{pos}{fs_style}">{display}</div>')
         label_rows.append(f'<div class="label-item">{"".join(field_lines)}</div>')
 
     html = f"""<!DOCTYPE html>

--- a/tests/test_browser/test_label_font_size.py
+++ b/tests/test_browser/test_label_font_size.py
@@ -1,0 +1,92 @@
+# Copyright (c) 2026 Noah Severs. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-Proprietary
+"""Feature test (issue #221) — the label designer must let the user set a per-field font size,
+and that size must be applied when the label is printed.
+
+Two checks:
+  1. Designer: a text field's row shows an editable font-size box, pre-filled from the saved value.
+  2. Print: a field with a saved fontSize renders at that size (a large size is clearly bigger
+     than the default), so what the user picks in the designer is what comes out on the label.
+"""
+import uuid
+
+import pytest
+
+pytestmark = pytest.mark.browser
+
+
+def _make_template(api, font_size, ftype="text", key="name", label="Name"):
+    r = api.post("/api/labels/templates", json={
+        "name": f"fs-{uuid.uuid4().hex[:6]}",
+        "format": "40x30mm",
+        "fields": [{"key": key, "label": label, "type": ftype, "x": 2.0, "y": 2.0, "fontSize": font_size}],
+    })
+    assert r.status_code in {200, 201}, f"template create failed: {r.text}"
+    return r.json()["id"]
+
+
+def test_designer_shows_editable_font_size(page, ui_server, api):
+    """The designer renders a visible, editable font-size box for a text field, pre-filled with
+    the template's saved value."""
+    tid = _make_template(api, 22)
+    page.goto(f"{ui_server}/settings/labels/{tid}", wait_until="domcontentloaded")
+
+    fs_box = page.locator(".field-row-compact .fld-fs").first
+    assert fs_box.count() > 0, "no font-size box rendered in the field row"
+    assert fs_box.is_visible(), "font-size box should be visible for a text field"
+    assert fs_box.input_value() == "22", f"font-size box should show saved value; got {fs_box.input_value()!r}"
+
+
+def test_print_applies_designed_font_size(page, ui_server, api):
+    """A field saved with a large font size prints noticeably larger than the default."""
+    tid = _make_template(api, 24)  # 24pt ~= 32px at 96dpi
+    r = api.post("/items", json={
+        "sku": f"FS-{uuid.uuid4().hex[:6]}",
+        "name": "FontProbe",
+        "quantity": 1,
+        "sell_by": "piece",
+    })
+    assert r.status_code in {200, 201}, f"item create failed: {r.text}"
+    eid = r.json()["id"]
+
+    page.goto(f"{ui_server}/labels/print/{eid}?template_id={tid}", wait_until="domcontentloaded")
+    body = page.locator("body").inner_text()
+    assert "Internal Server Error" not in body, f"print page errored: {body!r}"
+
+    fld = page.locator("div.label-field", has_text="Name:").first
+    assert fld.count() > 0, f"text field not rendered; body={body!r}"
+    fs_px = fld.evaluate("el => parseFloat(getComputedStyle(el).fontSize)")
+    # 24pt is ~32px; the un-styled default is ~11px. Require clearly larger than default.
+    assert fs_px > 24, f"printed font size not applied (got {fs_px:.1f}px, expected ~32px)"
+
+
+def test_designer_shows_font_size_for_barcode_number(page, ui_server, api):
+    """The barcode-number field (barcode_text) also gets an editable font-size box."""
+    tid = _make_template(api, 18, ftype="barcode_text", key="barcode_text", label="No")
+    page.goto(f"{ui_server}/settings/labels/{tid}", wait_until="domcontentloaded")
+
+    fs_box = page.locator(".field-row-compact .fld-fs").first
+    assert fs_box.count() > 0, "no font-size box rendered for the barcode-number field"
+    assert fs_box.is_visible(), "font-size box should be visible for a barcode-number field"
+    assert fs_box.input_value() == "18", f"font-size box should show saved value; got {fs_box.input_value()!r}"
+
+
+def test_print_applies_font_size_to_barcode_number(page, ui_server, api):
+    """A barcode-number field saved with a large font size prints noticeably larger than default."""
+    tid = _make_template(api, 24, ftype="barcode_text", key="barcode_text", label="No")
+    r = api.post("/items", json={
+        "sku": f"BN-{uuid.uuid4().hex[:6]}",
+        "name": "BarNumProbe",
+        "barcode": "9876543210",
+        "quantity": 1,
+        "sell_by": "piece",
+    })
+    assert r.status_code in {200, 201}, f"item create failed: {r.text}"
+    eid = r.json()["id"]
+
+    page.goto(f"{ui_server}/labels/print/{eid}?template_id={tid}", wait_until="domcontentloaded")
+    span = page.locator("span.bc-human").first
+    assert span.count() > 0, "barcode-number text not rendered"
+    fs_px = span.evaluate("el => parseFloat(getComputedStyle(el).fontSize)")
+    # 24pt is ~32px; the un-styled .bc-human default is 9px. Require clearly larger than default.
+    assert fs_px > 20, f"barcode-number font size not applied (got {fs_px:.1f}px, expected ~32px)"


### PR DESCRIPTION
## What this changes

The label designer had no way to set text size — every field printed at a single fixed size, so text could overflow small stickers and important fields couldn't be emphasized.

Turn the hidden fontSize input into a visible "Font" box (points, 4-72) in each field row, shown for text fields including the barcode number (barcode_text), and hidden for barcode bars / QR. It updates the live preview and is saved with the template (persistence already round-tripped fontSize). The print renderer now applies a chosen size; fields with none set fall through to the existing default, so existing labels are unchanged.

Add browser tests covering the designer control and print output for both a plain text field and the barcode-number field.


## Checklist

- [X] Tests added or updated, and the relevant suites pass locally
- [X] License headers are correct for the paths touched (see `LICENSING.md`; enforced by `scripts/licenses.py`)
