### PR TITLE
build(linux): package metadata required by the .deb target

### DIFF
--- a/LICENSING.md
+++ b/LICENSING.md
@@ -29,7 +29,7 @@ operative statement for that file; this map governs by path otherwise.
 Notes:
 - The BSL components use the SPDX identifier `BUSL-1.1` (the official short identifier for Business
   Source License 1.1). They are source-available, not open source, until the Change Date, on which they
-  convert to the Change License stated in `LICENSE` (Apache-2.0), at the latest. BSL also converts the
+  convert to the Change License stated in `LICENSE` (Apache-2.0), at the latest. BUSL also converts the
   fourth anniversary of each version's first public distribution, whichever is earlier.
 - The MIT modules depend on the BUSL-1.1 engine at runtime; redistributing an MIT module does not change
   the license of the engine it requires, and using the engine remains governed by `LICENSE`.

--- a/LICENSING.md
+++ b/LICENSING.md
@@ -1,5 +1,8 @@
 # Licensing
 
+Celerp is free to download, self-host, and use to run your own business. Different
+components use different licenses, as mapped below.
+
 Celerp is multi-licensed. This file is the authoritative map of which license applies to which part of
 the repository. Where a source file carries an `SPDX-License-Identifier` header, that header is the
 operative statement for that file; this map governs by path otherwise.

--- a/electron/package.json
+++ b/electron/package.json
@@ -8,7 +8,7 @@
     "email": "support@celerp.com"
   },
   "homepage": "https://www.celerp.com",
-  "license": "BUSL-1.1",
+  "license": "SEE LICENSE IN LICENSING.md",
   "packageManager": "pnpm@9.0.0",
   "scripts": {
     "start": "electron .",
@@ -61,6 +61,8 @@
           "alembic.ini",
           "pyproject.toml",
           "MANIFEST.in",
+          "LICENSE",
+          "LICENSING.md",
           "!**/__pycache__",
           "!**/*.pyc",
           "!tests/**",

--- a/electron/package.json
+++ b/electron/package.json
@@ -8,7 +8,8 @@
     "email": "support@celerp.com"
   },
   "homepage": "https://www.celerp.com",
-  "license": "BUSL-1.1",
+  "license": "SEE LICENSE IN LICENSING.md",
+  "private": true,
   "packageManager": "pnpm@9.0.0",
   "scripts": {
     "start": "electron .",
@@ -63,6 +64,7 @@
           "MANIFEST.in",
           "LICENSE",
           "LICENSING.md",
+          "legal/**",
           "!**/__pycache__",
           "!**/*.pyc",
           "!tests/**",
@@ -156,6 +158,8 @@
     "linux": {
       "icon": "assets/icon.png",
       "category": "Office",
+      "maintainer": "Data Universal Limited <support@celerp.com>",
+      "vendor": "Data Universal Limited",
       "target": [
         {
           "target": "AppImage",

--- a/electron/package.json
+++ b/electron/package.json
@@ -3,7 +3,11 @@
   "version": "1.0.0",
   "description": "Free business software \u2014 inventory, invoicing, and operations in one place.",
   "main": "main.js",
-  "author": "Data Universal Limited",
+  "author": {
+    "name": "Data Universal Limited",
+    "email": "support@celerp.com"
+  },
+  "homepage": "https://www.celerp.com",
   "license": "BUSL-1.1",
   "packageManager": "pnpm@9.0.0",
   "scripts": {

--- a/electron/package.json
+++ b/electron/package.json
@@ -8,7 +8,7 @@
     "email": "support@celerp.com"
   },
   "homepage": "https://www.celerp.com",
-  "license": "SEE LICENSE IN LICENSING.md",
+  "license": "BUSL-1.1",
   "packageManager": "pnpm@9.0.0",
   "scripts": {
     "start": "electron .",


### PR DESCRIPTION
The .deb target added in #211 needs a package homepage and an author email for the deb Maintainer field; the AppImage target never required them, so the Linux release build fails without this. Blocks the next tag.