### PR TITLE
Fix Celerp not launching on Ubuntu 24.04

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -500,15 +500,19 @@ jobs:
           cd electron
           if [ "$RUNNER_OS" = "Linux" ]; then
             sudo apt-get update -qq && sudo apt-get install -y -qq xvfb
-            # Electron's SUID sandbox helper must be owned by root with mode 4755;
-            # the unpacked tree ships it owned by the runner (real AppImage/deb
-            # installs set this), so fix it here or the sandbox aborts on launch.
-            sudo chown root:root dist/linux-unpacked/chrome-sandbox
-            sudo chmod 4755 dist/linux-unpacked/chrome-sandbox
+            # Install the actual .deb so ITS postinst runs and sets chrome-sandbox's
+            # mode, then boot the installed /opt/Celerp/celerp below. Booting
+            # dist/linux-unpacked with a hand-applied chmod (what we used to do) never
+            # exercised the postinst, so it could not catch the postinst leaving
+            # chrome-sandbox at 0755 on Ubuntu 24.04 - where the namespace sandbox is
+            # blocked and the SUID helper must be 4755, or the app aborts on launch.
+            # Installing for real means that misconfiguration fails the build here
+            # instead of shipping.
+            sudo apt-get install -y -qq "$PWD/dist/Celerp.deb"
           fi
           case "$RUNNER_OS" in
             macOS)   APP_BIN="$(ls -d dist/mac*/Celerp.app | head -1)/Contents/MacOS/Celerp" ;;
-            Linux)   APP_BIN="$(find dist/linux-unpacked -maxdepth 1 -type f -executable ! -name 'chrome*' ! -name '*.so*' | head -1)" ;;
+            Linux)   APP_BIN="/opt/Celerp/celerp" ;;
           esac
           echo "smoke: launching $APP_BIN"
           API_PORT=$(python3 -c 'import socket;s=socket.socket();s.bind(("127.0.0.1",0));print(s.getsockname()[1]);s.close()')

--- a/electron/build/deb-after-install.sh
+++ b/electron/build/deb-after-install.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+# Custom deb postinst (replaces electron-builder's default via build.deb.afterInstall).
+#
+# Why we override it: electron-builder's default postinst decides the
+# chrome-sandbox mode with a `unshare --user` test that runs as root. That test
+# passes on Ubuntu 23.10+/24.04 (root can always unshare), so it sets
+# chrome-sandbox to 0755. But those releases set
+# kernel.apparmor_restrict_unprivileged_userns=1, which stops the app (running
+# as a normal user) from using the namespace sandbox. Electron then falls back
+# to the SUID chrome-sandbox and, finding it at 0755 instead of 4755, aborts on
+# launch with SIGTRAP - so the app crashes the first time every 24.04 user opens
+# it. We set 4755 unconditionally; the SUID sandbox works on every supported
+# system, so this is safe everywhere.
+#
+# Keep the rest in sync with electron-builder's default (the /usr/bin symlink
+# via update-alternatives, mime and desktop database refresh) so uninstall still
+# pairs with the default postrm.
+
+if type update-alternatives 2>/dev/null >&1; then
+    # Remove previous link if it doesn't use update-alternatives
+    if [ -L '/usr/bin/celerp' -a -e '/usr/bin/celerp' -a "`readlink '/usr/bin/celerp'`" != '/etc/alternatives/celerp' ]; then
+        rm -f '/usr/bin/celerp'
+    fi
+    update-alternatives --install '/usr/bin/celerp' 'celerp' '/opt/Celerp/celerp' 100 || ln -sf '/opt/Celerp/celerp' '/usr/bin/celerp'
+else
+    ln -sf '/opt/Celerp/celerp' '/usr/bin/celerp'
+fi
+
+# Always install the SUID sandbox (see note above).
+chmod 4755 '/opt/Celerp/chrome-sandbox' || true
+
+if hash update-mime-database 2>/dev/null; then
+    update-mime-database /usr/share/mime || true
+fi
+
+if hash update-desktop-database 2>/dev/null; then
+    update-desktop-database /usr/share/applications || true
+fi

--- a/electron/package.json
+++ b/electron/package.json
@@ -198,7 +198,8 @@
       "artifactName": "Celerp.AppImage"
     },
     "deb": {
-      "artifactName": "Celerp.deb"
+      "artifactName": "Celerp.deb",
+      "afterInstall": "build/deb-after-install.sh"
     },
     "afterPack": "./after-pack.js",
     "publish": {


### PR DESCRIPTION
Celerp installed from the .deb closed immediately on launch on Ubuntu 23.10 and 24.04. The package shipped its Chromium sandbox helper without the setuid bit, and those Ubuntu releases block the fallback sandbox, so Electron aborted at startup before the window appeared.

The .deb now sets the sandbox helper to the mode Electron needs at install time, so it launches on 24.04 and on earlier releases the same way.

- The package installs chrome-sandbox as setuid root (mode 4755) regardless of the kernel's user-namespace policy, which is what Electron needs when the namespace sandbox is unavailable.
- The Linux boot smoke now installs the built .deb and launches the installed app, instead of booting the unpacked tree with permissions set by hand, so a packaging regression that stops the app launching fails the build.