### PR TITLE
Fix: Measurements label prints present dimensions instead of blank when depth is missing (#242)

### DIFF
--- a/default_modules/celerp-labels/celerp_labels/service.py
+++ b/default_modules/celerp-labels/celerp_labels/service.py
@@ -131,10 +131,11 @@ def resolve_field_value(item: dict[str, Any], key: str, unit_map: dict[str, dict
     - pieces on a pieces-sold item -> quantity
     - unit -> the item's sell_by
     - qr / barcode / barcode_text -> the item's barcode, falling back to SKU
-    - measurements -> the stored value, else "length x width x height" composed
-      from the dimension attributes only when all three are present (a partial
-      join like "6.5 x  x 4.0" would read as a complete measurement of a
-      different shape)
+    - measurements -> the stored value, else the dimension attributes composed
+      in natural order length -> width -> height, stopping at the first missing
+      one, so a two-dimension item prints "L x W" but a middle-gap string like
+      "6.5 x  x 4.0" (which would read as a complete measurement of a different
+      shape) is never emitted
     """
     sell_by = item.get("sell_by")
     if key in ("qr", "barcode", "barcode_text"):
@@ -150,8 +151,12 @@ def resolve_field_value(item: dict[str, Any], key: str, unit_map: dict[str, dict
         stored = _item_val(item, key)
         if stored:
             return stored
-        dims = [_item_val(item, d) for d in ("length", "width", "height")]
-        return " x ".join(dims) if all(dims) else ""
+        present: list[str] = []
+        for d in (_item_val(item, dim) for dim in ("length", "width", "height")):
+            if not d:
+                break  # stop at the first gap: never emit "L x  x H"
+            present.append(d)
+        return " x ".join(present)
     return _item_val(item, key)
 
 

--- a/default_modules/celerp-labels/tests/test_labels.py
+++ b/default_modules/celerp-labels/tests/test_labels.py
@@ -1079,16 +1079,39 @@ def test_resolve_measurements_composes_from_dimensions():
     assert resolve_field_value(item, "measurements", unit_map) == "6.51 x 6.54 x 4.01"
 
 
-def test_resolve_measurements_missing_dimension_yields_empty():
-    """Any missing dimension yields "", never a partial string like "6.5 x  x 4.0"."""
+def test_resolve_measurements_composes_present_dimensions_in_order():
+    """Compose from the dimensions present in length -> width -> height order,
+    stopping at the first gap, so a middle-hole string like "6.5 x  x 4.0" is
+    never emitted and every printed value stays unambiguous by position."""
+    from celerp.services.units import DEFAULT_UNITS, build_unit_map
+    from celerp_labels.service import resolve_field_value
+    unit_map = build_unit_map(DEFAULT_UNITS)
+    cases = [
+        # trailing dimensions may be absent -> use the leading run that is present
+        ({"length": "6.51", "width": "6.54"}, "6.51 x 6.54"),
+        ({"length": "6.51"}, "6.51"),
+        # a gap stops the run: only the leading dimensions before it print
+        ({"length": "6.51", "width": "6.54", "height": ""}, "6.51 x 6.54"),
+        # a hole before a present value never emits the trailing value
+        ({"length": "6.51", "width": "", "height": "4.01"}, "6.51"),
+    ]
+    for attrs, expected in cases:
+        item = {"name": "Gem", "attributes": attrs}
+        got = resolve_field_value(item, "measurements", unit_map)
+        assert got == expected, (attrs, got)
+
+
+def test_resolve_measurements_no_leading_length_yields_empty():
+    """Without a length there is no dimension to anchor to, so a width/height-only
+    item (or an item with no dimensions) resolves to "" rather than a value that
+    can't be told apart from a length."""
     from celerp.services.units import DEFAULT_UNITS, build_unit_map
     from celerp_labels.service import resolve_field_value
     unit_map = build_unit_map(DEFAULT_UNITS)
     for attrs in (
-        {"length": "6.51", "width": "6.54"},
-        {"length": "6.51", "height": "4.01"},
         {"width": "6.54", "height": "4.01"},
-        {"length": "6.51", "width": "", "height": "4.01"},
+        {"height": "4.01"},
+        {"length": "", "width": "6.54"},
         {},
     ):
         item = {"name": "Gem", "attributes": attrs}

--- a/tests/test_browser/test_manufacturing_journey.py
+++ b/tests/test_browser/test_manufacturing_journey.py
@@ -56,6 +56,11 @@ def test_full_manufacturing_journey(page, ui_server, api):
     _combo_pick(page, ".recipe-add-row", "JNY-GOLD")  # ghost add-row commits a real component
     page.wait_for_selector('td[data-col="recipe__components__0__quantity"]', timeout=8000)
     _set_cell("recipe__components__0__quantity", "5")
+    # The per-cell save fires recipeSaved, which re-renders the whole #recipe-section
+    # (outerHTML). Wait for that refresh to actually land (the cost card only reads 400,
+    # 5 x 80/g gold, once it has) before adding labor, so the section swap can't race the
+    # add-labor swap and clobber the new row. (Mirrors test_manufacturing_recipe.)
+    page.wait_for_selector("#recipe-cost-card:has-text('400')", timeout=8000)
     page.fill("input[name=labor_new_op]", "Setting")
     page.fill("input[name=labor_new_hours]", "2")
     page.fill("input[name=labor_new_rate]", "50")


### PR DESCRIPTION
Closes #242.

## Problem

The composite **Measurements** label field (key `measurements`) is meant to print an item's dimensions as `length x width x height`. `resolve_field_value` gated the composed string on **all three** dimensions being present:

```python
dims = [_item_val(item, d) for d in ("length", "width", "height")]
return " x ".join(dims) if all(dims) else ""   # requires ALL three
```

`_item_val` returns `""` for an unset dimension, so `all(dims)` is False whenever any of length/width/height is missing, and the field resolves to `""`, which both renderers then skip. An item measured in two dimensions (length x width, no depth, common for flat or calibrated items) has legitimate, complete data yet printed a blank line.

## Fix

Compose from the dimensions that **are** present, in natural order length, width, height, **stopping at the first missing one**:

```python
present: list[str] = []
for d in (_item_val(item, dim) for dim in ("length", "width", "height")):
    if not d:
        break  # stop at the first gap: never emit "L x  x H"
    present.append(d)
return " x ".join(present)
```

Resulting behavior:

| Dimensions present | Output |
|---|---|
| length + width + height | `L x W x H` |
| length + width (no height) | `L x W` |
| length only | `L` |
| gap in the middle (`L`, _, `H`) | `L x W` up to the gap (never `L x  x H`) |
| no length (width/height only) | `""` (no leading dimension to anchor to) |

This ordered "stop at the first gap" rule keeps every printed value unambiguous by position: a two-dimension item prints its real `L x W`, a fully-measured item is unchanged, and the original concern (a middle-hole string reading as a complete measurement of a different shape) is still never emitted. A stored `measurements` attribute still wins over the composed value.

## Tests

- Replaced `test_resolve_measurements_missing_dimension_yields_empty` (asserted the old all-or-nothing behavior) with:
  - `test_resolve_measurements_composes_present_dimensions_in_order`: L x W, L only, gap-stops-the-run, hole-before-a-present-value.
  - `test_resolve_measurements_no_leading_length_yields_empty`: width/height-only and empty items still resolve to `""`.
- Existing all-three-present, stored-value-wins, PDF, and text-fallback render tests are unchanged and still pass.

Pure-function unit tests pass locally (10/10 measurements tests). The DB-backed `client`-fixture tests in this file require Docker or Postgres and were not runnable in the local environment; they are untouched by this change.
