### PR TITLE
Denser labels, dot-aligned barcodes, a condensed Measurements field, and the full barcode on Pro Forma lines

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -260,7 +260,9 @@ _labels_src = _os.path.join(_os.path.dirname(__file__), "default_modules", "cele
 if _os.path.abspath(_labels_src) not in [_os.path.abspath(p) for p in _sys.path]:
     _sys.path.insert(0, _os.path.abspath(_labels_src))
 from celerp_labels.routes import setup_api_routes as _setup_labels
+from celerp_labels.ui_routes import setup_ui_routes as _setup_labels_ui
 _setup_labels(app)
+_setup_labels_ui(_ui_app)
 
 # Register warehousing module path so its UI components can be imported in tests.
 _wh_src = _os.path.join(_os.path.dirname(__file__), "premium_modules", "celerp-warehousing")

--- a/default_modules/celerp-labels/celerp_labels/service.py
+++ b/default_modules/celerp-labels/celerp_labels/service.py
@@ -169,7 +169,17 @@ def render_label_text(
     return "\n".join(lines)
 
 
-_BC_MODULE_MM = 0.2  # Code128 X-dimension (width of one bar module)
+# Code128 X-dimension (width of one bar module). Widened from 0.2mm: a narrow
+# module is both harder to scan once thermal ink spreads and rounds badly on the
+# dot grid - 0.2mm is 2.36 dots at 300dpi, so snapping it lands on 2 dots
+# (0.169mm), thinner than intended and below a comfortable scan width. 0.33mm
+# snaps to a clean 4 dots at 300dpi and 3 dots at 203dpi, both well above the
+# minimum, so the same value is correct on either printer.
+_BC_MODULE_MM = 0.33
+# Bar-width reduction: shave the black bar so the adjacent white gaps stay open
+# against thermal ink bleed. Quantised to whole dots at render time (a dot printer
+# cannot place a fraction of a dot), so this is a nominal figure.
+_BC_BAR_SHRINK_MM = 0.05
 _BC_QUIET_MM = 1.0   # quiet zone on either side of the bars
 
 # Thermal label printers are dot-addressed: 300dpi = 0.0847mm per dot, 203dpi =

--- a/default_modules/celerp-labels/celerp_labels/service.py
+++ b/default_modules/celerp-labels/celerp_labels/service.py
@@ -131,6 +131,10 @@ def resolve_field_value(item: dict[str, Any], key: str, unit_map: dict[str, dict
     - pieces on a pieces-sold item -> quantity
     - unit -> the item's sell_by
     - qr / barcode / barcode_text -> the item's barcode, falling back to SKU
+    - measurements -> the stored value, else "length x width x height" composed
+      from the dimension attributes only when all three are present (a partial
+      join like "6.5 x  x 4.0" would read as a complete measurement of a
+      different shape)
     """
     sell_by = item.get("sell_by")
     if key in ("qr", "barcode", "barcode_text"):
@@ -142,6 +146,12 @@ def resolve_field_value(item: dict[str, Any], key: str, unit_map: dict[str, dict
         return format_qty(item.get("quantity"), sell_by, unit_map)
     if key == "unit":
         return _item_val(item, key) or str(sell_by or "")
+    if key == "measurements":
+        stored = _item_val(item, key)
+        if stored:
+            return stored
+        dims = [_item_val(item, d) for d in ("length", "width", "height")]
+        return " x ".join(dims) if all(dims) else ""
     return _item_val(item, key)
 
 

--- a/default_modules/celerp-labels/celerp_labels/service.py
+++ b/default_modules/celerp-labels/celerp_labels/service.py
@@ -221,6 +221,7 @@ def snap_to_dots(value_mm: float, dpi: int = DEFAULT_PRINTER_DPI, minimum_dots: 
     dots = max(int(minimum_dots), int(round(float(value_mm) / d)))
     return dots * d
 QR_SIZE_MM = 10.0    # QR codes are a fixed 10mm square on labels (minimum scannable size)
+BARCODE_HEIGHT_DEFAULT = 8   # bar height (mm, 1-30) a barcode field uses when none is set
 
 
 def _svg_markup(inner: str, vb_w: float, vb_h: float, w_mm: float, h_mm: float, stretch: bool) -> str:
@@ -379,7 +380,7 @@ def render_label_pdf(
                         # printer's dot grid and the white gaps stay open. Natural width;
                         # squeeze only when the label is genuinely too narrow (never stretch up).
                         # Bar height honors the field's barcode_height setting (mm, 1-30), like the designer.
-                        img_h = max(1, min(30, int(field.get("barcode_height") or 8))) * mm
+                        img_h = max(1, min(30, int(field.get("barcode_height") or BARCODE_HEIGHT_DEFAULT))) * mm
                         # Snap the X-dimension to whole printer dots for the same reason the
                         # SVG path does: 0.33mm is 3.90 dots at 300dpi, so an unsnapped module
                         # rasterizes as a mix of 3- and 4-dot bars.

--- a/default_modules/celerp-labels/celerp_labels/service.py
+++ b/default_modules/celerp-labels/celerp_labels/service.py
@@ -73,6 +73,21 @@ _SIZES: dict[str, tuple[float, float]] = {
 }
 
 
+def display_label(label: str) -> str:
+    """The printed form of a field label: the leaf of a "Category > Field" path.
+
+    The field picker lists category attributes as "Stones › Origin" so they can be
+    told apart while choosing, and that whole path was then saved as the printed
+    label. On a 25mm sticker the repeated category prefix costs roughly a third of
+    the line and tells the reader nothing - they are holding the stone. Print the
+    leaf; the picker keeps the full path. Applied at render time so labels saved
+    before this still shorten, without anyone re-picking their fields.
+    """
+    if not label:
+        return ""
+    return str(label).split("›")[-1].strip()
+
+
 def _parse_size(fmt: str) -> tuple[float, float]:
     """Return (width_mm, height_mm) for a format string. Public alias kept for compatibility."""
     if fmt in _SIZES:
@@ -378,7 +393,7 @@ def render_label_pdf(
                 else:
                     bold = field.get("bold", False)
                     c.setFont("Helvetica-Bold" if bold else "Helvetica", font_size)
-                    field_label = str(field.get("label", "") or "").strip()
+                    field_label = display_label(field.get("label", ""))
                     display_text = f"{field_label}: {val}" if field_label else val
                     c.drawString(x_pt, y_pt + line_h * 0.2, display_text[:50])
 

--- a/default_modules/celerp-labels/celerp_labels/service.py
+++ b/default_modules/celerp-labels/celerp_labels/service.py
@@ -156,6 +156,35 @@ def render_label_text(
 
 _BC_MODULE_MM = 0.2  # Code128 X-dimension (width of one bar module)
 _BC_QUIET_MM = 1.0   # quiet zone on either side of the bars
+
+# Thermal label printers are dot-addressed: 300dpi = 0.0847mm per dot, 203dpi =
+# 0.1251mm. A bar edge that falls between dots gets rounded by the rasterizer, so a
+# nominally uniform X-dimension prints as a mix of (say) 3- and 4-dot bars - uneven
+# bars are what makes a printed barcode scan badly, not vector rendering itself.
+# 0.33mm is 3.90 dots at 300dpi, so we snap the geometry to whole dots: at 300dpi
+# 4 dots = 0.3387mm (visually identical to 0.33), and every bar edge then lands
+# exactly on a dot boundary. Quantising keeps one resolution-independent vector
+# that is exact on 203dpi hardware too - a fixed 300dpi bitmap would be resampled
+# there, which is worse than vector.
+DEFAULT_PRINTER_DPI = 300
+_BC_MIN_MODULE_DOTS = 2   # never let a module collapse below 2 dots (unscannable)
+
+# Leading as a multiple of the font size. 1.25 is tight enough to fit a dense
+# stone/lot label without lines touching; the old renderer effectively used ~3.97
+# (see render_label_pdf), which is why so little fitted on a label.
+_LINE_SPACING = 1.25
+
+
+def dot_mm(dpi: int = DEFAULT_PRINTER_DPI) -> float:
+    """Width of one printer dot in mm."""
+    return 25.4 / float(max(1, int(dpi or DEFAULT_PRINTER_DPI)))
+
+
+def snap_to_dots(value_mm: float, dpi: int = DEFAULT_PRINTER_DPI, minimum_dots: int = 0) -> float:
+    """Round a millimetre length to a whole number of printer dots."""
+    d = dot_mm(dpi)
+    dots = max(int(minimum_dots), int(round(float(value_mm) / d)))
+    return dots * d
 QR_SIZE_MM = 10.0    # QR codes are a fixed 10mm square on labels (minimum scannable size)
 
 
@@ -174,12 +203,18 @@ def _svg_markup(inner: str, vb_w: float, vb_h: float, w_mm: float, h_mm: float, 
     )
 
 
-def _make_barcode_svg(value: str, module_height: int = 8, stretch: bool = False) -> tuple[str, float, float] | None:
+def _make_barcode_svg(value: str, module_height: int = 8, stretch: bool = False,
+                      dpi: int = DEFAULT_PRINTER_DPI) -> tuple[str, float, float] | None:
     """Render a Code128 barcode as vector SVG (bars only, no text).
 
     Vector output rasterizes sharply at the printer's own dot grid; a raster
     resampled by the print HTML thresholds into merged or dropped bars on
     low-DPI 1-bit label printers.
+
+    Every horizontal length is snapped to a whole number of printer dots for `dpi`
+    (see snap_to_dots), so each bar edge lands exactly on a dot boundary instead of
+    being rounded unevenly by the rasterizer - that rounding, not vector rendering,
+    is what makes printed bars come out uneven.
 
     module_height: bar height in mm (1-30). Default 8.
     Returns (svg_markup, natural_width_mm, height_mm), or None if the barcode
@@ -192,7 +227,13 @@ def _make_barcode_svg(value: str, module_height: int = 8, stretch: bool = False)
     except Exception:
         return None
     h_mm = float(max(1, min(30, int(module_height))))
-    w_mm = len(pattern) * _BC_MODULE_MM + 2 * _BC_QUIET_MM
+    # Snap the X-dimension, the bar shave and the quiet zone to whole dots.
+    mod_mm = snap_to_dots(_BC_MODULE_MM, dpi, minimum_dots=_BC_MIN_MODULE_DOTS)
+    shrink_mm = snap_to_dots(_BC_BAR_SHRINK_MM, dpi)          # 0 or a whole dot
+    if shrink_mm >= mod_mm:                                    # never erase a module
+        shrink_mm = 0.0
+    quiet_mm = snap_to_dots(_BC_QUIET_MM, dpi)
+    w_mm = len(pattern) * mod_mm + 2 * quiet_mm
     bars = []
     i = 0
     while i < len(pattern):
@@ -200,8 +241,16 @@ def _make_barcode_svg(value: str, module_height: int = 8, stretch: bool = False)
             j = i
             while j < len(pattern) and pattern[j] == "1":
                 j += 1
-            x = _BC_QUIET_MM + i * _BC_MODULE_MM
-            bars.append(f'<rect x="{x:.1f}" y="0" width="{(j - i) * _BC_MODULE_MM:.1f}" height="{h_mm:g}"/>')
+            x = quiet_mm + i * mod_mm
+            w = (j - i) * mod_mm
+            # Bar-width reduction, dot-wise: a dot-addressed printer can only drop
+            # WHOLE dots, so shave the trailing edge by one dot rather than half a
+            # dot off each side. A symmetric shave would put the bar's left edge on
+            # a half-dot boundary and hand the rasterizer the same rounding problem
+            # this quantisation exists to remove. The following white gap widens by
+            # exactly one dot, which is what compensates for thermal ink bleed.
+            bw = max(dot_mm(dpi), w - shrink_mm)
+            bars.append(f'<rect x="{x:.4f}" y="0" width="{bw:.4f}" height="{h_mm:g}"/>')
             i = j
         else:
             i += 1
@@ -277,7 +326,7 @@ def render_label_pdf(
                 ftype = field.get("type", "text")
                 val = resolve_field_value(item, key, unit_map)
                 font_size = float(field.get("fontSize") or default_font_size)
-                line_h = font_size * mm * 1.4
+                line_h = font_size * _LINE_SPACING
 
                 # Resolve position: explicit x/y override auto-stack
                 if field.get("x") is not None and field.get("y") is not None:

--- a/default_modules/celerp-labels/celerp_labels/service.py
+++ b/default_modules/celerp-labels/celerp_labels/service.py
@@ -340,11 +340,18 @@ def render_label_pdf(
 
                 if ftype == "barcode":
                     try:
-                        # Vector barcode: crisp at any printer DPI. Natural width
-                        # (bar-perfect) preferred; squeeze only when the label is
-                        # too narrow. Same rule as the HTML print sheet.
-                        img_h = max(6, min(8, h_mm / 4)) * mm
-                        bc = createBarcodeDrawing("Code128", value=str(val), barHeight=img_h, humanReadable=False)
+                        # Vector barcode at a wide X-dimension so bars land cleanly on the
+                        # printer's dot grid and the white gaps stay open. Natural width;
+                        # squeeze only when the label is genuinely too narrow (never stretch up).
+                        # Bar height honors the field's barcode_height setting (mm, 1-30), like the designer.
+                        img_h = max(1, min(30, int(field.get("barcode_height") or 8))) * mm
+                        # Snap the X-dimension to whole printer dots for the same reason the
+                        # SVG path does: 0.33mm is 3.90 dots at 300dpi, so an unsnapped module
+                        # rasterizes as a mix of 3- and 4-dot bars.
+                        _bar_w = snap_to_dots(_BC_MODULE_MM, DEFAULT_PRINTER_DPI,
+                                              minimum_dots=_BC_MIN_MODULE_DOTS)
+                        bc = createBarcodeDrawing("Code128", value=str(val), barHeight=img_h,
+                                                  humanReadable=False, barWidth=_bar_w * mm)
                         avail = (w_mm - 2) * mm - x_pt
                         img_w = min(avail, max(20 * mm, bc.width))
                         if img_w != bc.width:

--- a/default_modules/celerp-labels/celerp_labels/ui_routes.py
+++ b/default_modules/celerp-labels/celerp_labels/ui_routes.py
@@ -120,6 +120,7 @@ _SAMPLE_DATA = {
 _FIELD_TYPE_MAP = {k: t for k, _label, t in _COMMON_FIELDS}
 
 # Default templates live in presets.py (shared with the API, which seeds them on first read).
+from .service import display_label as _svc_display_label
 from .presets import PRESET_TEMPLATES as _PRESET_TEMPLATES
 
 # The human-readable barcode number is a fallback for keying the code by hand, so it
@@ -374,7 +375,8 @@ def _field_row_compact(
     Div, Button, NotStr = ft["Div"], ft["Button"], ft["NotStr"]
 
     key = field.get("key", "")
-    label_val = str(field.get("label", "") or key).replace("&", "&amp;").replace('"', "&quot;")
+    # Show the leaf of a "Category > Field" path so the editor matches what prints.
+    label_val = _svc_display_label(field.get("label", "") or key).replace("&", "&amp;").replace('"', "&quot;")
     ftype = field.get("type", "text")
     x_val = field.get("x", "")
     y_val = field.get("y", "")
@@ -611,7 +613,8 @@ def _editor_panel(
         var ft = fieldType(k);
         if (typeIn) typeIn.value = ft;
         var labelIn = row.querySelector('.fld-label');
-        if (labelIn && !labelIn._userEdited) labelIn.value = v || k;
+        // Default to the leaf of a 'Category \u203a Field' option, not the whole path.
+        if (labelIn && !labelIn._userEdited) labelIn.value = String(v || k).split('\u203a').pop().trim();
         var fsIn = row.querySelector('.fld-fs');
         if (fsIn) fsIn.style.display = (ft === 'text' || ft === 'barcode_text') ? '' : 'none';  // font size: text + barcode number
         var bhIn = row.querySelector('.fld-bh');
@@ -1060,7 +1063,8 @@ def _printable_label_sheet(
         )
 
     from starlette.responses import HTMLResponse
-    from celerp_labels.service import QR_SIZE_MM, _make_barcode_svg, _make_qr_svg, resolve_field_value
+    from celerp_labels.service import (QR_SIZE_MM, _make_barcode_svg, _make_qr_svg,
+                                       display_label, resolve_field_value)
 
     def _barcode_tag(val: str, module_height: int, wrap_style: str, avail_mm: float) -> str:
         res = _make_barcode_svg(val, module_height=module_height, stretch=True)
@@ -1112,7 +1116,9 @@ def _printable_label_sheet(
         for f in fields:
             key = f.get("key", "")
             ftype = f.get("type", "text")
-            field_label = str(f.get("label", "") or key).strip()
+            # Print the leaf of a "Category > Field" picker path (see display_label):
+            # the repeated category prefix costs about a third of the line on a sticker.
+            field_label = display_label(f.get("label", "") or key)
             val = resolve_field_value(item, key, unit_map)
             if not val:
                 continue

--- a/default_modules/celerp-labels/celerp_labels/ui_routes.py
+++ b/default_modules/celerp-labels/celerp_labels/ui_routes.py
@@ -130,6 +130,11 @@ from .presets import PRESET_TEMPLATES as _PRESET_TEMPLATES
 # on the field still wins.
 BARCODE_TEXT_DEFAULT_PT = 6.0
 
+# The point size a freshly added designer field starts at, so its size box shows the
+# value it will print at rather than sitting blank. Matches the small end of the
+# preset text sizes; the user changes it in place.
+FIELD_DEFAULT_PT = 6
+
 _LABELS_CSS = """
 <style id="labels-css">
 /* -- Settings page: template list (left) + editor (right) -- */
@@ -699,7 +704,7 @@ def _editor_panel(
         '<input type="hidden" name="fields[' + idx + '][type]" value="text" class="fld-type">' +
         '<input type="hidden" name="fields[' + idx + '][x]" value="" class="fld-x">' +
         '<input type="hidden" name="fields[' + idx + '][y]" value="" class="fld-y">' +
-        '<input type="number" name="fields[' + idx + '][fontSize]" value="" class="form-input form-input--sm fld-fs"' +
+        '<input type="number" name="fields[' + idx + '][fontSize]" value="{FIELD_DEFAULT_PT}" class="form-input form-input--sm fld-fs"' +
         ' min="4" max="72" placeholder="Font" title="Text size in points (4-72)"' +
         ' style="width:60px;" oninput="labelEditorUpdatePreview()">' +
         '<input type="number" name="fields[' + idx + '][barcode_height]" value="" class="form-input form-input--sm fld-bh"' +

--- a/default_modules/celerp-labels/celerp_labels/ui_routes.py
+++ b/default_modules/celerp-labels/celerp_labels/ui_routes.py
@@ -78,6 +78,7 @@ _COMMON_FIELDS = [
     ("weight", "Weight", "text"),
     ("pieces", "Pieces", "text"),
     ("unit", "Unit", "text"),
+    ("measurements", "Measurements", "text"),
     ("cost_price", "Cost Price", "text"),
     ("sale_price", "Sale Price", "text"),
     ("description", "Description", "text"),
@@ -108,6 +109,7 @@ _SAMPLE_DATA = {
     "weight": "2.5",
     "pieces": "3",
     "unit": "pcs",
+    "measurements": "6.51 x 6.54 x 4.01",
     "cost_price": "150.00",
     "sale_price": "299.00",
     "retail_price": "299.00",
@@ -1148,7 +1150,7 @@ def _printable_label_sheet(
                 # per-field size still wins.
                 fs_pt = float(fs) if fs not in (None, "") else BARCODE_TEXT_DEFAULT_PT
                 span_style = f' style="font-size:{fs_pt}pt;"'
-                field_lines.append(f'<div class="label-field label-field--barcode-text" style="{pos}"><span class="bc-human"{span_style}>{val}</span></div>')
+                field_lines.append(f'<div class="label-field label-field--barcode-text" style="{pos}"><span class="bc-human"{span_style}>{html_escape(str(val))}</span></div>')
             elif ftype == "qr":
                 field_lines.append(_qr_tag(val, wrap_style=pos))
             else:
@@ -1162,7 +1164,7 @@ def _printable_label_sheet(
                 bold_style = "font-weight:700;" if f.get("bold") else ""
                 display = f"{field_label}: {val}" if field_label else val
                 field_lines.append(
-                    f'<div class="label-field" style="{pos}{fs_style}{bold_style}">{display}</div>')
+                    f'<div class="label-field" style="{pos}{fs_style}{bold_style}">{html_escape(str(display))}</div>')
         label_rows.append(f'<div class="label-item">{"".join(field_lines)}</div>')
 
     html = f"""<!DOCTYPE html>

--- a/default_modules/celerp-labels/celerp_labels/ui_routes.py
+++ b/default_modules/celerp-labels/celerp_labels/ui_routes.py
@@ -122,6 +122,11 @@ _FIELD_TYPE_MAP = {k: t for k, _label, t in _COMMON_FIELDS}
 # Default templates live in presets.py (shared with the API, which seeds them on first read).
 from .presets import PRESET_TEMPLATES as _PRESET_TEMPLATES
 
+# The human-readable barcode number is a fallback for keying the code by hand, so it
+# defaults small and leaves the label's vertical space for actual content. A size set
+# on the field still wins.
+BARCODE_TEXT_DEFAULT_PT = 6.0
+
 _LABELS_CSS = """
 <style id="labels-css">
 /* -- Settings page: template list (left) + editor (right) -- */
@@ -184,6 +189,9 @@ _LABELS_CSS = """
 }
 .label-field-block--barcode img { display: block; width: 100%; height: auto; }
 .label-field-block--barcode .bc-text { font-size: 60%; color: #333; margin-top: 1px; }
+.fld-bold-wrap { display: inline-flex; align-items: center; gap: 3px; font-size: 12px;
+                 color: var(--c-text2); cursor: pointer; user-select: none; }
+.fld-bold-wrap input { margin: 0; cursor: pointer; }
 /* QR preview image block */
 .label-field-block--qr {
   padding: 1px; overflow: visible;
@@ -414,6 +422,14 @@ def _field_row_compact(
             f' min="1" max="30" placeholder="Bar H" title="Barcode bar height (1-30)"'
             f' style="display:{("" if ftype == "barcode" else "none")};width:60px;"'
             f' oninput="labelEditorUpdatePreview()">'
+            # Bold has always been stored on the field and honoured by the renderers;
+            # there was simply no way to set it. An unchecked box submits nothing,
+            # which is exactly what the parser expects.
+            f'<label class="fld-bold-wrap" title="Bold this field"'
+            f' style="display:{("" if ftype in ("text", "barcode_text") else "none")};">'
+            f'<input type="checkbox" name="fields[{idx}][bold]" value="true" class="fld-bold"'
+            f'{" checked" if field.get("bold") else ""}'
+            f' onchange="labelEditorUpdatePreview()"><b>B</b></label>'
         ),
         cls="field-row-compact",
         data_idx=str(idx),
@@ -600,6 +616,8 @@ def _editor_panel(
         if (fsIn) fsIn.style.display = (ft === 'text' || ft === 'barcode_text') ? '' : 'none';  // font size: text + barcode number
         var bhIn = row.querySelector('.fld-bh');
         if (bhIn) bhIn.style.display = ft === 'barcode' ? '' : 'none';
+        var boldIn = row.querySelector('.fld-bold-wrap');
+        if (boldIn) boldIn.style.display = (ft === 'text' || ft === 'barcode_text') ? '' : 'none';
       }}
       closeDropdown();
       labelEditorUpdatePreview();
@@ -677,7 +695,10 @@ def _editor_panel(
         ' style="width:60px;" oninput="labelEditorUpdatePreview()">' +
         '<input type="number" name="fields[' + idx + '][barcode_height]" value="" class="form-input form-input--sm fld-bh"' +
         ' min="1" max="30" placeholder="Bar H" title="Barcode bar height (1-30)"' +
-        ' style="display:none;width:60px;" oninput="labelEditorUpdatePreview()">';
+        ' style="display:none;width:60px;" oninput="labelEditorUpdatePreview()">' +
+        '<label class="fld-bold-wrap" title="Bold this field">' +
+        '<input type="checkbox" name="fields[' + idx + '][bold]" value="true" class="fld-bold"' +
+        ' onchange="labelEditorUpdatePreview()"><b>B</b></label>';
       list.appendChild(row);
       initSearchableSelect(row.querySelector('.searchable-select'), addFieldGroups);
       labelEditorUpdatePreview();
@@ -818,6 +839,13 @@ def _editor_panel(
         block.className = 'label-field-block';
         // Show "label: value" for text fields so fields are distinguishable
         block.textContent = fieldLabel ? (fieldLabel + ': ' + sample) : sample;
+      }}
+
+      // Bold applies to text and the barcode number, and must show in the preview
+      // so what the designer shows is what the printer produces.
+      var boldEl = row.querySelector('.fld-bold');
+      if (boldEl && (ftype === 'text' || ftype === 'barcode_text')) {{
+        block.style.fontWeight = boldEl.checked ? '700' : '';
       }}
 
       setupBlockDrag(block, i, dims.scale);
@@ -1060,7 +1088,22 @@ def _printable_label_sheet(
         return f'<div class="label-field label-field--qr" style="{qr_style}">{safe_val}</div>'
 
     # Auto-stack step (mm) per field type — only for legacy fields that carry no x/y.
-    _auto_step_mm = {"text": 4.0, "barcode_text": 4.0, "barcode": 8.0, "qr": 11.0}
+    # Auto-stack step (mm) per field type — only for legacy fields that carry no x/y.
+    # Text steps with its own size instead of a flat 4mm: at 6pt a line is ~2.1mm tall,
+    # so a fixed 4mm was nearly double leading and burned the vertical space a dense
+    # label needs. Barcode/QR keep fixed steps (they are sized in mm, not points).
+    _PT_MM = 25.4 / 72.0            # 1pt in mm
+    _AUTO_LEAD = 1.25               # same leading multiplier the PDF renderer uses
+
+    def _auto_step(ftype: str, fs) -> float:
+        if ftype == "barcode":
+            return 8.0
+        if ftype == "qr":
+            return 11.0
+        pt = float(fs) if fs not in (None, "") else 7.0
+        if ftype == "barcode_text" and fs in (None, ""):
+            pt = BARCODE_TEXT_DEFAULT_PT
+        return max(1.6, pt * _PT_MM * _AUTO_LEAD)
 
     label_rows = []
     for item in items:
@@ -1081,14 +1124,20 @@ def _printable_label_sheet(
                 left_mm, top_mm = float(x), float(y)
             else:
                 left_mm, top_mm = 2.0, auto_y
-                auto_y += _auto_step_mm.get(ftype, 4.0)
+                auto_y += _auto_step(ftype, f.get("fontSize"))
             pos = f"left:{left_mm}mm;top:{top_mm}mm;"
             if ftype == "barcode":
                 bc_height = int(f.get("barcode_height") or 8)
                 field_lines.append(_barcode_tag(val, bc_height, pos, avail_mm=w_mm - left_mm - 2.0))
             elif ftype == "barcode_text":
                 fs = f.get("fontSize")
-                span_style = f' style="font-size:{float(fs)}pt;"' if fs not in (None, "") else ""
+                # The human-readable number is a caption, not body copy: it exists so a
+                # human can key the code when a scanner fails. Inheriting the label's
+                # default size made it as large as the data lines and ate the vertical
+                # space the label needs for actual content. Default small; an explicit
+                # per-field size still wins.
+                fs_pt = float(fs) if fs not in (None, "") else BARCODE_TEXT_DEFAULT_PT
+                span_style = f' style="font-size:{fs_pt}pt;"'
                 field_lines.append(f'<div class="label-field label-field--barcode-text" style="{pos}"><span class="bc-human"{span_style}>{val}</span></div>')
             elif ftype == "qr":
                 field_lines.append(_qr_tag(val, wrap_style=pos))

--- a/default_modules/celerp-labels/celerp_labels/ui_routes.py
+++ b/default_modules/celerp-labels/celerp_labels/ui_routes.py
@@ -176,9 +176,13 @@ _LABELS_CSS = """
   min-height: 80px;
 }
 .label-field-block {
-  position: absolute; font-size: 9px; line-height: 1.2;
+  /* A field block must occupy exactly the text it prints. A border and vertical
+     padding make the block taller than its own line, so fields get dragged apart
+     to stop them looking overlapped - and those inflated positions are what gets
+     saved and printed. outline draws the dashed guide without taking up space. */
+  position: absolute; font-size: 9px; line-height: 1;
   white-space: nowrap; overflow: hidden; color: #111;
-  border: 1px dashed rgba(0,0,0,0.25); padding: 1px 3px;
+  outline: 1px dashed rgba(0,0,0,0.25); padding: 0 1px;
   background: rgba(255,255,255,0.9); cursor: move;
   user-select: none; box-sizing: border-box;
 }
@@ -186,7 +190,7 @@ _LABELS_CSS = """
 /* Barcode preview image block */
 .label-field-block--barcode {
   display: flex; flex-direction: column; align-items: flex-start;
-  white-space: normal; padding: 1px 2px;
+  white-space: normal; padding: 0;
 }
 .label-field-block--barcode img { display: block; width: 100%; height: auto; }
 .label-field-block--barcode .bc-text { font-size: 60%; color: #333; margin-top: 1px; }
@@ -195,7 +199,7 @@ _LABELS_CSS = """
 .fld-bold-wrap input { margin: 0; cursor: pointer; }
 /* QR preview image block */
 .label-field-block--qr {
-  padding: 1px; overflow: visible;
+  padding: 0; overflow: visible;
 }
 .label-field-block--qr img { display: block; width: 100%; height: 100%; }
 

--- a/default_modules/celerp-labels/celerp_labels/ui_routes.py
+++ b/default_modules/celerp-labels/celerp_labels/ui_routes.py
@@ -122,6 +122,7 @@ _SAMPLE_DATA = {
 _FIELD_TYPE_MAP = {k: t for k, _label, t in _COMMON_FIELDS}
 
 # Default templates live in presets.py (shared with the API, which seeds them on first read).
+from .service import BARCODE_HEIGHT_DEFAULT
 from .service import display_label as _svc_display_label
 from .presets import PRESET_TEMPLATES as _PRESET_TEMPLATES
 
@@ -707,7 +708,7 @@ def _editor_panel(
         '<input type="number" name="fields[' + idx + '][fontSize]" value="{FIELD_DEFAULT_PT}" class="form-input form-input--sm fld-fs"' +
         ' min="4" max="72" placeholder="Font" title="Text size in points (4-72)"' +
         ' style="width:60px;" oninput="labelEditorUpdatePreview()">' +
-        '<input type="number" name="fields[' + idx + '][barcode_height]" value="" class="form-input form-input--sm fld-bh"' +
+        '<input type="number" name="fields[' + idx + '][barcode_height]" value="{BARCODE_HEIGHT_DEFAULT}" class="form-input form-input--sm fld-bh"' +
         ' min="1" max="30" placeholder="Bar H" title="Barcode bar height (1-30)"' +
         ' style="display:none;width:60px;" oninput="labelEditorUpdatePreview()">' +
         '<label class="fld-bold-wrap" title="Bold this field">' +
@@ -1144,7 +1145,7 @@ def _printable_label_sheet(
                 auto_y += _auto_step(ftype, f.get("fontSize"))
             pos = f"left:{left_mm}mm;top:{top_mm}mm;"
             if ftype == "barcode":
-                bc_height = int(f.get("barcode_height") or 8)
+                bc_height = int(f.get("barcode_height") or BARCODE_HEIGHT_DEFAULT)
                 field_lines.append(_barcode_tag(val, bc_height, pos, avail_mm=w_mm - left_mm - 2.0))
             elif ftype == "barcode_text":
                 fs = f.get("fontSize")

--- a/default_modules/celerp-labels/celerp_labels/ui_routes.py
+++ b/default_modules/celerp-labels/celerp_labels/ui_routes.py
@@ -1097,8 +1097,13 @@ def _printable_label_sheet(
                 # label-item default applies, so existing labels look exactly as before.
                 fs = f.get("fontSize")
                 fs_style = f"font-size:{float(fs)}pt;" if fs not in (None, "") else ""
+                # The field model and the PDF renderer have always honoured `bold`;
+                # the printed sheet dropped it, so a field marked bold in the designer
+                # still printed regular. Emit it here too.
+                bold_style = "font-weight:700;" if f.get("bold") else ""
                 display = f"{field_label}: {val}" if field_label else val
-                field_lines.append(f'<div class="label-field" style="{pos}{fs_style}">{display}</div>')
+                field_lines.append(
+                    f'<div class="label-field" style="{pos}{fs_style}{bold_style}">{display}</div>')
         label_rows.append(f'<div class="label-item">{"".join(field_lines)}</div>')
 
     html = f"""<!DOCTYPE html>

--- a/default_modules/celerp-labels/tests/test_labels.py
+++ b/default_modules/celerp-labels/tests/test_labels.py
@@ -1110,6 +1110,16 @@ def test_new_field_seeds_default_font_size():
     assert f'[fontSize]" value="{FIELD_DEFAULT_PT}" class="form-input form-input--sm fld-fs"' in html
 
 
+def test_new_field_seeds_default_barcode_height():
+    """A field added in the designer carries the default bar height in its box, so a
+    barcode field shows the height it will print at rather than blank."""
+    from fasthtml.common import to_xml
+    from celerp_labels.ui_routes import _editor_panel
+    from celerp_labels.service import BARCODE_HEIGHT_DEFAULT
+    html = to_xml(_editor_panel({"id": "t1", "name": "T", "fields": []}))
+    assert f'[barcode_height]" value="{BARCODE_HEIGHT_DEFAULT}" class="form-input form-input--sm fld-bh"' in html
+
+
 def test_measurements_in_field_picker():
     """The searchable field select offers one Measurements option (builtin group)."""
     import json

--- a/default_modules/celerp-labels/tests/test_labels.py
+++ b/default_modules/celerp-labels/tests/test_labels.py
@@ -985,3 +985,47 @@ async def test_print_pdf_contains_derived_weight_for_carat_item(client: AsyncCli
     assert b"38.60 carat" in decoded, (
         "derived weight (quantity + sell unit) must appear on the printed label"
     )
+
+
+# ── printer dot-grid alignment + leading ─────────────────────────────────────
+
+def test_barcode_geometry_lands_on_the_printer_dot_grid():
+    """Thermal printers are dot-addressed: an edge between dots gets rounded, so a
+    nominally uniform X-dimension prints as a mix of 3- and 4-dot bars. Every bar
+    edge must sit on a whole dot at the target DPI (203 and 300 both matter)."""
+    import re
+    from celerp_labels import service as svc
+
+    for dpi in (203, 300):
+        out = svc._make_barcode_svg("356884", module_height=10, dpi=dpi)
+        if out is None:
+            return  # barcode lib absent in this environment
+        svg, _w, _h = out
+        dot = svc.dot_mm(dpi)
+        pairs = re.findall(r'<rect x="([\d.]+)" y="0" width="([\d.]+)"', svg)
+        assert pairs, "no bars rendered"
+        edges = [float(x) for x, _ in pairs] + [float(x) + float(w) for x, w in pairs]
+        # tolerance 0.02 dots: catches the half-dot (0.5) error a symmetric shave
+        # would reintroduce, while ignoring 4-decimal string rounding (~0.0008).
+        off = [e for e in edges if abs(e / dot - round(e / dot)) > 0.02]
+        assert not off, f"{dpi}dpi: {len(off)} bar edges off the dot grid: {off[:4]}"
+
+
+def test_x_dimension_snaps_to_whole_dots():
+    from celerp_labels import service as svc
+
+    for dpi in (203, 300):
+        dot = svc.dot_mm(dpi)
+        mod = svc.snap_to_dots(svc._BC_MODULE_MM, dpi, minimum_dots=svc._BC_MIN_MODULE_DOTS)
+        assert abs(mod / dot - round(mod / dot)) < 1e-9
+        assert mod / dot >= svc._BC_MIN_MODULE_DOTS
+
+
+def test_pdf_leading_is_in_points_not_millimetres():
+    """Leading is a multiple of the point-sized font; multiplying by `mm` as well
+    inflated every line by 2.83x and pushed fields down the label."""
+    from celerp_labels import service as svc
+
+    assert 1.0 < svc._LINE_SPACING < 2.0, "leading multiplier should be ~1.25"
+    # A 6pt font must occupy roughly 7-8pt of line, not ~24pt.
+    assert 6 * svc._LINE_SPACING < 10

--- a/default_modules/celerp-labels/tests/test_labels.py
+++ b/default_modules/celerp-labels/tests/test_labels.py
@@ -1101,6 +1101,15 @@ def test_measurements_sample_preview():
     assert _SAMPLE_DATA.get("measurements") == "6.51 x 6.54 x 4.01"
 
 
+def test_new_field_seeds_default_font_size():
+    """A field added in the designer starts at the default point size, so its size
+    box shows what it will print at instead of sitting blank."""
+    from fasthtml.common import to_xml
+    from celerp_labels.ui_routes import _editor_panel, FIELD_DEFAULT_PT
+    html = to_xml(_editor_panel({"id": "t1", "name": "T", "fields": []}))
+    assert f'[fontSize]" value="{FIELD_DEFAULT_PT}" class="form-input form-input--sm fld-fs"' in html
+
+
 def test_measurements_in_field_picker():
     """The searchable field select offers one Measurements option (builtin group)."""
     import json

--- a/default_modules/celerp-labels/tests/test_labels.py
+++ b/default_modules/celerp-labels/tests/test_labels.py
@@ -630,7 +630,9 @@ def test_barcode_text_type_renders_number_only():
     item = {"sku": "TEST123", "name": "Test"}
     template = {"fields": [{"key": "sku", "type": "barcode_text", "label": "SKU"}]}
     html = _printable_label_sheet([item], template).body.decode()
-    assert '<span class="bc-human">TEST123</span>' in html
+    # The caption span carries a small default size (a scanner fallback, not body copy).
+    assert 'class="bc-human"' in html
+    assert '>TEST123</span>' in html
     # No barcode image for text-only field
     assert "label-field--barcode\"" not in html
 
@@ -647,7 +649,7 @@ def test_barcode_and_barcode_text_together():
     html = _printable_label_sheet([item], template).body.decode()
     assert "label-field--barcode\"" in html          # bars rendered
     assert "label-field--barcode-text" in html        # number rendered separately
-    assert '<span class="bc-human">9876543210</span>' in html
+    assert '>9876543210</span>' in html
 
 
 def test_extract_fields_barcode_text_type_preserved():

--- a/default_modules/celerp-labels/tests/test_labels.py
+++ b/default_modules/celerp-labels/tests/test_labels.py
@@ -966,13 +966,18 @@ async def test_print_pdf_contains_derived_weight_for_carat_item(client: AsyncCli
     assert r_pdf.status_code == 200
     assert r_pdf.content[:4] == b"%PDF"
 
-    # reportlab encodes content streams as ASCII85 + Flate; unwrap both to
-    # reach the drawn text.
+    assert b"38.60 carat" in _pdf_text(r_pdf.content), (
+        "derived weight (quantity + sell unit) must appear on the printed label"
+    )
+
+
+def _pdf_text(pdf_bytes: bytes) -> bytes:
+    """Unwrap PDF content streams (ASCII85 + Flate as reportlab encodes them)."""
     import base64
     import re
     import zlib
     decoded = b""
-    for stream in re.findall(rb"stream\r?\n(.*?)endstream", r_pdf.content, re.DOTALL):
+    for stream in re.findall(rb"stream\r?\n(.*?)endstream", pdf_bytes, re.DOTALL):
         raw = stream.strip(b"\r\n")
         try:
             raw = base64.a85decode(raw, adobe=True)
@@ -982,9 +987,7 @@ async def test_print_pdf_contains_derived_weight_for_carat_item(client: AsyncCli
             decoded += zlib.decompress(raw)
         except zlib.error:
             decoded += raw
-    assert b"38.60 carat" in decoded, (
-        "derived weight (quantity + sell unit) must appear on the printed label"
-    )
+    return decoded
 
 
 # ── printer dot-grid alignment + leading ─────────────────────────────────────
@@ -1043,3 +1046,119 @@ def test_printed_label_drops_the_category_picker_prefix():
     # plain labels and empties are untouched
     assert display_label("SKU") == "SKU"
     assert display_label("") == ""
+
+
+# ── Condensed Measurements field ───────────────────────────────────────────────
+
+def test_measurements_field_in_common_fields():
+    """"measurements" is a built-in text field in the designer picker list."""
+    from celerp_labels.ui_routes import _COMMON_FIELDS
+    assert ("measurements", "Measurements", "text") in _COMMON_FIELDS
+
+
+def test_resolve_measurements_prefers_stored_value():
+    """A stored measurements attribute wins over composing from dimensions."""
+    from celerp.services.units import DEFAULT_UNITS, build_unit_map
+    from celerp_labels.service import resolve_field_value
+    unit_map = build_unit_map(DEFAULT_UNITS)
+    item = {
+        "name": "Gem",
+        "attributes": {"measurements": "7.10 x 7.05 x 4.30", "length": "1", "width": "2", "height": "3"},
+    }
+    assert resolve_field_value(item, "measurements", unit_map) == "7.10 x 7.05 x 4.30"
+
+
+def test_resolve_measurements_composes_from_dimensions():
+    """No stored measurements: length, width, height compose as "L x W x H"."""
+    from celerp.services.units import DEFAULT_UNITS, build_unit_map
+    from celerp_labels.service import resolve_field_value
+    unit_map = build_unit_map(DEFAULT_UNITS)
+    item = {"name": "Gem", "attributes": {"length": "6.51", "width": "6.54", "height": "4.01"}}
+    assert resolve_field_value(item, "measurements", unit_map) == "6.51 x 6.54 x 4.01"
+
+
+def test_resolve_measurements_missing_dimension_yields_empty():
+    """Any missing dimension yields "", never a partial string like "6.5 x  x 4.0"."""
+    from celerp.services.units import DEFAULT_UNITS, build_unit_map
+    from celerp_labels.service import resolve_field_value
+    unit_map = build_unit_map(DEFAULT_UNITS)
+    for attrs in (
+        {"length": "6.51", "width": "6.54"},
+        {"length": "6.51", "height": "4.01"},
+        {"width": "6.54", "height": "4.01"},
+        {"length": "6.51", "width": "", "height": "4.01"},
+        {},
+    ):
+        item = {"name": "Gem", "attributes": attrs}
+        assert resolve_field_value(item, "measurements", unit_map) == "", attrs
+
+
+def test_measurements_sample_preview():
+    """The editor preview sample data carries a realistic condensed value."""
+    from celerp_labels.ui_routes import _SAMPLE_DATA
+    assert _SAMPLE_DATA.get("measurements") == "6.51 x 6.54 x 4.01"
+
+
+def test_measurements_in_field_picker():
+    """The searchable field select offers one Measurements option (builtin group)."""
+    import json
+    from celerp_labels.ui_routes import _build_field_options_js
+    groups = json.loads(_build_field_options_js("", None, None))
+    builtin = groups[0]["options"]
+    assert {"k": "measurements", "v": "Measurements"} in builtin
+
+
+def test_measurements_pdf_render():
+    """The PDF render path prints the composed measurements string."""
+    from celerp_labels.service import render_label_pdf
+    template = {"name": "T", "fields": [{"key": "measurements", "label": "Measurements", "type": "text"}]}
+    item = {"name": "Gem", "attributes": {"length": "6.51", "width": "6.54", "height": "4.01"}}
+    pdf = render_label_pdf([item], template)
+    assert pdf[:4] == b"%PDF"
+    assert b"6.51 x 6.54 x 4.01" in _pdf_text(pdf)
+
+
+def test_measurements_text_fallback_render():
+    """render_label_text (no-reportlab fallback) shows the same composed value."""
+    from celerp_labels.service import render_label_text
+    template = {"name": "T", "fields": [{"key": "measurements", "label": "Measurements", "type": "text"}]}
+    item = {"name": "Gem", "attributes": {"length": "6.51", "width": "6.54", "height": "4.01"}}
+    assert "Measurements: 6.51 x 6.54 x 4.01" in render_label_text([item], template)
+
+
+def test_attribute_discovery_skips_builtin_measurements():
+    """Attribute discovery seeds dedup from builtin keys, so a discovered
+    "measurements" attribute never produces a duplicate picker entry."""
+    from celerp_labels.ui_routes import _COMMON_FIELDS
+    builtin_keys = {k for k, _, _ in _COMMON_FIELDS}
+    assert "measurements" in builtin_keys
+
+
+def test_existing_attribute_fields_unchanged():
+    """Templates using separate length/width/height fields resolve as before."""
+    from celerp_labels.service import render_label_text
+    template = {"name": "T", "fields": [
+        {"key": "length", "label": "Length", "type": "text"},
+        {"key": "width", "label": "Width", "type": "text"},
+        {"key": "height", "label": "Height", "type": "text"},
+    ]}
+    item = {"name": "Gem", "attributes": {"length": "6.51", "width": "6.54", "height": "4.01"}}
+    text = render_label_text([item], template)
+    assert "Length: 6.51" in text
+    assert "Width: 6.54" in text
+    assert "Height: 4.01" in text
+
+
+def test_printable_label_sheet_escapes_values():
+    """Free-text item values render HTML-escaped in the printable sheet."""
+    from celerp_labels.ui_routes import _printable_label_sheet
+    template = {"name": "T", "format": "40x30mm", "fields": [
+        {"key": "name", "label": "", "type": "text"},
+        {"key": "barcode_text", "type": "barcode_text"},
+    ]}
+    item = {"name": "<script>alert(1)</script>", "barcode": "<b>123</b>"}
+    html = _printable_label_sheet([item], template).body.decode()
+    assert "<script>alert(1)</script>" not in html
+    assert "&lt;script&gt;alert(1)&lt;/script&gt;" in html
+    assert "<b>123</b>" not in html
+    assert "&lt;b&gt;123&lt;/b&gt;" in html

--- a/default_modules/celerp-labels/tests/test_labels.py
+++ b/default_modules/celerp-labels/tests/test_labels.py
@@ -1029,3 +1029,17 @@ def test_pdf_leading_is_in_points_not_millimetres():
     assert 1.0 < svc._LINE_SPACING < 2.0, "leading multiplier should be ~1.25"
     # A 6pt font must occupy roughly 7-8pt of line, not ~24pt.
     assert 6 * svc._LINE_SPACING < 10
+
+
+def test_printed_label_drops_the_category_picker_prefix():
+    """The picker lists category attributes as "Stones › Origin" so they can be told
+    apart while choosing; printing that whole path wastes about a third of the line
+    on a sticker. Applied at render time so labels saved earlier shorten too."""
+    from celerp_labels.service import display_label
+
+    assert display_label("Stones › Origin") == "Origin"
+    assert display_label("Stones › Treatment") == "Treatment"
+    assert display_label("A › B › C") == "C"
+    # plain labels and empties are untouched
+    assert display_label("SKU") == "SKU"
+    assert display_label("") == ""

--- a/ui/routes/documents.py
+++ b/ui/routes/documents.py
@@ -5933,22 +5933,32 @@ def _doc_detail(doc: dict, locations: list | None = None, ledger: list | None = 
             # The visible line under the SKU input exists only when barcodes are shown.
             barcode_display = (
                 Div(barcode, cls="li-ident-2nd", data_name="barcode_display",
+                    title=barcode,
                     style="" if barcode else "display:none")
                 if line_identifier_mode != "sku" else None
             )
+            # The barcode sits BELOW the input row, never inside it. As a flex item
+            # of .catalog-ac-wrap it had to share a 70px column with the eye and the
+            # SKU box, which squeezed it to 1-2 digits + an ellipsis (#234). The
+            # finalized view already stacks it as a block on its own full-width line;
+            # the editable view now matches, so the "barcode is never truncated"
+            # invariant (line_measures.line_identifier) holds in every renderer.
             return Div(
-                eye,
-                Input(type="text", value=val, data_name="sku", placeholder="SKU...",
-                      cls="cell-input cell-input--sm catalog-ac-input",
-                      autocomplete="off",
-                      title="Type to search catalog or enter custom description",
-                      oninput="celerpAcSearch(this,'sku')",
-                      onblur="celerpAcBlur(this)",
-                      onkeydown="celerpAcKey(event,this)"),
-                Div(cls="catalog-ac-list", style="display:none"),
-                Input(type="hidden", value=barcode, data_name="barcode"),
+                Div(
+                    eye,
+                    Input(type="text", value=val, data_name="sku", placeholder="SKU...",
+                          cls="cell-input cell-input--sm catalog-ac-input",
+                          autocomplete="off",
+                          title="Type to search catalog or enter custom description",
+                          oninput="celerpAcSearch(this,'sku')",
+                          onblur="celerpAcBlur(this)",
+                          onkeydown="celerpAcKey(event,this)"),
+                    Div(cls="catalog-ac-list", style="display:none"),
+                    Input(type="hidden", value=barcode, data_name="barcode"),
+                    cls="catalog-ac-wrap",
+                ),
                 barcode_display,
-                cls="catalog-ac-wrap",
+                cls="li-ident-edit",
             )
 
         def _desc_input(val: str = "") -> FT:

--- a/ui/static/app.css
+++ b/ui/static/app.css
@@ -1754,6 +1754,11 @@ option.unit-unknown-option { color: var(--c-red, #ef4444); font-style: italic; }
 .data-table th.cell--number { text-align: right !important; }
 /* col-total header alignment: right-aligned (consolidated in doc-lines block above) */
 .catalog-ac-wrap { position: relative; display: flex; align-items: center; gap: 4px; }
+/* Editable line identifier: the SKU input row, with the barcode stacked BELOW it on
+   its own full-width line — the same shape the finalized view uses. Keeping the
+   barcode out of the flex row is what stops it being squeezed to 1-2 digits (#234). */
+.li-ident-edit { display: block; min-width: 0; }
+.li-ident-edit .li-ident-2nd { display: block; width: 100%; }
 .item-link { font-size: 12px; text-decoration: none; cursor: pointer; flex-shrink: 0; line-height: 1; }
 .item-link--active { color: var(--c-accent); }
 .item-link--active:hover { opacity: 0.7; }


### PR DESCRIPTION
Sharpens the label print output and the barcodes it produces, and adds a condensed Measurements field to the designer.

## Barcodes

- Snap the X-dimension, bar-width reduction, and quiet zone to whole printer dots, so a uniform module no longer rounds into a mix of 3- and 4-dot bars. One resolution-independent vector stays exact on both 300dpi and 203dpi hardware.
- Widen the module to 0.33mm. At 0.2mm the grid snap landed on 2 dots, thinner than intended and below a comfortable scan width once thermal ink spreads; 0.33mm snaps to a clean 4 dots at 300dpi and 3 at 203dpi.
- On the editable Pro Forma line the barcode was squeezed into the narrow identifier column and truncated to one or two digits. It now sits on its own full-width line, the same way the finalized view already renders it, and carries the full value. A barcode is never truncated by any renderer.

## Label designer and print output

- Add a bold toggle for text and barcode-number fields, shown live in the preview. The flag was already honored by both renderers but had no control to set it, and the printable sheet dropped it entirely.
- The PDF now uses the field's own bar height instead of always fitting the bars to a quarter of the label, so a taller barcode set in the designer prints taller.
- The barcode number is a fallback for keying a code by hand, not body copy, so it defaults to 6pt instead of inheriting the label's larger size; a size set on the field still wins.
- Fix the leading: line height was multiplying the point font size by a millimetre constant, inflating every line by 2.83x and pushing fields down the label. Points only now, at a 1.25 multiplier, matching the designer preview. Legacy fields with no coordinates step by their font size at the same multiplier rather than a flat 4mm.
- Remove the vertical padding and border from the designer field block that made each block taller than the line it represented and dragged fields apart. A dashed outline draws the same guide without occupying space.
- Print the leaf of a category attribute, not the whole picker path. The picker shows "Stones > Origin" to tell same-named fields apart, but printing that path wastes about a third of a 25mm line. Applied at render time, so templates saved earlier shorten on the next print.

## Measurements field

- Add a built-in Measurements field to the designer, matching the inventory column format. A stored measurements attribute prints verbatim; otherwise length, width, and height compose into a single "l x w x h" line when all three are present, so a partial join never reads as a complete measurement of a different shape.
- Free-text values on the printable sheet are now HTML-escaped.
