### PR TITLE
Restore Python 3.10 support declared in packaging

### DIFF
--- a/celerp/compat.py
+++ b/celerp/compat.py
@@ -1,0 +1,26 @@
+# Copyright (c) 2026 Noah Severs
+# SPDX-License-Identifier: BUSL-1.1
+"""Standard-library shims for the supported interpreter floor.
+
+pyproject sets ``requires-python >= 3.10``, but a handful of names the codebase
+relies on landed in 3.11. Import them from here so the floor is held in one
+place rather than re-implemented at each use site.
+"""
+from __future__ import annotations
+
+import sys
+
+if sys.version_info >= (3, 11):
+    from enum import StrEnum
+else:  # Python 3.10: enum.StrEnum arrived in 3.11.
+    from enum import Enum
+
+    class StrEnum(str, Enum):
+        """Backport of enum.StrEnum for 3.10: members are real ``str``, and
+        ``str(member)`` yields the member value (not ``'Class.MEMBER'``), which
+        is the behaviour 3.11+ code depends on."""
+
+        __str__ = str.__str__
+
+
+__all__ = ["StrEnum"]

--- a/celerp/events/types.py
+++ b/celerp/events/types.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2026 Noah Severs
 # SPDX-License-Identifier: BUSL-1.1
 
-from enum import StrEnum
+from celerp.compat import StrEnum
 
 
 class EventType(StrEnum):

--- a/celerp/importers/schema.py
+++ b/celerp/importers/schema.py
@@ -18,10 +18,11 @@ from __future__ import annotations
 
 from datetime import date, datetime
 from decimal import Decimal
-from enum import StrEnum
 from typing import Any, Literal
 
 from pydantic import BaseModel, Field, field_validator, model_validator
+
+from celerp.compat import StrEnum
 
 
 CIF_VERSION = "1"

--- a/celerp/services/fulfill.py
+++ b/celerp/services/fulfill.py
@@ -10,7 +10,7 @@ and by the fulfillment module's toggle/pick screen.
 from __future__ import annotations
 
 import uuid as _uuid
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 from typing import Any
 
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -47,7 +47,7 @@ async def execute_fulfill(
 
     Returns: {fulfillment_status, fulfilled_items, total_cogs}
     """
-    now = datetime.now(UTC).isoformat()
+    now = datetime.now(timezone.utc).isoformat()
     fulfilled_items: list[dict] = []
     total_cogs = 0.0
     cid = _to_uuid(company_id)

--- a/conftest.py
+++ b/conftest.py
@@ -573,8 +573,25 @@ async def client(session: AsyncSession):
     # The concurrent login gate is bypassed in tests because the tracker is
     # cleared at setup/teardown, so each test starts with an empty registry.
     app.dependency_overrides[get_session] = lambda: session
+
+    # Middleware (DrainMiddleware, SlidingTokenRefreshMiddleware) opens its own
+    # session via get_session_ctx() rather than the injected request session. Each
+    # test runs inside one uncommitted outer transaction on a single connection
+    # (the `session` fixture), so a middleware session on a *separate* connection
+    # blocks on that transaction's row locks - e.g. DrainMiddleware's _get_or_create
+    # INSERT of the SystemRuntimeState singleton the request session is already
+    # holding uncommitted - and hangs until the per-test timeout. Route middleware
+    # to the same shared session (the patch point middleware.py imports for this
+    # purpose) so it joins the one transaction instead of deadlocking against it.
+    from contextlib import asynccontextmanager
+
+    @asynccontextmanager
+    async def _shared_session_ctx():
+        yield session
+
     with patch("celerp.gateway.client._client", MagicMock()), \
-         patch("celerp.gateway.state.get_session_token", return_value="test-session-token"):
+         patch("celerp.gateway.state.get_session_token", return_value="test-session-token"), \
+         patch("celerp.middleware.get_session_ctx", _shared_session_ctx):
         async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
             yield c
     app.dependency_overrides.clear()

--- a/default_modules/celerp-dashboard/celerp_dashboard/routes.py
+++ b/default_modules/celerp-dashboard/celerp_dashboard/routes.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-from datetime import UTC, datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from fastapi import APIRouter, Depends, Query
 from sqlalchemy import select
@@ -29,7 +29,7 @@ async def get_kpis(company_id=Depends(get_current_company_id), role: str = Depen
     deals = [r for r in rows if r.entity_type == "deal"]
     subscriptions = [r for r in rows if r.entity_type == "doc" and r.state.get("doc_type") in {"subscription_invoice", "subscription_po"}]
 
-    now = datetime.now(UTC).date().isoformat()
+    now = datetime.now(timezone.utc).date().isoformat()
     month_prefix = now[:7]  # "YYYY-MM"
     year_prefix = now[:4]   # "YYYY"
 
@@ -155,13 +155,13 @@ async def search_activity(
 
     if date_from:
         try:
-            dt_from = datetime.fromisoformat(date_from).replace(tzinfo=UTC)
+            dt_from = datetime.fromisoformat(date_from).replace(tzinfo=timezone.utc)
             stmt = stmt.where(LedgerEntry.ts >= dt_from)
         except ValueError:
             pass
     if date_to:
         try:
-            dt_to = datetime.fromisoformat(date_to).replace(tzinfo=UTC)
+            dt_to = datetime.fromisoformat(date_to).replace(tzinfo=timezone.utc)
             # Advance by one day so a date-only value includes the full chosen day.
             if "T" not in date_to and " " not in date_to:
                 dt_to += timedelta(days=1)

--- a/default_modules/celerp-docs/celerp_docs/routes.py
+++ b/default_modules/celerp-docs/celerp_docs/routes.py
@@ -7,7 +7,7 @@ import asyncio
 import csv
 import io
 import uuid
-from datetime import UTC, datetime, date as _date
+from datetime import datetime, timezone, date as _date
 
 from fastapi import APIRouter, Depends, Form, HTTPException, Query, UploadFile
 from fastapi.responses import StreamingResponse
@@ -1927,7 +1927,7 @@ async def apply_cn_to_invoice(entity_id: str, payload: ApplyToInvoiceBody, compa
     if payload.amount > inv_outstanding + 1e-9:
         raise HTTPException(status_code=409, detail="Amount exceeds invoice outstanding")
 
-    payment_date = payload.date or datetime.now(UTC).date().isoformat()
+    payment_date = payload.date or datetime.now(timezone.utc).date().isoformat()
 
     # Both docs are locked (sorted order, so two concurrent applications can
     # never deadlock) while indices are allocated and the events land: a
@@ -2389,7 +2389,7 @@ async def receive_po(entity_id: str, payload: ReceiveBody, company_id: str = Dep
             total=po_total,
             unique_suffix=str(uuid.uuid4()),
             base_currency=_rcv_base_currency,
-            receive_date=datetime.now(UTC).date().isoformat(),
+            receive_date=datetime.now(timezone.utc).date().isoformat(),
         )
     elif doc_type == "bill" and landed_drawdown:
         # A bill already recognised goods + AP at finalize (create_for_bill_conversion); receiving must
@@ -2398,7 +2398,7 @@ async def receive_po(entity_id: str, payload: ReceiveBody, company_id: str = Dep
         await auto_je.create_for_landed_capitalisation(
             session, company_id=company_id, user_id=user.id, doc_id=entity_id,
             landed_by_kind=landed_drawdown, receive_suffix=str(uuid.uuid4()),
-            receive_date=datetime.now(UTC).date().isoformat(),
+            receive_date=datetime.now(timezone.utc).date().isoformat(),
         )
     # consignment_in: no JE (goods not owned).
     await session.commit()
@@ -2568,7 +2568,7 @@ async def convert_doc(entity_id: str, company_id: str = Depends(get_current_comp
         if state.get("status") in {"void", "converted"}:
             raise HTTPException(status_code=409, detail="Cannot convert quotation in current status")
         valid_until = state.get("valid_until")
-        if valid_until and valid_until < datetime.now(UTC).date().isoformat():
+        if valid_until and valid_until < datetime.now(timezone.utc).date().isoformat():
             raise HTTPException(status_code=409, detail="Cannot convert expired quotation")
         company = await session.get(Company, company_id)
         ref = next_doc_ref(company, "invoice")
@@ -2727,7 +2727,7 @@ async def add_doc_note(
             "note": payload.note.strip(),
             "author_id": str(user.id),
             "author_name": getattr(user, "name", None) or user.email,
-            "created_at": datetime.now(UTC).isoformat(),
+            "created_at": datetime.now(timezone.utc).isoformat(),
         },
         actor_id=user.id, location_id=None, source="api",
         idempotency_key=payload.idempotency_key or str(uuid.uuid4()), metadata_={},
@@ -2753,7 +2753,7 @@ async def update_doc_note(
     entry = await emit_event(
         session, company_id=company_id, entity_id=note_id, entity_type="doc_note",
         event_type="doc.note_updated",
-        data={"doc_id": entity_id, "note_id": note_id, "note": payload.note.strip(), "updated_at": datetime.now(UTC).isoformat()},
+        data={"doc_id": entity_id, "note_id": note_id, "note": payload.note.strip(), "updated_at": datetime.now(timezone.utc).isoformat()},
         actor_id=user.id, location_id=None, source="api",
         idempotency_key=payload.idempotency_key or str(uuid.uuid4()), metadata_={},
     )
@@ -3303,7 +3303,7 @@ async def finalize_list(
         raise HTTPException(status_code=409, detail="Only a draft list can be finalized")
     lt = state.get("list_type") or DEFAULT_LIST_TYPE
     milestone = behavior(lt).finalize_milestone
-    now = datetime.now(UTC).isoformat()
+    now = datetime.now(timezone.utc).isoformat()
     data: dict = {"status": FINALIZED, "finalized_at": now}
     if milestone == "freeze_onhand":
         # An audit counts each inventory item once, so its manifest is a set keyed by item_id. Collapse
@@ -3494,7 +3494,7 @@ async def add_list_note(
             "note": payload.note.strip(),
             "author_id": str(user.id),
             "author_name": getattr(user, "name", None) or user.email,
-            "created_at": datetime.now(UTC).isoformat(),
+            "created_at": datetime.now(timezone.utc).isoformat(),
         },
         actor_id=user.id, location_id=None, source="api",
         idempotency_key=payload.idempotency_key or str(uuid.uuid4()), metadata_={},
@@ -3520,7 +3520,7 @@ async def update_list_note(
     entry = await emit_event(
         session, company_id=company_id, entity_id=note_id, entity_type="list_note",
         event_type="list.note_updated",
-        data={"list_id": entity_id, "note_id": note_id, "note": payload.note.strip(), "updated_at": datetime.now(UTC).isoformat()},
+        data={"list_id": entity_id, "note_id": note_id, "note": payload.note.strip(), "updated_at": datetime.now(timezone.utc).isoformat()},
         actor_id=user.id, location_id=None, source="api",
         idempotency_key=payload.idempotency_key or str(uuid.uuid4()), metadata_={},
     )
@@ -3889,7 +3889,7 @@ async def fulfill_lines(
     if not to_fulfill and not service_eids:
         raise HTTPException(status_code=422, detail="No fulfillable items in the provided line_entity_ids")
 
-    now = datetime.now(UTC).isoformat()
+    now = datetime.now(timezone.utc).isoformat()
     cid = uuid.UUID(str(company_id))
     uid = user.id
 
@@ -4074,7 +4074,7 @@ async def revert_lines(
     if not to_revert:
         raise HTTPException(status_code=422, detail="No revertible items in the provided line_entity_ids")
 
-    now = datetime.now(UTC).isoformat()
+    now = datetime.now(timezone.utc).isoformat()
     cid = uuid.UUID(str(company_id))
     uid = user.id
 
@@ -4261,7 +4261,7 @@ async def receive_return(
                 )
 
     # --- Create returned inventory items ---
-    now = datetime.now(UTC).isoformat()
+    now = datetime.now(timezone.utc).isoformat()
     total_cogs = 0.0
     received_items = []
 
@@ -4404,7 +4404,7 @@ async def undo_receive_return(
     if not received_items:
         raise HTTPException(status_code=409, detail="No received return to undo")
 
-    now = datetime.now(UTC).isoformat()
+    now = datetime.now(timezone.utc).isoformat()
     item_ids = [r["item_id"] for r in received_items if r.get("item_id")]
     total_cogs = sum(
         float(r.get("cost_total") or 0) or (float(r.get("cost_price") or 0) * float(r.get("quantity") or 0))
@@ -4511,7 +4511,7 @@ async def undo_receive(
     if not received_item_ids:
         raise HTTPException(status_code=409, detail="No received goods to revert")
 
-    now = datetime.now(UTC).isoformat()
+    now = datetime.now(timezone.utc).isoformat()
 
     # Pre-flight: verify every created item is still "available" before disposing
     rows_result = await session.execute(
@@ -4633,7 +4633,7 @@ async def upload_doc_file(
             "url": meta["url"],
             "document_tag": None,
             "description": None,
-            "uploaded_at": datetime.now(UTC).isoformat(),
+            "uploaded_at": datetime.now(timezone.utc).isoformat(),
         },
         actor_id=user.id,
         location_id=None,
@@ -4936,7 +4936,7 @@ async def scan_list(
     lines = [dict(l) for l in (state.get("line_items") or [])]
     _normalize_line_item_ids(lines)  # heal any legacy lines stored with only entity_id so matching works
     idx = next((i for i, l in enumerate(lines) if l.get("item_id") == item.entity_id), None)
-    now = datetime.now(UTC).isoformat()
+    now = datetime.now(timezone.utc).isoformat()
 
     if status == DRAFT:
         if lt == "audit":
@@ -5017,7 +5017,7 @@ async def set_scanned(
     if row.state.get("status") != FINALIZED:
         raise HTTPException(status_code=409, detail="Counting happens on a finalized audit")
     targets = set(payload.item_ids)
-    stamp = datetime.now(UTC).isoformat() if payload.scanned else None
+    stamp = datetime.now(timezone.utc).isoformat() if payload.scanned else None
     lines = [dict(l) for l in (row.state.get("line_items") or [])]
     changed = 0
     for l in lines:
@@ -5174,7 +5174,7 @@ async def send_list(
     row = await _get_list(session, company_id, entity_id)
     if row.state.get("status") != FINALIZED:
         raise HTTPException(status_code=409, detail="Issue the list before sending it")
-    now = datetime.now(UTC).isoformat()
+    now = datetime.now(timezone.utc).isoformat()
     await _set_list_fields(session, company_id, entity_id, user,
                            {"sent_at": now, "sent_via": payload.sent_via or "email",
                             "sent_to": payload.sent_to})
@@ -5252,6 +5252,6 @@ async def move_transfer(
         moved += 1
     await _set_list_fields(session, company_id, entity_id, user,
                            {"moved_to_location_id": payload.to_location_id,
-                            "moved_at": datetime.now(UTC).isoformat()})
+                            "moved_at": datetime.now(timezone.utc).isoformat()})
     await session.commit()
     return {"moved": moved, "to_location_id": payload.to_location_id}

--- a/default_modules/celerp-docs/celerp_docs/sequences.py
+++ b/default_modules/celerp-docs/celerp_docs/sequences.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 import re
-from datetime import datetime, UTC
+from datetime import datetime, timezone
 
 from celerp.models.company import Company
 
@@ -84,7 +84,7 @@ def validate_pattern(pattern: str) -> str | None:
 
 def preview_pattern(pattern: str, prefix: str, seq_num: int = 1) -> str:
     """Generate a preview of what the pattern produces right now."""
-    return _expand_pattern(pattern, prefix, datetime.now(UTC), seq_num)
+    return _expand_pattern(pattern, prefix, datetime.now(timezone.utc), seq_num)
 
 
 def next_doc_ref(company: Company, doc_type: str) -> str:
@@ -92,7 +92,7 @@ def next_doc_ref(company: Company, doc_type: str) -> str:
     if doc_type not in _PREFIX_BY_DOC_TYPE:
         raise ValueError(f"Unsupported doc_type for sequence: {doc_type}")
 
-    now = datetime.now(UTC)
+    now = datetime.now(timezone.utc)
     settings = dict(company.settings or {})
     sequences = dict(settings.get("sequences") or {})
     seq = dict(sequences.get(doc_type) or {})
@@ -124,7 +124,7 @@ def get_all_sequences(company: Company) -> list[dict]:
     """Return the numbering config for all doc types."""
     settings = dict(company.settings or {})
     sequences = dict(settings.get("sequences") or {})
-    now = datetime.now(UTC)
+    now = datetime.now(timezone.utc)
     result = []
     for doc_type, default_prefix in _PREFIX_BY_DOC_TYPE.items():
         seq = dict(sequences.get(doc_type) or {})
@@ -165,7 +165,7 @@ def update_sequence(company: Company, doc_type: str, prefix: str | None = None,
     settings["sequences"] = sequences
     company.settings = settings
 
-    now = datetime.now(UTC)
+    now = datetime.now(timezone.utc)
     pfx = str(seq.get("prefix") or _PREFIX_BY_DOC_TYPE[doc_type])
     pat = str(seq.get("pattern") or DEFAULT_PATTERN)
     n = int(seq.get("next", 1))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,8 @@ dependencies = [
     # IANA timezone database for zoneinfo. Windows ships no system tz database, so
     # zoneinfo.ZoneInfo() fails there without this; also protects minimal Linux.
     "tzdata>=2024.1",
+    # celerp/config.py falls back to tomli where the stdlib has no tomllib (3.10).
+    "tomli>=2.0; python_version < \"3.11\"",
     # Bundled PostgreSQL 17 for zero-setup pip installs: `celerp init` boots a
     # self-contained cluster when no system Postgres is running (an existing server
     # always wins). Marker-guarded to platforms with wheels — Linux x86_64/aarch64

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -334,3 +334,15 @@ class TestFirstBootSequence:
         cfg = mod.read_config()
         assert "inventory" in cfg["modules"]["enabled"]
         assert cfg["server"]["api_port"] == 8000
+
+
+def test_tomli_declared_for_pre_311():
+    """celerp/config.py falls back to `import tomli as tomllib` on 3.10; the
+    fallback only works if packaging declares tomli for those interpreters."""
+    import tomllib
+    pyproject = tomllib.loads(
+        (Path(__file__).resolve().parents[1] / "pyproject.toml").read_text())
+    deps = pyproject["project"]["dependencies"]
+    tomli_specs = [d for d in deps if d.split(";")[0].strip().startswith("tomli")]
+    assert tomli_specs, "tomli missing from dependencies; 3.10 config read fails"
+    assert any('python_version < "3.11"' in d for d in tomli_specs)

--- a/tests/test_fulfillment.py
+++ b/tests/test_fulfillment.py
@@ -6,7 +6,7 @@
 from __future__ import annotations
 
 import uuid
-from datetime import UTC, datetime, timedelta
+from datetime import datetime, timedelta
 
 import pytest
 import pytest_asyncio

--- a/tests/test_python310_floor.py
+++ b/tests/test_python310_floor.py
@@ -1,0 +1,75 @@
+# Copyright (c) 2026 Noah Severs
+# SPDX-License-Identifier: LicenseRef-Proprietary
+
+"""Guard the declared Python floor (pyproject ``requires-python >= 3.10``).
+
+A few names the codebase uses only exist from 3.11: ``datetime.UTC`` and
+``enum.StrEnum``. Importing either on 3.10 fails at import time, so a single
+such line in shipped code silently breaks the whole package there - and the
+3.10 CI leg runs a narrow, ``--noconftest`` subset that never imports most of
+it. This test scans the shipped packages by AST so any reintroduction fails
+here, on every interpreter, instead of only for a user on 3.10.
+
+Sanctioned fallbacks live in one place each: ``enum.StrEnum`` behind the version
+gate in ``celerp/compat.py``, and ``tomllib`` behind the ``ImportError`` fallback
+in ``celerp/config.py``. Both are exempt below.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+from celerp.compat import StrEnum
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_SHIPPED_ROOTS = [_REPO_ROOT / "celerp", _REPO_ROOT / "default_modules"]
+_EXEMPT = {_REPO_ROOT / "celerp" / "compat.py"}
+
+
+def _shipped_py_files() -> list[Path]:
+    files: list[Path] = []
+    for root in _SHIPPED_ROOTS:
+        files.extend(p for p in root.rglob("*.py") if p not in _EXEMPT)
+    return files
+
+
+def _from_imports(tree: ast.AST) -> list[tuple[str, str]]:
+    """Every (module, imported_name) pair from ``from X import Y`` statements."""
+    pairs: list[tuple[str, str]] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.module:
+            pairs.extend((node.module, alias.name) for alias in node.names)
+    return pairs
+
+
+@pytest.mark.parametrize("path", _shipped_py_files(), ids=lambda p: str(p.relative_to(_REPO_ROOT)))
+def test_no_python311_only_imports(path: Path):
+    """No shipped module imports a 3.11-only stdlib name outside its sanctioned
+    single-source fallback."""
+    tree = ast.parse(path.read_text())
+    imports = _from_imports(tree)
+    assert ("enum", "StrEnum") not in imports, (
+        f"{path.relative_to(_REPO_ROOT)} imports enum.StrEnum (3.11+); "
+        "import StrEnum from celerp.compat instead")
+    assert ("datetime", "UTC") not in imports, (
+        f"{path.relative_to(_REPO_ROOT)} imports datetime.UTC (3.11+); "
+        "use datetime.timezone.utc instead")
+    src = path.read_text()
+    assert "datetime.UTC" not in src, (
+        f"{path.relative_to(_REPO_ROOT)} uses datetime.UTC (3.11+); "
+        "use datetime.timezone.utc instead")
+
+
+def test_compat_strenum_stringifies_to_value():
+    """The 3.10 backport must behave like enum.StrEnum: members are real str and
+    stringify to their value, which serialization and comparisons depend on."""
+    class Color(StrEnum):
+        RED = "red"
+
+    assert isinstance(Color.RED, str)
+    assert Color.RED == "red"
+    assert str(Color.RED) == "red"
+    assert f"{Color.RED}" == "red"

--- a/tests/test_scalability.py
+++ b/tests/test_scalability.py
@@ -290,6 +290,36 @@ class TestDrainMiddleware:
             assert r.status_code == 200
 
     @pytest.mark.asyncio
+    @pytest.mark.timeout(15)
+    async def test_write_request_does_not_deadlock_on_held_singleton(self, client, session):
+        """Regression: a write request must not deadlock when the request session
+        already holds the SystemRuntimeState singleton row uncommitted.
+
+        Each test runs inside one uncommitted outer transaction on a single
+        connection (the `session` fixture). DrainMiddleware runs is_draining on
+        every write; if it opens its own session on a *separate* connection, its
+        _get_or_create INSERT of the singleton blocks forever on the request
+        session's uncommitted insert of the same row - a self-deadlock that hangs
+        to the per-test timeout. It only surfaces on CI because the 1s in-process
+        drain cache usually skips the DB. Middleware must share the request
+        transaction so this completes.
+        """
+        from celerp.services.runtime_state import (
+            get_runtime_state, _drain_cache_bust, _SINGLETON_ID)
+        from celerp.models.auth import SystemRuntimeState
+
+        # Request session (connection A) creates + holds the singleton uncommitted.
+        await get_runtime_state(session)
+        assert await session.get(SystemRuntimeState, _SINGLETON_ID) is not None
+        # Force the next write's is_draining to hit the DB rather than the 1s cache
+        # - the exact window the CI flake needs.
+        _drain_cache_bust()
+
+        # DrainMiddleware runs is_draining here; a second connection would deadlock.
+        r = await client.post("/auth/login", json={"email": "x@x.com", "password": "wrong"})
+        assert r.status_code != 503
+
+    @pytest.mark.asyncio
     async def test_drain_middleware_fail_open(self, client):
         """DrainMiddleware passes request when DB raises an exception."""
         with patch("celerp.middleware.is_draining", new_callable=AsyncMock, side_effect=Exception("DB down")):

--- a/tests/test_services/test_sequences.py
+++ b/tests/test_services/test_sequences.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 from types import SimpleNamespace
-from datetime import datetime, UTC
+from datetime import datetime, timezone
 from unittest.mock import patch
 
 import pytest
@@ -27,7 +27,7 @@ def _company(**kwargs) -> SimpleNamespace:
 def test_default_pattern_produces_prefix_yymm_format():
     """Default {PREFIX}-{YY}{MM}-{####} pattern produces e.g. INV-2603-0001."""
     c = _company()
-    now = datetime.now(UTC)
+    now = datetime.now(timezone.utc)
     yy = f"{now.year % 100:02d}"
     mm = f"{now.month:02d}"
     ref = next_doc_ref(c, "invoice")
@@ -38,7 +38,7 @@ def test_default_pattern_produces_prefix_yymm_format():
 
 def test_custom_pattern_with_prefix():
     c = _company(sequences={"invoice": {"prefix": "INV", "pattern": "{PREFIX}-{YYYY}-{####}"}})
-    now = datetime.now(UTC)
+    now = datetime.now(timezone.utc)
     ref = next_doc_ref(c, "invoice")
     assert ref == f"INV-{now.year}-0001"
     ref2 = next_doc_ref(c, "invoice")
@@ -50,7 +50,7 @@ def test_monthly_reset():
     c = _company(sequences={"invoice": {
         "pattern": "{YY}{MM}-{##}", "next": 5, "year": 2026, "month": 2,
     }})
-    now = datetime.now(UTC)
+    now = datetime.now(timezone.utc)
     ref = next_doc_ref(c, "invoice")
     if now.month != 2 or now.year != 2026:
         # Month changed, so counter reset to 1
@@ -64,14 +64,14 @@ def test_yearly_reset():
     c = _company(sequences={"invoice": {
         "pattern": "{YYYY}-{####}", "prefix": "INV", "next": 10, "year": 2025, "month": 12,
     }})
-    now = datetime.now(UTC)
+    now = datetime.now(timezone.utc)
     ref = next_doc_ref(c, "invoice")
     assert ref == f"{now.year}-0001"  # Year changed from 2025, reset
 
 
 def test_per_doc_type_independent_sequences():
     c = _company()
-    now = datetime.now(UTC)
+    now = datetime.now(timezone.utc)
     yymm = f"{now.year % 100:02d}{now.month:02d}"
     assert next_doc_ref(c, "invoice") == f"INV-{yymm}-0001"
     assert next_doc_ref(c, "purchase_order") == f"PO-{yymm}-0001"
@@ -104,7 +104,7 @@ def test_validate_pattern_accepts_valid():
 
 def test_preview_pattern():
     preview = preview_pattern("{PREFIX}-{YY}{MM}-{##}", "INV", seq_num=42)
-    now = datetime.now(UTC)
+    now = datetime.now(timezone.utc)
     assert preview == f"INV-{now.year % 100:02d}{now.month:02d}-42"
 
 
@@ -152,13 +152,13 @@ def test_update_sequence_min_next_is_1():
 
 
 def test_expand_pattern_with_dd():
-    now = datetime(2026, 3, 23, tzinfo=UTC)
+    now = datetime(2026, 3, 23, tzinfo=timezone.utc)
     result = _expand_pattern("{DD}/{MM}/{YY}-{###}", "X", now, 7)
     assert result == "23/03/26-007"
 
 
 def test_expand_pattern_hash_padding():
-    now = datetime(2026, 1, 1, tzinfo=UTC)
+    now = datetime(2026, 1, 1, tzinfo=timezone.utc)
     assert _expand_pattern("{#####}", "X", now, 42) == "00042"
     assert _expand_pattern("{##}", "X", now, 42) == "42"
     assert _expand_pattern("{##}", "X", now, 1) == "01"


### PR DESCRIPTION
pyproject declares `requires-python >= 3.10`, but several modules imported names that only exist from 3.11 - `enum.StrEnum` and `datetime.UTC` - so the package failed to import on 3.10 despite the declared floor. The narrow 3.10 CI leg ran a `--noconftest` subset that never imported most of it, so the breakage went unseen.

## Changes

- Add `celerp/compat.py` with a single-source `StrEnum` shim (the real `enum.StrEnum` on 3.11+, a `str, Enum` backport on 3.10) and route `celerp/events/types.py` and `celerp/importers/schema.py` through it.
- Switch every `datetime.UTC` use to `datetime.timezone.utc` across `celerp/services/fulfill.py` and the docs/dashboard default modules.
- Declare the `tomli` dependency that `config.py`'s `tomllib` fallback relies on for `python_version < "3.11"`.
- Add an AST guard test that scans the shipped packages and fails on any reintroduction of a 3.11-only stdlib import, on every interpreter, plus a packaging test asserting the tomli marker.