### PR TITLE
See what a customer holds on memo, and what a supplier has with us

### DIFF
--- a/celerp/events/schemas.py
+++ b/celerp/events/schemas.py
@@ -79,6 +79,10 @@ class ItemQuantityAdjusted(BaseModel):
     reason: str | None = None
     source_list_id: str | None = None
     prior_qty: float | None = None
+    # Set only when returning consigned goods to a supplier: None once nothing is left on
+    # hand, "in" while a partial balance remains. Omitted by ordinary stock adjustments,
+    # which must leave the item's consignment status untouched.
+    consignment_flag: str | None = None
 
 
 class ItemLandedCostApplied(BaseModel):
@@ -597,6 +601,14 @@ class DocFulfilled(BaseModel):
     total_cogs: float
 
 
+class DocItemsReturned(BaseModel):
+    """Goods sent back to a supplier off a consignment_in / bill / purchase_order."""
+    items: list[dict[str, Any]]
+    returned_by: str
+    returned_at: str = ""
+    notes: str | None = None
+
+
 class DocReturnReceived(BaseModel):
     items: list[dict[str, Any]]
     received_by: str
@@ -1086,6 +1098,7 @@ EVENT_SCHEMA_MAP: dict[str, type[BaseModel]] = {
     "doc.fulfilled": DocFulfilled,
     "doc.partially_fulfilled": DocPartiallyFulfilled,
     "doc.partially_reverted": DocPartiallyReverted,
+    "doc.items_returned": DocItemsReturned,
     "doc.return_received": DocReturnReceived,
     "doc.return_undone": DocReturnUndone,
     "doc.receive_undone": DocReceiveUndone,

--- a/celerp/events/schemas.py
+++ b/celerp/events/schemas.py
@@ -646,6 +646,10 @@ class DocFulfillmentReversed(BaseModel):
     reversed_items: list[dict[str, Any]]
     reversed_by: str
     reason: str
+    # Lots that came back in part: the new in-stock parcel split off each part-returned
+    # line. Named apart from reversed_items because those lines are still out, for the
+    # balance the customer kept.
+    partially_returned_items: list[dict[str, Any]] = []
 
 
 class DocPartiallyReverted(BaseModel):
@@ -654,6 +658,7 @@ class DocPartiallyReverted(BaseModel):
     reversed_items: list[dict[str, Any]]
     reversed_by: str
     reason: str
+    partially_returned_items: list[dict[str, Any]] = []
 
 
 # -----------------

--- a/celerp/events/schemas.py
+++ b/celerp/events/schemas.py
@@ -83,6 +83,10 @@ class ItemQuantityAdjusted(BaseModel):
     # hand, "in" while a partial balance remains. Omitted by ordinary stock adjustments,
     # which must leave the item's consignment status untouched.
     consignment_flag: str | None = None
+    # Set only when returning goods to a supplier: the lot's goods cost rescaled to the
+    # quantity still on hand, since the returned units take their share of the cost with
+    # them. Omitted by ordinary stock adjustments, which leave the lot's cost alone.
+    cost_base: float | None = None
 
 
 class ItemLandedCostApplied(BaseModel):

--- a/celerp/services/holdings.py
+++ b/celerp/services/holdings.py
@@ -1,0 +1,119 @@
+# Copyright (c) 2026 Noah Severs
+# SPDX-License-Identifier: BUSL-1.1
+"""Contact-scoped consignment / memo holdings.
+
+Two mirror-image questions, answered as pure reads over existing projection state
+(no new columns, no migration):
+
+- What is currently out on memo TO a customer? Items with status ``memo_out`` whose
+  ``fulfilled_for_docs`` points at one of that customer's memo docs. Valued at the
+  price the customer was quoted, i.e. the memo LINE's ``unit_price`` (per unit,
+  post-discount) times the quantity still out, NOT the item's catalog price.
+- What do we currently hold on consignment FROM a supplier? Items with
+  ``consignment_flag == "in"`` created by one of that supplier's ``consignment_in``
+  docs (tracked on the doc as ``received_item_ids``). Valued at cost.
+
+Both functions are pure over already-loaded rows so the inventory endpoint can share
+one item scan, and so the membership predicate is unit-testable in isolation. The
+value each returns is exactly what the list endpoint should display and total for the
+scoped view, so the card total and the list reconcile by construction.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+
+def _num(value: object) -> float | None:
+    """Coerce a stored price/quantity to float, or None when absent/blank/garbage."""
+    if value in (None, ""):
+        return None
+    try:
+        return float(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return None
+
+
+def memo_holdings(
+    items: Iterable[tuple[str, dict]],
+    memo_docs: Iterable[tuple[str, dict]],
+) -> dict[str, float]:
+    """Map item_id -> quoted value for items still out on memo to a customer.
+
+    ``items``: (entity_id, state) for the company's items.
+    ``memo_docs``: (entity_id, state) for that customer's issued memo docs.
+
+    An item is out on memo when its status is ``memo_out`` and its
+    ``fulfilled_for_docs`` intersects the memo docs supplied. The value is the
+    memo line's ``unit_price`` times the quantity still out (so partial returns
+    step the value down), falling back to the line's ``line_total`` when no unit
+    price is stored, and to 0.0 when the line carries no price or cannot be
+    matched. An unpriceable item is still returned: the point of the view is that
+    nothing out on memo is quietly missing from it.
+    """
+    memo_docs = list(memo_docs)
+    doc_ids = {doc_id for doc_id, _ in memo_docs}
+    # (doc_id, item_id) -> line, so an item that was on memo to A, returned, then
+    # re-sent to B resolves against the doc that is actually in fulfilled_for_docs.
+    line_by: dict[tuple[str, str], dict] = {}
+    for doc_id, state in memo_docs:
+        for line in (state or {}).get("line_items", []) or []:
+            eid = line.get("entity_id") or line.get("item_id")
+            if eid:
+                line_by[(doc_id, eid)] = line
+
+    out: dict[str, float] = {}
+    for item_id, state in items:
+        state = state or {}
+        if str(state.get("status") or "").lower() != "memo_out":
+            continue
+        member_docs = doc_ids & set(state.get("fulfilled_for_docs") or [])
+        if not member_docs:
+            continue
+        remaining = _num(state.get("quantity")) or 0.0
+        value = 0.0
+        # Sorted so the priced line is chosen deterministically: an item is normally out
+        # on exactly one memo, but never let the value depend on set iteration order.
+        for doc_id in sorted(member_docs):
+            line = line_by.get((doc_id, item_id))
+            if line is None:
+                continue
+            unit = _num(line.get("unit_price"))
+            if unit is not None:
+                value = unit * remaining
+            else:
+                value = _num(line.get("line_total")) or 0.0
+            break
+        out[item_id] = round(value, 2)
+    return out
+
+
+def consignment_holdings(
+    items: Iterable[tuple[str, dict]],
+    consignment_docs: Iterable[tuple[str, dict]],
+) -> dict[str, float]:
+    """Map item_id -> cost value for items still held on consignment from a supplier.
+
+    ``items``: (entity_id, state) for the company's items.
+    ``consignment_docs``: (entity_id, state) for that supplier's issued consignment_in docs.
+
+    An item is still held when it was created by one of those docs (its id is in the
+    doc's ``received_item_ids``) and it still carries ``consignment_flag == "in"``
+    (the flag clears when the goods are fully returned to the supplier). Value is the
+    item's ``cost_total``, which already tracks remaining quantity after partial returns.
+    """
+    received: set[str] = set()
+    for _doc_id, state in consignment_docs:
+        received.update((state or {}).get("received_item_ids") or [])
+
+    out: dict[str, float] = {}
+    for item_id, state in items:
+        state = state or {}
+        if item_id not in received or state.get("consignment_flag") != "in":
+            continue
+        cost = _num(state.get("cost_total"))
+        if cost is None:
+            unit = _num(state.get("cost_price"))
+            cost = (unit * (_num(state.get("quantity")) or 0.0)) if unit is not None else 0.0
+        out[item_id] = round(cost, 2)
+    return out

--- a/default_modules/celerp-docs/celerp_docs/routes.py
+++ b/default_modules/celerp-docs/celerp_docs/routes.py
@@ -2433,10 +2433,20 @@ async def return_consignment_items(entity_id: str, payload: ReturnBody, company_
         if it.quantity_returned > current_qty + 1e-9:
             raise HTTPException(status_code=409, detail=f"Cannot return more than on-hand quantity for {it.item_id}")
         new_qty = max(0.0, current_qty - it.quantity_returned)
+        adjustment: dict = {"new_qty": new_qty, "consignment_flag": None if new_qty == 0 else "in"}
+        # The returned units physically leave, so the lot's goods cost leaves with them:
+        # scale cost_base to what is still on hand. Without this the remaining balance
+        # would keep carrying the whole lot's cost (a partial return is an in-place
+        # quantity reduction, not a split, so nothing else rescales it).
+        _base = item.state.get("cost_base")
+        if _base is None:
+            _base = item.state.get("cost_total")
+        if _base is not None and current_qty > 0:
+            adjustment["cost_base"] = round(float(_base) * (new_qty / current_qty), 2)
         await emit_event(
             session, company_id=company_id, entity_id=it.item_id, entity_type="item",
             event_type="item.quantity.adjusted",
-            data={"new_qty": new_qty, "consignment_flag": None if new_qty == 0 else "in"},
+            data=adjustment,
             actor_id=user.id, location_id=None, source="api",
             idempotency_key=str(uuid.uuid4()), metadata_={"source_return": entity_id},
         )

--- a/default_modules/celerp-docs/celerp_docs/routes.py
+++ b/default_modules/celerp-docs/celerp_docs/routes.py
@@ -2632,6 +2632,18 @@ async def convert_doc(entity_id: str, company_id: str = Depends(get_current_comp
                 Projection, {"company_id": company_id, "entity_id": li_eid}
             )
             if item_proj and item_proj.state.get("status") == "memo_out":
+                # Invoice what the customer actually still holds. A part-returned line keeps
+                # its original quantity, but the lot out with them has already been reduced,
+                # so bill the remainder or the return would be charged for as well.
+                _still_out = float(item_proj.state.get("quantity") or 0)
+                _line_qty = float(li.get("quantity") or 0)
+                if _line_qty and abs(_still_out - _line_qty) > 1e-9:
+                    _kept = to_decimal(_still_out) / to_decimal(_line_qty)
+                    li = {**li, "quantity": _still_out}
+                    if li.get("line_total") is not None:
+                        # Scale rather than recompute, so any per-line discount is preserved.
+                        li["line_total"] = to_stored_float(round_money(
+                            to_decimal(li["line_total"]) * _kept, state.get("currency")))
                 qualifying_line_items.append(li)
 
         if not qualifying_line_items:

--- a/default_modules/celerp-docs/celerp_docs/routes.py
+++ b/default_modules/celerp-docs/celerp_docs/routes.py
@@ -2422,6 +2422,11 @@ async def receive_po(entity_id: str, payload: ReceiveBody, company_id: str = Dep
     return {"event_id": entry.id}
 
 
+# Item statuses meaning the goods are not on our shelf, so they cannot be handed back to a
+# supplier: they are at a customer, gone, or no longer a live parcel.
+_NOT_ON_HAND_STATUSES: frozenset[str] = frozenset({"memo_out", "sold", "archived", "merged"})
+
+
 class ReturnItem(BaseModel):
     item_id: str
     quantity_returned: float
@@ -2446,6 +2451,16 @@ async def return_consignment_items(entity_id: str, payload: ReturnBody, company_
         item = await session.get(Projection, {"company_id": company_id, "entity_id": it.item_id})
         if item is None:
             raise HTTPException(status_code=404, detail=f"Item not found: {it.item_id}")
+        # Only goods actually on the shelf can go back to a supplier. Anything out on memo
+        # is at a customer's site and anything sold has left; shrinking those here would
+        # quietly write off stock that is still owed back to us.
+        _item_status = str(item.state.get("status") or "").lower()
+        if _item_status in _NOT_ON_HAND_STATUSES:
+            raise HTTPException(
+                status_code=409,
+                detail=(f"Cannot return {item.state.get('sku', it.item_id)}: it is "
+                        f"'{_item_status}', not on hand. Bring it back into stock first."),
+            )
         current_qty = float(item.state.get("quantity", 0) or 0)
         if it.quantity_returned > current_qty + 1e-9:
             raise HTTPException(status_code=409, detail=f"Cannot return more than on-hand quantity for {it.item_id}")

--- a/default_modules/celerp-docs/celerp_docs/routes.py
+++ b/default_modules/celerp-docs/celerp_docs/routes.py
@@ -211,6 +211,23 @@ class FulfillLinesRequest(BaseModel):
         return list(dict.fromkeys(eid for eid in v if eid))
 
 
+class RevertLinesRequest(FulfillLinesRequest):
+    """Revert whole lines, or return part of one.
+
+    ``quantities`` maps an item entity_id to the quantity coming back. Omit it, or give
+    the item's whole quantity, to take the whole lot back. A smaller quantity is a partial
+    return: that much is split off and comes back into stock, and the remainder stays out
+    with the customer, so goods still in their hands are never written off as returned.
+
+    ``weights`` / ``pieces`` carry the returned lot's measures for parcels tracked by a
+    measure the quantity does not imply (a piece-sold parcel that also carries a weight).
+    The measure of a part-returned parcel cannot be inferred, so it must be stated.
+    """
+    quantities: dict[str, float] | None = None
+    weights: dict[str, float] | None = None
+    pieces: dict[str, int] | None = None
+
+
 def _assert_date_order(patch: dict, current: dict | None = None) -> None:
     """Raise 422 if due_date is set and earlier than issue_date.
 
@@ -4039,7 +4056,7 @@ async def fulfill_lines(
 @router.post("/{entity_id}/revert-lines")
 async def revert_lines(
     entity_id: str,
-    body: FulfillLinesRequest,
+    body: RevertLinesRequest,
     company_id: str = Depends(get_current_company_id),
     _: None = require_permission("fulfill_documents"),
     user=Depends(get_current_user),
@@ -4061,8 +4078,18 @@ async def revert_lines(
     if not body.line_entity_ids:
         raise HTTPException(status_code=422, detail="line_entity_ids must not be empty")
 
+    _returned_qty = body.quantities or {}
+    _unknown = [eid for eid in _returned_qty if eid not in body.line_entity_ids]
+    if _unknown:
+        raise HTTPException(
+            status_code=422,
+            detail=f"quantities names items that are not in line_entity_ids: {', '.join(sorted(_unknown))}",
+        )
+
     errors: list[str] = []
     to_revert: list[str] = []
+    # item_eid -> quantity coming back, for lines where only part of the lot returned.
+    partial_plan: dict[str, float] = {}
     fetched: dict[str, Projection] = {}
     for item_eid in body.line_entity_ids:
         item_proj = await session.get(Projection, {"company_id": company_id, "entity_id": item_eid})
@@ -4075,18 +4102,66 @@ async def revert_lines(
                 f"{item_eid} ({item_proj.state.get('sku', '')}): must be 'memo_out' or 'sold' to revert, is '{item_status}'"
             )
             continue
+        _sku = item_proj.state.get("sku", "")
+        _qty_back = _returned_qty.get(item_eid)
+        if _qty_back is not None:
+            _on_hand = float(item_proj.state.get("quantity") or 0)
+            if _qty_back <= 0:
+                errors.append(f"{item_eid} ({_sku}): returned quantity must be greater than zero")
+                continue
+            if _qty_back > _on_hand + 1e-9:
+                errors.append(
+                    f"{item_eid} ({_sku}): cannot return {_qty_back:g} of {_on_hand:g} that went out"
+                )
+                continue
+            if abs(_qty_back - _on_hand) > 1e-9:
+                # Part of the lot is coming back; the rest stays with the customer.
+                if item_status != "memo_out":
+                    errors.append(
+                        f"{item_eid} ({_sku}): only goods out on memo can be part-returned, "
+                        f"this one is '{item_status}'"
+                    )
+                    continue
+                fetched[item_eid] = item_proj
+                partial_plan[item_eid] = float(_qty_back)
+                continue
         fetched[item_eid] = item_proj
         to_revert.append(item_eid)
 
-    if errors and not to_revert:
+    if errors and not to_revert and not partial_plan:
         raise HTTPException(status_code=422, detail={"errors": errors})
 
-    if not to_revert:
+    if not to_revert and not partial_plan:
         raise HTTPException(status_code=422, detail="No revertible items in the provided line_entity_ids")
 
     now = datetime.now(timezone.utc).isoformat()
     cid = uuid.UUID(str(company_id))
     uid = user.id
+
+    # Partial returns first: split the returned amount off the lot that is out. The child
+    # carries the returned goods and starts available (back in stock); the mother keeps the
+    # remainder and stays memo_out, so what the customer still holds is never lost.
+    returned_brief: list[dict] = []
+    if partial_plan:
+        from celerp_inventory.routes import split_off_child
+        _unit_map = await _get_unit_map(session, company_id)
+        for parent_eid, qty_back in partial_plan.items():
+            parent_proj = fetched[parent_eid]
+            _sb = parent_proj.state.get("sell_by") or ""
+            _sku = parent_proj.state.get("sku", "")
+            child_weight = qty_back if is_weight_unit(_sb, _unit_map) else (body.weights or {}).get(parent_eid)
+            child_pieces = qty_back if is_pieces_unit(_sb, _unit_map) else (body.pieces or {}).get(parent_eid)
+            try:
+                child_eid, _child_sku = await split_off_child(
+                    session, company_id=cid, user_id=uid, parent_proj=parent_proj,
+                    child_qty=qty_back, child_weight=child_weight, child_pieces=child_pieces,
+                )
+            except ValueError as exc:
+                raise HTTPException(
+                    status_code=409,
+                    detail=f"Cannot return part of {_sku}: {exc}",
+                )
+            returned_brief.append({"item_id": child_eid, "sku": _sku, "quantity": qty_back})
 
     for item_eid in to_revert:
         item_proj = fetched[item_eid]
@@ -4135,6 +4210,10 @@ async def revert_lines(
         "reversed_by": str(uid),
         "reason": "per_line_revert",
     }
+    if returned_brief:
+        # Part-returned lots: named separately from whole-line reverts, because the line
+        # itself is still out (for the balance the customer kept).
+        doc_event_data["partially_returned_items"] = returned_brief
     if any(s in ("memo_out", "sold") for s in all_statuses):
         doc_fulfillment_status = "partial"
         doc_event_type = "doc.partially_reverted"
@@ -4165,7 +4244,12 @@ async def revert_lines(
         )
 
     await session.commit()
-    return {"fulfillment_status": doc_fulfillment_status, "reverted": to_revert}
+    return {
+        "fulfillment_status": doc_fulfillment_status,
+        "reverted": to_revert,
+        # Lots that came back in part: the new in-stock parcel per part-returned line.
+        "partially_returned": returned_brief,
+    }
 
 
 class ReturnReceivedItem(BaseModel):

--- a/default_modules/celerp-inventory/celerp_inventory/projections.py
+++ b/default_modules/celerp-inventory/celerp_inventory/projections.py
@@ -296,6 +296,12 @@ def apply_item_event(state: dict, event_type: str, data: dict) -> dict:
             current["updated_at"] = data["updated_at"]
     elif event_type == "item.quantity.adjusted":
         current["quantity"] = data["new_qty"]
+        # Returning consigned goods to their supplier adjusts the quantity and settles the
+        # borrowed/owned question in the same breath: the emitter sends consignment_flag
+        # (None once nothing is left on hand, "in" while a partial balance remains). Only
+        # honour the key when present, so ordinary stock adjustments never touch the flag.
+        if "consignment_flag" in data:
+            current["consignment_flag"] = data["consignment_flag"]
         _recompute_cost(current)  # landed cost is per-unit, so it scales with quantity
     elif event_type == "item.landed_cost.applied":
         # Absolute per-unit landed contribution for one (source bill, kind); overwrite-safe so

--- a/default_modules/celerp-inventory/celerp_inventory/projections.py
+++ b/default_modules/celerp-inventory/celerp_inventory/projections.py
@@ -302,6 +302,10 @@ def apply_item_event(state: dict, event_type: str, data: dict) -> dict:
         # honour the key when present, so ordinary stock adjustments never touch the flag.
         if "consignment_flag" in data:
             current["consignment_flag"] = data["consignment_flag"]
+        # A return sends the goods cost that left with the units. Only honoured when
+        # present, so a plain stock correction still leaves the lot's cost alone.
+        if "cost_base" in data and data["cost_base"] is not None:
+            current["cost_base"] = float(data["cost_base"])
         _recompute_cost(current)  # landed cost is per-unit, so it scales with quantity
     elif event_type == "item.landed_cost.applied":
         # Absolute per-unit landed contribution for one (source bill, kind); overwrite-safe so

--- a/default_modules/celerp-inventory/celerp_inventory/routes.py
+++ b/default_modules/celerp-inventory/celerp_inventory/routes.py
@@ -317,6 +317,8 @@ async def list_items(
     location_id: str | None = None,
     source: str | None = None,
     filter: str | None = None,
+    on_memo_to: str | None = None,
+    consigned_from: str | None = None,
     sort: str | None = None,
     dir: str = "desc",
 ) -> dict:
@@ -328,6 +330,12 @@ async def list_items(
     category: exact category to filter on.
     filter: semantic filter. "low_stock" keeps only items at or below their
             reorder point (see celerp.services.reorder.is_below_reorder).
+    on_memo_to: customer contact_id. Scope to items currently out on memo to that
+            customer, valued (holding_value) at the price they were quoted.
+    consigned_from: supplier contact_id. Scope to items currently held on
+            consignment from that supplier, valued (holding_value) at cost.
+            When a contact scope is active the response also carries value_total,
+            the sum of holding_value over the whole scoped set (pre-pagination).
     """
     from celerp.services.reorder import is_below_reorder
     from celerp.models.company import Company, Location
@@ -362,6 +370,38 @@ async def list_items(
         result = [r for r in result if str(r.get("status") or "").lower() == status.lower()]
     else:
         result = [r for r in result if str(r.get("status") or "").lower() not in _HIDDEN_STATUSES]
+
+    # Contact-scoped holdings: memo out to a customer, or consignment in from a supplier.
+    # Membership is derived from that contact's docs (celerp.services.holdings), and is
+    # authoritative: it narrows result on its own. The per-item scope value (quoted memo
+    # price / consignment cost) is attached after cost-visibility gating, below.
+    holding_scoped = bool(on_memo_to or consigned_from)
+    scope_value: dict[str, float] = {}
+    if holding_scoped:
+        from celerp.services.holdings import consignment_holdings, memo_holdings
+        items_state = [(r.entity_id, r.state) for r in rows]
+        scope_doc_type = "memo" if on_memo_to else "consignment_in"
+        scope_contact = on_memo_to or consigned_from
+        scope_docs = (
+            await session.execute(
+                select(Projection).where(
+                    Projection.company_id == company_id,
+                    Projection.entity_type == "doc",
+                    Projection.state["doc_type"].as_string() == scope_doc_type,
+                    Projection.state["contact_id"].as_string() == scope_contact,
+                )
+            )
+        ).scalars().all()
+        # Only issued docs contribute; a draft or voided doc must not seed the set.
+        issued = [
+            (d.entity_id, d.state) for d in scope_docs
+            if str((d.state or {}).get("status") or "").lower() not in ("draft", "void")
+        ]
+        scope_value = (
+            memo_holdings(items_state, issued) if on_memo_to
+            else consignment_holdings(items_state, issued)
+        )
+        result = [r for r in result if r.get("id") in scope_value]
 
     if category:
         cats = {c.strip() for c in category.split(",") if c.strip()}
@@ -450,6 +490,14 @@ async def list_items(
     can_see_costs = role_has_permission(settings, role, "view_inventory_costs")
     result = apply_field_visibility(result, role, field_schema, can_see_costs)
 
+    # Attach the per-item scope value AFTER visibility (so it survives any dict rebuild).
+    # The consignment value is cost, so it is gated by view_inventory_costs exactly like
+    # every other cost figure; the memo value is a quoted sale price and is not gated.
+    gate_cost = bool(consigned_from) and not can_see_costs
+    if holding_scoped:
+        for r in result:
+            r["holding_value"] = None if gate_cost else scope_value.get(r.get("id"), 0.0)
+
     # FEFO: when company uses fefo, sort available items by expires_at ascending (soonest first)
     # so staff always see the items that need to be picked/sold first at the top.
     if company and (company.settings or {}).get("inventory_method") == "fefo":
@@ -483,8 +531,13 @@ async def list_items(
         result.sort(key=lambda item: str(item.get("updated_at") or ""), reverse=True)
 
     total = len(result)
-    return {"items": result[offset: offset + limit], "total": total,
-            "attribute_facets": attribute_facets}
+    resp: dict = {"items": result[offset: offset + limit], "total": total,
+                  "attribute_facets": attribute_facets}
+    if holding_scoped and not gate_cost:
+        # Total over the whole scoped set (post-filter, pre-pagination) so the contact
+        # card reads it directly and reconciles with the list at the same value basis.
+        resp["value_total"] = round(sum(float(scope_value.get(r.get("id"), 0.0)) for r in result), 2)
+    return resp
 
 
 @router.get("/valuation")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -339,7 +339,12 @@ class TestFirstBootSequence:
 def test_tomli_declared_for_pre_311():
     """celerp/config.py falls back to `import tomli as tomllib` on 3.10; the
     fallback only works if packaging declares tomli for those interpreters."""
-    import tomllib
+    # Read the manifest the same way celerp.config does, or this check for 3.10 support
+    # cannot itself run on 3.10: tomllib is stdlib only from 3.11.
+    try:
+        import tomllib  # Python 3.11+
+    except ImportError:
+        import tomli as tomllib  # type: ignore[no-redef]
     pyproject = tomllib.loads(
         (Path(__file__).resolve().parents[1] / "pyproject.toml").read_text())
     deps = pyproject["project"]["dependencies"]

--- a/tests/test_event_schema_registry.py
+++ b/tests/test_event_schema_registry.py
@@ -1,0 +1,26 @@
+# Copyright (c) 2026 Noah Severs
+# SPDX-License-Identifier: LicenseRef-Proprietary
+"""Registry guard: every declared EventType must have an emit-time schema.
+
+``emit_event`` looks the event type up in ``EVENT_SCHEMA_MAP`` and raises
+``ValueError: Unknown event_type`` when it is absent, so an ``EventType`` member
+with no schema entry is an endpoint that fails on every call. A projection
+reducer for the event is not enough: the emit never gets that far.
+
+This caught ``doc.items_returned`` (the supplier-return endpoint), which had an
+enum member and a reducer but no schema entry.
+"""
+
+from __future__ import annotations
+
+from celerp.events.schemas import EVENT_SCHEMA_MAP
+from celerp.events.types import EventType
+
+
+def test_every_event_type_has_an_emit_schema():
+    missing = sorted(e.value for e in EventType if e.value not in EVENT_SCHEMA_MAP)
+    assert not missing, (
+        "EventType members with no EVENT_SCHEMA_MAP entry: emit_event() raises "
+        f"'Unknown event_type' for each of these, so any endpoint emitting one always "
+        f"fails: {missing}"
+    )

--- a/tests/test_fulfillment.py
+++ b/tests/test_fulfillment.py
@@ -1577,3 +1577,123 @@ async def test_items_value_total_reconciles_with_listed_items(client, session, a
                              params={"on_memo_to": cust, "limit": 999})).json()
     listed = round(sum(float(i["holding_value"]) for i in resp["items"]), 2)
     assert resp["value_total"] == listed == 802.35
+
+
+# ---------------------------------------------------------------------------
+# Partial memo returns: a customer sends back part of a lot and keeps the rest.
+# The balance must stay out on memo, not be written off as returned.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_partial_memo_return_keeps_balance_out_with_customer(client, session, auth, _setup_ids):
+    cust = "contact:partialMemo"
+    sku = f"PM-{uuid.uuid4().hex[:6]}"
+    r = await client.post("/items", headers=auth["headers"],
+                          json={"sku": sku, "name": sku, "quantity": 7, "sell_by": "piece",
+                                "cost_total": 700.0})
+    assert r.status_code == 200, r.text
+    eid = r.json()["id"]
+    doc_id = await _create_memo(client, auth, [
+        {"sku": sku, "name": sku, "quantity": 7, "unit_price": 100.0, "entity_id": eid},
+    ], contact_id=cust)
+    fr = await client.post(f"/docs/{doc_id}/fulfill-lines", headers=auth["headers"],
+                           json={"line_entity_ids": [eid]})
+    assert fr.status_code == 200, fr.text
+
+    before = (await client.get("/items", headers=auth["headers"], params={"on_memo_to": cust})).json()
+    assert before["value_total"] == 700.0
+
+    # Customer returns 3, keeps 4.
+    rr = await client.post(f"/docs/{doc_id}/revert-lines", headers=auth["headers"],
+                           json={"line_entity_ids": [eid], "quantities": {eid: 3}})
+    assert rr.status_code == 200, rr.text
+    assert rr.json()["reverted"] == [], "the line is still out, so nothing was fully reverted"
+    (returned,) = rr.json()["partially_returned"]
+    assert returned["quantity"] == 3
+
+    # The 4 they kept are still out on memo, at the price they were quoted.
+    after = (await client.get("/items", headers=auth["headers"], params={"on_memo_to": cust})).json()
+    assert {i["id"] for i in after["items"]} == {eid}, "the balance must stay out with the customer"
+    (still_out,) = after["items"]
+    assert still_out["quantity"] == 4.0
+    assert still_out["status"] == "memo_out"
+    assert after["value_total"] == 400.0, "4 units still out at the quoted 100 each"
+
+    # The 3 that came back are in stock, and are not counted as still out.
+    returned_item = (await client.get(f"/items/{returned['item_id']}", headers=auth["headers"])).json()
+    assert returned_item["status"] == "available"
+    assert returned_item["quantity"] == 3.0
+    assert returned_item["id"] not in {i["id"] for i in after["items"]}
+
+
+@pytest.mark.asyncio
+async def test_full_quantity_revert_still_reverts_whole_line(client, session, auth, _setup_ids):
+    """Passing the whole quantity is the same as passing no quantity: a full revert,
+    with no stray split."""
+    cust = "contact:fullQtyMemo"
+    sku = f"FQ-{uuid.uuid4().hex[:6]}"
+    r = await client.post("/items", headers=auth["headers"],
+                          json={"sku": sku, "name": sku, "quantity": 5, "sell_by": "piece"})
+    eid = r.json()["id"]
+    doc_id = await _create_memo(client, auth, [
+        {"sku": sku, "name": sku, "quantity": 5, "unit_price": 10.0, "entity_id": eid},
+    ], contact_id=cust)
+    await client.post(f"/docs/{doc_id}/fulfill-lines", headers=auth["headers"],
+                      json={"line_entity_ids": [eid]})
+
+    rr = await client.post(f"/docs/{doc_id}/revert-lines", headers=auth["headers"],
+                           json={"line_entity_ids": [eid], "quantities": {eid: 5}})
+    assert rr.status_code == 200, rr.text
+    assert rr.json()["reverted"] == [eid]
+    assert rr.json()["partially_returned"] == []
+    item = (await client.get(f"/items/{eid}", headers=auth["headers"])).json()
+    assert item["status"] == "available" and item["quantity"] == 5.0
+    after = (await client.get("/items", headers=auth["headers"], params={"on_memo_to": cust})).json()
+    assert after["items"] == []
+
+
+@pytest.mark.asyncio
+async def test_partial_memo_return_rejects_more_than_went_out(client, session, auth, _setup_ids):
+    cust = "contact:overReturn"
+    sku = f"OR-{uuid.uuid4().hex[:6]}"
+    r = await client.post("/items", headers=auth["headers"],
+                          json={"sku": sku, "name": sku, "quantity": 2, "sell_by": "piece"})
+    eid = r.json()["id"]
+    doc_id = await _create_memo(client, auth, [
+        {"sku": sku, "name": sku, "quantity": 2, "unit_price": 10.0, "entity_id": eid},
+    ], contact_id=cust)
+    await client.post(f"/docs/{doc_id}/fulfill-lines", headers=auth["headers"],
+                      json={"line_entity_ids": [eid]})
+
+    rr = await client.post(f"/docs/{doc_id}/revert-lines", headers=auth["headers"],
+                           json={"line_entity_ids": [eid], "quantities": {eid: 5}})
+    assert rr.status_code == 422
+    for bad in (0, -1):
+        assert (await client.post(f"/docs/{doc_id}/revert-lines", headers=auth["headers"],
+                                  json={"line_entity_ids": [eid], "quantities": {eid: bad}})).status_code == 422
+    # Nothing moved.
+    item = (await client.get(f"/items/{eid}", headers=auth["headers"])).json()
+    assert item["status"] == "memo_out" and item["quantity"] == 2.0
+
+
+@pytest.mark.asyncio
+async def test_revert_lines_without_quantities_is_unchanged(client, session, auth, _setup_ids):
+    """The existing whole-line call shape keeps working untouched."""
+    cust = "contact:noQty"
+    sku = f"NQ-{uuid.uuid4().hex[:6]}"
+    r = await client.post("/items", headers=auth["headers"],
+                          json={"sku": sku, "name": sku, "quantity": 3, "sell_by": "piece"})
+    eid = r.json()["id"]
+    doc_id = await _create_memo(client, auth, [
+        {"sku": sku, "name": sku, "quantity": 3, "unit_price": 10.0, "entity_id": eid},
+    ], contact_id=cust)
+    await client.post(f"/docs/{doc_id}/fulfill-lines", headers=auth["headers"],
+                      json={"line_entity_ids": [eid]})
+
+    rr = await client.post(f"/docs/{doc_id}/revert-lines", headers=auth["headers"],
+                           json={"line_entity_ids": [eid]})
+    assert rr.status_code == 200, rr.text
+    assert rr.json()["reverted"] == [eid]
+    item = (await client.get(f"/items/{eid}", headers=auth["headers"])).json()
+    assert item["status"] == "available" and item["quantity"] == 3.0

--- a/tests/test_fulfillment.py
+++ b/tests/test_fulfillment.py
@@ -736,15 +736,18 @@ async def _create_consignment_in(client, auth, line_items) -> str:
 # ---------------------------------------------------------------------------
 
 
-async def _create_memo(client, auth, line_items) -> str:
+async def _create_memo(client, auth, line_items, contact_id=None) -> str:
     """Create a finalized memo document. line_items should include entity_id for linked items."""
     total = sum(li.get("quantity", 0) * li.get("unit_price", 0) for li in line_items)
-    r = await client.post("/docs", headers=auth["headers"], json={
+    payload = {
         "doc_type": "memo",
         "ref_id": f"MEMO-{uuid.uuid4().hex[:6]}",
         "line_items": line_items,
         "total": total,
-    })
+    }
+    if contact_id:
+        payload["contact_id"] = contact_id
+    r = await client.post("/docs", headers=auth["headers"], json=payload)
     assert r.status_code == 200, r.text
     doc_id = r.json()["id"]
     r2 = await client.post(f"/docs/{doc_id}/finalize", headers=auth["headers"])
@@ -1468,3 +1471,109 @@ async def test_fulfill_spans_across_lots_specific_id_cogs(client, session, auth,
     fulfilled = next((e for e in led if e.get("event_type") == "doc.fulfilled"), None)
     assert fulfilled is not None
     assert abs(float(fulfilled["data"].get("total_cogs", 0)) - 140.0) < 1e-6
+
+
+# ---------------------------------------------------------------------------
+# Contact-scoped holdings filter: items currently out on memo to a customer.
+# GET /items?on_memo_to=<contact_id> (celerp.services.holdings.memo_holdings).
+# ---------------------------------------------------------------------------
+
+
+async def _memo_out(client, auth, sku, unit_price, contact_id, cost_price=0.0, retail_price=None):
+    """Create an item, put it on memo to `contact_id` at `unit_price`, return its id."""
+    data = {"sku": sku, "name": sku, "quantity": 1, "sell_by": "piece"}
+    if cost_price:
+        data["cost_total"] = cost_price
+    if retail_price is not None:
+        data["retail_price"] = retail_price
+    r = await client.post("/items", headers=auth["headers"], json=data)
+    assert r.status_code == 200, r.text
+    eid = r.json()["id"]
+    doc_id = await _create_memo(
+        client, auth,
+        [{"sku": sku, "name": sku, "quantity": 1, "unit_price": unit_price, "entity_id": eid}],
+        contact_id=contact_id,
+    )
+    fr = await client.post(f"/docs/{doc_id}/fulfill-lines", headers=auth["headers"],
+                           json={"line_entity_ids": [eid]})
+    assert fr.status_code == 200, fr.text
+    return eid, doc_id
+
+
+@pytest.mark.asyncio
+async def test_items_on_memo_to_lists_outstanding_at_quoted_price(client, session, auth, _setup_ids):
+    cust = "contact:custA"
+    sku_a, sku_b = f"HOL-A-{uuid.uuid4().hex[:6]}", f"HOL-B-{uuid.uuid4().hex[:6]}"
+    eid_a, _ = await _memo_out(client, auth, sku_a, 500.0, cust)
+    eid_b, _ = await _memo_out(client, auth, sku_b, 750.0, cust)
+
+    resp = (await client.get("/items", headers=auth["headers"], params={"on_memo_to": cust})).json()
+    assert {i["id"] for i in resp["items"]} == {eid_a, eid_b}
+    assert {i["id"]: i["holding_value"] for i in resp["items"]} == {eid_a: 500.0, eid_b: 750.0}
+    assert resp["value_total"] == 1250.0
+
+
+@pytest.mark.asyncio
+async def test_items_on_memo_to_uses_quoted_override_not_catalog(client, session, auth, _setup_ids):
+    """The value is the price quoted on the memo line, never the item's catalog/retail price."""
+    cust = "contact:custOverride"
+    sku = f"HOL-OV-{uuid.uuid4().hex[:6]}"
+    # Catalog/retail says 1000, but the customer was quoted 800 on the memo.
+    eid, _ = await _memo_out(client, auth, sku, 800.0, cust, cost_price=400.0, retail_price=1000.0)
+
+    resp = (await client.get("/items", headers=auth["headers"], params={"on_memo_to": cust})).json()
+    assert resp["value_total"] == 800.0
+    (item,) = resp["items"]
+    assert item["holding_value"] == 800.0
+    # Prove it is genuinely the quoted price, not the catalog value carried on the item.
+    assert item.get("retail_price") in (1000.0, None) and item["holding_value"] != 1000.0
+
+
+@pytest.mark.asyncio
+async def test_items_on_memo_to_excludes_other_customer(client, session, auth, _setup_ids):
+    a, b = "contact:memoA", "contact:memoB"
+    eid_a, _ = await _memo_out(client, auth, f"HOL-CA-{uuid.uuid4().hex[:6]}", 100.0, a)
+    await _memo_out(client, auth, f"HOL-CB-{uuid.uuid4().hex[:6]}", 100.0, b)
+
+    resp = (await client.get("/items", headers=auth["headers"], params={"on_memo_to": a})).json()
+    assert {i["id"] for i in resp["items"]} == {eid_a}
+    assert resp["value_total"] == 100.0
+
+
+@pytest.mark.asyncio
+async def test_items_on_memo_to_excludes_returned_item(client, session, auth, _setup_ids):
+    cust = "contact:memoReturn"
+    eid, doc_id = await _memo_out(client, auth, f"HOL-R-{uuid.uuid4().hex[:6]}", 300.0, cust)
+    # Return the memo line: item goes back to available and drops out of the scope.
+    rr = await client.post(f"/docs/{doc_id}/revert-lines", headers=auth["headers"],
+                           json={"line_entity_ids": [eid]})
+    assert rr.status_code == 200, rr.text
+
+    resp = (await client.get("/items", headers=auth["headers"], params={"on_memo_to": cust})).json()
+    assert resp["items"] == []
+    assert resp["value_total"] == 0.0
+
+
+@pytest.mark.asyncio
+async def test_items_on_memo_to_aggregates_multiple_memos(client, session, auth, _setup_ids):
+    """The whole point of the feature: several open memos to one customer, one list + total."""
+    cust = "contact:memoMulti"
+    eid_1, _ = await _memo_out(client, auth, f"HOL-M1-{uuid.uuid4().hex[:6]}", 400.0, cust)
+    eid_2, _ = await _memo_out(client, auth, f"HOL-M2-{uuid.uuid4().hex[:6]}", 600.0, cust)  # separate memo doc
+
+    resp = (await client.get("/items", headers=auth["headers"], params={"on_memo_to": cust})).json()
+    assert {i["id"] for i in resp["items"]} == {eid_1, eid_2}
+    assert resp["value_total"] == 1000.0
+
+
+@pytest.mark.asyncio
+async def test_items_value_total_reconciles_with_listed_items(client, session, auth, _setup_ids):
+    """Keystone: value_total equals the sum of the per-item holding_value shown in the list."""
+    cust = "contact:memoRecon"
+    await _memo_out(client, auth, f"HOL-X1-{uuid.uuid4().hex[:6]}", 123.45, cust)
+    await _memo_out(client, auth, f"HOL-X2-{uuid.uuid4().hex[:6]}", 678.90, cust)
+
+    resp = (await client.get("/items", headers=auth["headers"],
+                             params={"on_memo_to": cust, "limit": 999})).json()
+    listed = round(sum(float(i["holding_value"]) for i in resp["items"]), 2)
+    assert resp["value_total"] == listed == 802.35

--- a/tests/test_fulfillment.py
+++ b/tests/test_fulfillment.py
@@ -1697,3 +1697,32 @@ async def test_revert_lines_without_quantities_is_unchanged(client, session, aut
     assert rr.json()["reverted"] == [eid]
     item = (await client.get(f"/items/{eid}", headers=auth["headers"])).json()
     assert item["status"] == "available" and item["quantity"] == 3.0
+
+
+@pytest.mark.asyncio
+async def test_convert_after_partial_memo_return_bills_only_what_was_kept(client, session, auth, _setup_ids):
+    """Converting a part-returned memo must invoice the balance the customer kept, not the
+    quantity that originally went out."""
+    cust = "contact:convertPartial"
+    sku = f"CP-{uuid.uuid4().hex[:6]}"
+    r = await client.post("/items", headers=auth["headers"],
+                          json={"sku": sku, "name": sku, "quantity": 10, "sell_by": "piece"})
+    eid = r.json()["id"]
+    doc_id = await _create_memo(client, auth, [
+        {"sku": sku, "name": sku, "quantity": 10, "unit_price": 50.0, "line_total": 500.0, "entity_id": eid},
+    ], contact_id=cust)
+    await client.post(f"/docs/{doc_id}/fulfill-lines", headers=auth["headers"],
+                      json={"line_entity_ids": [eid]})
+
+    # Customer sends back 6 and keeps 4.
+    rr = await client.post(f"/docs/{doc_id}/revert-lines", headers=auth["headers"],
+                           json={"line_entity_ids": [eid], "quantities": {eid: 6}})
+    assert rr.status_code == 200, rr.text
+
+    conv = await client.post(f"/docs/{doc_id}/convert", headers=auth["headers"])
+    assert conv.status_code == 200, conv.text
+    invoice = (await client.get(f"/docs/{conv.json()['target_doc_id']}", headers=auth["headers"])).json()
+    (inv_line,) = [li for li in invoice["line_items"]
+                   if (li.get("entity_id") or li.get("item_id")) == eid]
+    assert inv_line["quantity"] == 4.0, "must bill the 4 kept, not the 10 that went out"
+    assert inv_line["line_total"] == 200.0, "4 at 50 each"

--- a/tests/test_holdings.py
+++ b/tests/test_holdings.py
@@ -1,0 +1,106 @@
+# Copyright (c) 2026 Noah Severs
+# SPDX-License-Identifier: LicenseRef-Proprietary
+"""Unit tests for the contact-scoped holdings resolver (celerp.services.holdings).
+
+Pure functions over already-loaded (entity_id, state) rows, so no DB is needed.
+These pin the membership predicate and the value basis in isolation; the endpoint
+tests then layer the HTTP wiring on top.
+"""
+
+from __future__ import annotations
+
+from celerp.services.holdings import consignment_holdings, memo_holdings
+
+
+# --- memo (consignment out to a customer) -----------------------------------
+
+def test_memo_value_is_quoted_unit_price_times_remaining_qty():
+    items = [("item:1", {"status": "memo_out", "quantity": 2, "fulfilled_for_docs": ["doc:A"]})]
+    memo_docs = [("doc:A", {"line_items": [{"entity_id": "item:1", "unit_price": 100.0}]})]
+    assert memo_holdings(items, memo_docs) == {"item:1": 200.0}
+
+
+def test_memo_uses_quoted_override_not_catalog_price():
+    # The line was quoted at 90 even though the item's own catalog/retail is irrelevant here:
+    # the resolver reads the memo line, never the item's price fields.
+    items = [("item:1", {"status": "memo_out", "quantity": 1, "fulfilled_for_docs": ["doc:A"],
+                          "retail_price": 130.0})]
+    memo_docs = [("doc:A", {"line_items": [{"entity_id": "item:1", "unit_price": 90.0}]})]
+    assert memo_holdings(items, memo_docs) == {"item:1": 90.0}
+
+
+def test_memo_falls_back_to_line_total_when_no_unit_price():
+    items = [("item:1", {"status": "memo_out", "quantity": 3, "fulfilled_for_docs": ["doc:A"]})]
+    memo_docs = [("doc:A", {"line_items": [{"item_id": "item:1", "line_total": 150.0}]})]
+    assert memo_holdings(items, memo_docs) == {"item:1": 150.0}
+
+
+def test_memo_excludes_returned_item():
+    # Reverted memo line: status back to available, doc dropped from fulfilled_for_docs.
+    items = [("item:1", {"status": "available", "quantity": 1, "fulfilled_for_docs": []})]
+    memo_docs = [("doc:A", {"line_items": [{"entity_id": "item:1", "unit_price": 100.0}]})]
+    assert memo_holdings(items, memo_docs) == {}
+
+
+def test_memo_excludes_item_out_to_a_different_customer():
+    # item is memo_out, but its doc is not among THIS customer's memo docs.
+    items = [("item:1", {"status": "memo_out", "quantity": 1, "fulfilled_for_docs": ["doc:OTHER"]})]
+    memo_docs = [("doc:A", {"line_items": [{"entity_id": "item:1", "unit_price": 100.0}]})]
+    assert memo_holdings(items, memo_docs) == {}
+
+
+def test_memo_aggregates_across_multiple_memos_to_same_customer():
+    items = [
+        ("item:1", {"status": "memo_out", "quantity": 1, "fulfilled_for_docs": ["doc:A"]}),
+        ("item:2", {"status": "memo_out", "quantity": 1, "fulfilled_for_docs": ["doc:B"]}),
+    ]
+    memo_docs = [
+        ("doc:A", {"line_items": [{"entity_id": "item:1", "unit_price": 100.0}]}),
+        ("doc:B", {"line_items": [{"entity_id": "item:2", "unit_price": 250.0}]}),
+    ]
+    assert memo_holdings(items, memo_docs) == {"item:1": 100.0, "item:2": 250.0}
+
+
+def test_memo_resolves_current_doc_when_item_reappears_in_two_docs():
+    # item:1 was on memo to this customer twice (doc:A then doc:B); only doc:B is live
+    # (in fulfilled_for_docs). The value must come from doc:B's line, not doc:A's.
+    items = [("item:1", {"status": "memo_out", "quantity": 1, "fulfilled_for_docs": ["doc:B"]})]
+    memo_docs = [
+        ("doc:A", {"line_items": [{"entity_id": "item:1", "unit_price": 100.0}]}),
+        ("doc:B", {"line_items": [{"entity_id": "item:1", "unit_price": 175.0}]}),
+    ]
+    assert memo_holdings(items, memo_docs) == {"item:1": 175.0}
+
+
+# --- consignment (consignment in from a supplier) ---------------------------
+
+def test_consignment_value_is_item_cost():
+    items = [("item:1", {"consignment_flag": "in", "cost_total": 400.0})]
+    docs = [("doc:C", {"received_item_ids": ["item:1"]})]
+    assert consignment_holdings(items, docs) == {"item:1": 400.0}
+
+
+def test_consignment_cost_from_unit_when_no_cost_total():
+    items = [("item:1", {"consignment_flag": "in", "cost_price": 50.0, "quantity": 3})]
+    docs = [("doc:C", {"received_item_ids": ["item:1"]})]
+    assert consignment_holdings(items, docs) == {"item:1": 150.0}
+
+
+def test_consignment_excludes_returned_item_flag_cleared():
+    # Fully returned to supplier: flag cleared to None, still listed in received_item_ids.
+    items = [("item:1", {"consignment_flag": None, "cost_total": 400.0})]
+    docs = [("doc:C", {"received_item_ids": ["item:1"]})]
+    assert consignment_holdings(items, docs) == {}
+
+
+def test_consignment_excludes_owned_inventory():
+    # Owned item (no consignment flag) even if some doc lists it.
+    items = [("item:1", {"cost_total": 400.0})]
+    docs = [("doc:C", {"received_item_ids": ["item:1"]})]
+    assert consignment_holdings(items, docs) == {}
+
+
+def test_consignment_excludes_item_from_a_different_supplier():
+    items = [("item:1", {"consignment_flag": "in", "cost_total": 400.0})]
+    docs = [("doc:C", {"received_item_ids": ["item:OTHER"]})]
+    assert consignment_holdings(items, docs) == {}

--- a/tests/test_routers/test_doc_workflows.py
+++ b/tests/test_routers/test_doc_workflows.py
@@ -383,7 +383,7 @@ async def test_po_receive_quotation_convert_and_credit_note_adjustment(client, s
         headers=_h(token),
         json={"doc_type": "quotation", "contact_id": "contact:1", "line_items": [], "subtotal": 0, "tax": 0, "total": 0, "valid_until": "2000-01-01"},
     )
-    assert (await client.post(f"/docs/{expired.json()["id"]}/convert", headers=_h(token))).status_code == 409
+    assert (await client.post(f"/docs/{expired.json()['id']}/convert", headers=_h(token))).status_code == 409
 
     # credit note adjusts source invoice outstanding
     inv = await _create_invoice(client, token, subtotal=100, tax=0, total=100)

--- a/tests/test_routers/test_holdings_filter.py
+++ b/tests/test_routers/test_holdings_filter.py
@@ -1,0 +1,140 @@
+# Copyright (c) 2026 Noah Severs
+# SPDX-License-Identifier: LicenseRef-Proprietary
+"""Endpoint tests for the consignment-in side of the contact-scoped holdings filter.
+
+GET /items?consigned_from=<supplier_contact_id> lists items still held on
+consignment from that supplier, valued at cost (celerp.services.holdings).
+
+The memo side (GET /items?on_memo_to=...) is covered in tests/test_fulfillment.py,
+where the memo create/fulfil helpers already live. These live in their own file
+(rather than test_doc_workflows.py) so they collect under every supported Python.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+
+async def _register(client) -> str:
+    addr = f"admin-{uuid.uuid4().hex[:8]}@holdings.test"
+    r = await client.post("/auth/register",
+                          json={"company_name": "Holdings Co", "email": addr, "name": "Admin", "password": "pw"})
+    assert r.status_code == 200, r.text
+    return r.json()["access_token"]
+
+
+def _h(token: str) -> dict:
+    return {"Authorization": f"Bearer {token}"}
+
+
+async def _create_location(client, token: str) -> str:
+    r = await client.post("/companies/me/locations", headers=_h(token),
+                          json={"name": "Warehouse", "type": "warehouse", "is_default": True})
+    assert r.status_code == 200, r.text
+    return r.json()["id"]
+
+
+async def _consign_in_received(client, token, location_id, supplier, sku, qty=1, cost_price=250.0):
+    """Create + finalize + receive a consignment_in doc; return (doc_id, created_item_id)."""
+    total = cost_price * qty
+    r = await client.post("/docs", headers=_h(token), json={
+        "doc_type": "consignment_in", "contact_id": supplier,
+        "line_items": [{"sku": sku, "name": sku, "quantity": qty, "unit_price": cost_price, "line_total": total}],
+        "subtotal": total, "tax": 0, "total": total,
+    })
+    assert r.status_code == 200, r.text
+    doc_id = r.json()["id"]
+    await client.post("/docs/{}/finalize".format(doc_id), headers=_h(token))
+    rec = await client.post("/docs/{}/receive".format(doc_id), headers=_h(token), json={
+        "location_id": location_id,
+        "received_items": [{"po_line_index": 0, "sku": sku, "name": sku,
+                            "quantity_received": qty, "cost_price": cost_price, "receive_as": "stock"}],
+    })
+    assert rec.status_code == 200, rec.text
+    doc = (await client.get("/docs/{}".format(doc_id), headers=_h(token))).json()
+    return doc_id, doc["line_items"][0]["entity_id"]
+
+
+@pytest.mark.asyncio
+async def test_items_consigned_from_lists_held_at_cost(client, session):
+    token = await _register(client)
+    location_id = await _create_location(client, token)
+    supplier = "contact:supHold"
+    _doc, item_id = await _consign_in_received(client, token, location_id, supplier,
+                                               "CIN-HOLD-1", cost_price=250.0)
+
+    resp = (await client.get("/items", headers=_h(token), params={"consigned_from": supplier})).json()
+    assert {i["id"] for i in resp["items"]} == {item_id}
+    assert resp["items"][0]["holding_value"] == 250.0
+    assert resp["value_total"] == 250.0
+
+
+@pytest.mark.asyncio
+async def test_items_consigned_from_excludes_returned(client, session):
+    token = await _register(client)
+    location_id = await _create_location(client, token)
+    supplier = "contact:supReturn"
+    doc_id, item_id = await _consign_in_received(client, token, location_id, supplier,
+                                                 "CIN-RET-1", qty=1, cost_price=250.0)
+    # Return the full quantity to the supplier -> consignment_flag clears -> out of scope.
+    rr = await client.post("/docs/{}/return-items".format(doc_id), headers=_h(token),
+                           json={"items": [{"item_id": item_id, "quantity_returned": 1}]})
+    assert rr.status_code == 200, rr.text
+
+    resp = (await client.get("/items", headers=_h(token), params={"consigned_from": supplier})).json()
+    assert resp["items"] == []
+    assert resp["value_total"] == 0.0
+
+
+@pytest.mark.asyncio
+async def test_items_consigned_from_excludes_owned_and_other_supplier(client, session):
+    token = await _register(client)
+    location_id = await _create_location(client, token)
+    sup_a, sup_b = "contact:supA", "contact:supB"
+    _da, item_a = await _consign_in_received(client, token, location_id, sup_a, "CIN-A-1", cost_price=100.0)
+    await _consign_in_received(client, token, location_id, sup_b, "CIN-B-1", cost_price=999.0)
+    # Owned (non-consignment) inventory must never appear under a consignment scope.
+    owned = await client.post("/items", headers=_h(token),
+                              json={"sku": "OWNED-1", "name": "Owned", "quantity": 1,
+                                    "sell_by": "piece", "cost_total": 50.0})
+    assert owned.status_code == 200, owned.text
+
+    resp = (await client.get("/items", headers=_h(token), params={"consigned_from": sup_a})).json()
+    assert {i["id"] for i in resp["items"]} == {item_a}
+    assert resp["value_total"] == 100.0
+
+
+@pytest.mark.asyncio
+async def test_items_consigned_from_partial_return_keeps_item_in_scope(client, session):
+    """A partial return leaves the balance on consignment: the item stays in scope with
+    consignment_flag still "in", and only the returned quantity leaves the shelf.
+
+    Value note: cost_total is the lot's purchase cost and is deliberately not rescaled by
+    a quantity adjustment (see _recompute_cost - only per-unit landed cost scales), so the
+    holding value of a partially returned lot still reflects the lot cost. That is existing
+    system-wide cost behaviour, not something this scope introduces; it is asserted here so
+    the behaviour is pinned rather than assumed.
+    """
+    token = await _register(client)
+    location_id = await _create_location(client, token)
+    supplier = "contact:supPartial"
+    doc_id, item_id = await _consign_in_received(client, token, location_id, supplier,
+                                                 "CIN-PART-1", qty=2, cost_price=125.0)
+    before = (await client.get("/items", headers=_h(token), params={"consigned_from": supplier})).json()
+    assert before["value_total"] == 250.0
+
+    rr = await client.post("/docs/{}/return-items".format(doc_id), headers=_h(token),
+                           json={"items": [{"item_id": item_id, "quantity_returned": 1}]})
+    assert rr.status_code == 200, rr.text
+
+    after = (await client.get("/items", headers=_h(token), params={"consigned_from": supplier})).json()
+    assert {i["id"] for i in after["items"]} == {item_id}, "partial return must keep the balance in scope"
+    (item,) = after["items"]
+    assert item["quantity"] == 1.0
+    assert item["consignment_flag"] == "in", "flag must persist while a balance remains"
+    # Card and list still agree, whatever the basis.
+    assert after["value_total"] == item["holding_value"]
+    # Pinned: the lot cost is not rescaled by the quantity adjustment (see docstring).
+    assert after["value_total"] == 250.0

--- a/tests/test_routers/test_holdings_filter.py
+++ b/tests/test_routers/test_holdings_filter.py
@@ -109,13 +109,12 @@ async def test_items_consigned_from_excludes_owned_and_other_supplier(client, se
 @pytest.mark.asyncio
 async def test_items_consigned_from_partial_return_keeps_item_in_scope(client, session):
     """A partial return leaves the balance on consignment: the item stays in scope with
-    consignment_flag still "in", and only the returned quantity leaves the shelf.
+    consignment_flag still "in", only the returned quantity leaves the shelf, and the
+    value steps down with it.
 
-    Value note: cost_total is the lot's purchase cost and is deliberately not rescaled by
-    a quantity adjustment (see _recompute_cost - only per-unit landed cost scales), so the
-    holding value of a partially returned lot still reflects the lot cost. That is existing
-    system-wide cost behaviour, not something this scope introduces; it is asserted here so
-    the behaviour is pinned rather than assumed.
+    A partial return reduces quantity in place (unlike partial fulfillment, it does not
+    split off a child), so the goods cost has to be rescaled with it or the remaining
+    balance would keep carrying the whole lot's cost.
     """
     token = await _register(client)
     location_id = await _create_location(client, token)
@@ -136,5 +135,9 @@ async def test_items_consigned_from_partial_return_keeps_item_in_scope(client, s
     assert item["consignment_flag"] == "in", "flag must persist while a balance remains"
     # Card and list still agree, whatever the basis.
     assert after["value_total"] == item["holding_value"]
-    # Pinned: the lot cost is not rescaled by the quantity adjustment (see docstring).
-    assert after["value_total"] == 250.0
+    # 1 of 2 units returned, so half the lot cost went back with them.
+    assert after["value_total"] == 125.0
+    # The quantity left on the lot is the record of how much was kept, and per-unit cost
+    # is unchanged by the return: a lot is homogeneous, so scaling the lot cost with the
+    # quantity is what a split would have produced anyway.
+    assert item["cost_price"] == 125.0, "per-unit cost must survive a partial return"

--- a/tests/test_routers/test_holdings_filter.py
+++ b/tests/test_routers/test_holdings_filter.py
@@ -141,3 +141,35 @@ async def test_items_consigned_from_partial_return_keeps_item_in_scope(client, s
     # is unchanged by the return: a lot is homogeneous, so scaling the lot cost with the
     # quantity is what a split would have produced anyway.
     assert item["cost_price"] == 125.0, "per-unit cost must survive a partial return"
+
+
+@pytest.mark.asyncio
+async def test_return_items_rejects_goods_not_on_hand(client, session):
+    """Goods out with a customer cannot be handed back to a supplier: they are not on our
+    shelf, and shrinking them here would write off stock still owed back to us."""
+    token = await _register(client)
+    location_id = await _create_location(client, token)
+    supplier = "contact:supNotOnHand"
+    doc_id, item_id = await _consign_in_received(client, token, location_id, supplier,
+                                                 "CIN-OUT-1", qty=2, cost_price=100.0)
+    # Send the consigned goods out on memo to a customer.
+    memo = await client.post("/docs", headers=_h(token), json={
+        "doc_type": "memo", "contact_id": "contact:cust1",
+        "line_items": [{"sku": "CIN-OUT-1", "name": "CIN-OUT-1", "quantity": 2,
+                        "unit_price": 200.0, "line_total": 400.0, "entity_id": item_id}],
+        "subtotal": 400, "tax": 0, "total": 400,
+    })
+    assert memo.status_code == 200, memo.text
+    memo_id = memo.json()["id"]
+    await client.post("/docs/{}/finalize".format(memo_id), headers=_h(token))
+    ff = await client.post("/docs/{}/fulfill-lines".format(memo_id), headers=_h(token),
+                           json={"line_entity_ids": [item_id]})
+    assert ff.status_code == 200, ff.text
+
+    rr = await client.post("/docs/{}/return-items".format(doc_id), headers=_h(token),
+                           json={"items": [{"item_id": item_id, "quantity_returned": 1}]})
+    assert rr.status_code == 409, rr.text
+    assert "not on hand" in str(rr.json().get("detail", ""))
+    # Untouched: still out with the customer at full quantity.
+    item = (await client.get("/items/{}".format(item_id), headers=_h(token))).json()
+    assert item["status"] == "memo_out" and item["quantity"] == 2.0

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -1031,6 +1031,63 @@ class TestInventoryPage:
         assert b"Ruby" in r.content
 
     @pytest.mark.asyncio
+    async def test_inventory_on_memo_scope_shows_quoted_value(self, ui_client):
+        """Landing from the contact card: the scope is passed to the API, the banner names
+        the basis, and the per-row value is the quoted price (not the catalog price)."""
+        captured: dict = {}
+
+        async def _fake_list_items(token, params=None):
+            captured.update(params or {})
+            return {"items": [{**_ITEM, "holding_value": 4200.0}], "total": 1, "value_total": 4200.0}
+
+        with (
+            patch("ui.api_client.get_item_schema", new=AsyncMock(return_value=_SCHEMA)),
+            patch("ui.api_client.list_items", new=AsyncMock(side_effect=_fake_list_items)),
+            patch("ui.api_client.get_valuation", new=AsyncMock(return_value=_VALUATION)),
+            patch("ui.api_client.get_company", new=AsyncMock(return_value=_COMPANY)),
+        ):
+            r = await ui_client.get("/inventory?on_memo_to=ct:1", cookies=_authed())
+        assert r.status_code == 200
+        assert captured.get("on_memo_to") == "ct:1", "scope must reach the API call"
+        body = r.content
+        assert b"Out on memo to this customer" in body
+        assert b"price quoted to the customer" in body
+        assert b"4,200.00" in body
+
+    @pytest.mark.asyncio
+    async def test_inventory_consigned_scope_shows_cost_basis(self, ui_client):
+        captured: dict = {}
+
+        async def _fake_list_items(token, params=None):
+            captured.update(params or {})
+            return {"items": [{**_ITEM, "holding_value": 1750.5}], "total": 1, "value_total": 1750.5}
+
+        with (
+            patch("ui.api_client.get_item_schema", new=AsyncMock(return_value=_SCHEMA)),
+            patch("ui.api_client.list_items", new=AsyncMock(side_effect=_fake_list_items)),
+            patch("ui.api_client.get_valuation", new=AsyncMock(return_value=_VALUATION)),
+            patch("ui.api_client.get_company", new=AsyncMock(return_value=_COMPANY)),
+        ):
+            r = await ui_client.get("/inventory?consigned_from=ct:9", cookies=_authed())
+        assert r.status_code == 200
+        assert captured.get("consigned_from") == "ct:9"
+        assert b"Held on consignment from this supplier" in r.content
+        assert b"1,750.50" in r.content
+
+    @pytest.mark.asyncio
+    async def test_inventory_unscoped_has_no_holdings_banner(self, ui_client):
+        """The banner and the scope column appear only under a contact scope."""
+        with (
+            patch("ui.api_client.get_item_schema", new=AsyncMock(return_value=_SCHEMA)),
+            patch("ui.api_client.list_items", new=AsyncMock(return_value={"items": [_ITEM], "total": 1})),
+            patch("ui.api_client.get_valuation", new=AsyncMock(return_value=_VALUATION)),
+            patch("ui.api_client.get_company", new=AsyncMock(return_value=_COMPANY)),
+        ):
+            r = await ui_client.get("/inventory", cookies=_authed())
+        assert r.status_code == 200
+        assert b"holdings-scope-banner" not in r.content
+
+    @pytest.mark.asyncio
     async def test_inventory_empty_values_show_double_dash(self, ui_client):
         """Empty cell values must render as '--' not '-' or blank."""
         item_empty = {"entity_id": "gc:999", "name": "", "status": "", "total_cost": ""}
@@ -1122,6 +1179,50 @@ class TestCRMPage:
             r = await ui_client.get("/contacts/ct:1", cookies=_authed())
         assert r.status_code == 200
         assert b"Alice" in r.content
+
+    @pytest.mark.asyncio
+    async def test_contact_detail_holdings_cards(self, ui_client):
+        """On Memo / Consignment cards show the live holdings value and link to that
+        exact filtered inventory list, so the number and the list cannot disagree."""
+        contact = {**_CONTACTS[0], "contact_type": "both"}
+
+        async def _fake_list_items(token, params=None):
+            params = params or {}
+            if params.get("on_memo_to"):
+                return {"items": [], "total": 0, "value_total": 4200.0}
+            if params.get("consigned_from"):
+                return {"items": [], "total": 0, "value_total": 1750.5}
+            return {"items": [], "total": 0}
+
+        with (
+            patch("ui.api_client.get_contact", new=AsyncMock(return_value=contact)),
+            patch("ui.api_client.list_contact_docs", new=AsyncMock(return_value={"items": [], "total": 0})),
+            patch("ui.api_client.list_items", new=AsyncMock(side_effect=_fake_list_items)),
+        ):
+            r = await ui_client.get("/contacts/ct:1", cookies=_authed())
+        assert r.status_code == 200
+        body = r.content
+        assert b"On Memo" in body
+        assert b"4,200.00" in body and b"1,750.50" in body
+        assert b"/inventory?on_memo_to=ct:1" in body
+        assert b"/inventory?consigned_from=ct:1" in body
+
+    @pytest.mark.asyncio
+    async def test_contact_detail_holdings_unavailable_falls_back(self, ui_client):
+        """When the holdings figure cannot be fetched the page still renders, and the
+        Consignment card falls back to the document-derived total."""
+        contact = {**_CONTACTS[0], "contact_type": "vendor"}
+        docs = [{"doc_type": "consignment_in", "status": "received", "total_amount": 900.0}]
+        with (
+            patch("ui.api_client.get_contact", new=AsyncMock(return_value=contact)),
+            patch("ui.api_client.list_contact_docs", new=AsyncMock(return_value={"items": docs, "total": 1})),
+            patch("ui.api_client.list_items", new=AsyncMock(side_effect=RuntimeError("api down"))),
+        ):
+            r = await ui_client.get("/contacts/ct:1", cookies=_authed())
+        assert r.status_code == 200
+        assert b"900.00" in r.content
+        # Falls back to the document list, not a broken holdings link.
+        assert b"/docs?type=consignment_in" in r.content
 
     @pytest.mark.asyncio
     async def test_crm_empty_values_show_double_dash(self, ui_client):

--- a/ui/api_client.py
+++ b/ui/api_client.py
@@ -742,9 +742,15 @@ async def fulfill_lines(token: str, entity_id: str, line_entity_ids: list[str]) 
         return _raise(await c.post(f"/docs/{entity_id}/fulfill-lines", json={"line_entity_ids": line_entity_ids})).json()
 
 
-async def unfulfill_lines(token: str, entity_id: str, line_entity_ids: list[str]) -> dict:
+async def unfulfill_lines(token: str, entity_id: str, line_entity_ids: list[str],
+                          quantities: dict[str, float] | None = None) -> dict:
+    """Revert whole lines, or pass quantities={item_id: qty_coming_back} to take back only
+    part of a lot; the remainder stays out with the customer."""
+    payload: dict = {"line_entity_ids": line_entity_ids}
+    if quantities:
+        payload["quantities"] = quantities
     async with _api_client(token) as c:
-        return _raise(await c.post(f"/docs/{entity_id}/revert-lines", json={"line_entity_ids": line_entity_ids})).json()
+        return _raise(await c.post(f"/docs/{entity_id}/revert-lines", json=payload)).json()
 
 
 async def receive_return(token: str, entity_id: str, items: list[dict], notes: str | None = None) -> dict:

--- a/ui/routes/contacts.py
+++ b/ui/routes/contacts.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import asyncio as _asyncio
 import json as _json
 import logging
 from datetime import date, datetime, timezone as _tz
@@ -243,8 +244,17 @@ def _settings_card(c: dict) -> FT:
     )
 
 
-def _financial_summary(docs: list[dict], contact_id: str = "", fiscal_year_start: str = "01-01") -> FT:
-    """Compute and render financial summary cards from contact docs."""
+def _financial_summary(docs: list[dict], contact_id: str = "", fiscal_year_start: str = "01-01",
+                       consigned_total: float | None = None, on_memo_total: float | None = None) -> FT:
+    """Compute and render financial summary cards from contact docs.
+
+    consigned_total / on_memo_total are the live value of goods currently held on
+    consignment from this supplier (at cost) and currently out on memo to this customer
+    (at the price they were quoted). Both come from the contact-scoped holdings filter,
+    so each card's number is the value of the very list it links to. None means the
+    figure was unavailable (e.g. the caller could not reach the API, or costs are
+    hidden from this role), and the card falls back to the document-derived total.
+    """
     from ui.routes.reports import _fy_start
     today = date.today()
     # Reuse the canonical parser: it falls back to Jan 1 on a malformed
@@ -270,12 +280,17 @@ def _financial_summary(docs: list[dict], contact_id: str = "", fiscal_year_start
                 pass
     avg_dtp = f"{sum(days) // len(days)}d" if days else EMPTY
 
-    # Consignment total (active consignments for this contact)
-    consignment_docs = [d for d in docs if d.get("doc_type") == "consignment_in"]
-    total_consigned = sum(
-        float(d.get("total_amount") or 0) for d in consignment_docs
-        if d.get("status") not in ("void", "converted")
-    )
+    # Consignment: value of goods still held from this supplier. Prefer the live holdings
+    # figure (the value of the items the card links to); fall back to the document totals
+    # when it is unavailable, which reads as the original consigned value.
+    if consigned_total is None:
+        consignment_docs = [d for d in docs if d.get("doc_type") == "consignment_in"]
+        total_consigned = sum(
+            float(d.get("total_amount") or 0) for d in consignment_docs
+            if d.get("status") not in ("void", "converted")
+        )
+    else:
+        total_consigned = consigned_total
 
     def _card(label: str, value: str, sub_label: str = "", href: str = "") -> FT:
         label_el = Div(
@@ -299,8 +314,15 @@ def _financial_summary(docs: list[dict], contact_id: str = "", fiscal_year_start
         _card("Outstanding", fmt_money(outstanding, None),
               href=f"/docs?type=invoice&status=awaiting_payment{contact_filter}" if contact_id else ""),
         _card("Avg Days to Pay", avg_dtp),
+        # An unavailable figure shows as EMPTY rather than 0.00, which would wrongly read
+        # as "this customer is holding nothing of ours".
+        _card("On Memo", fmt_money(on_memo_total, None) if on_memo_total is not None else EMPTY,
+              sub_label="Out to customer",
+              href=f"/inventory?on_memo_to={contact_id}" if (contact_id and on_memo_total is not None) else ""),
         _card("Consignment", fmt_money(total_consigned, None),
-              href=f"/docs?type=consignment_in{contact_filter}" if contact_id else ""),
+              sub_label="Held from supplier" if consigned_total is not None else "",
+              href=(f"/inventory?consigned_from={contact_id}" if (contact_id and consigned_total is not None)
+                    else (f"/docs?type=consignment_in{contact_filter}" if contact_id else ""))),
         cls="financial-cards",
     )
 
@@ -775,7 +797,9 @@ async def build_contact_detail(contact: dict, docs: list, vocab: list, company: 
                          contact_id: str = "", show_financials: bool = True, show_delete: bool = True,
                          show_contact_addresses: bool = True, extra_sections: list | None = None,
                          back: tuple | None = None, nav_active: str | None = None,
-                         title: str | None = None) -> FT:
+                         title: str | None = None,
+                         consigned_total: float | None = None,
+                         on_memo_total: float | None = None) -> FT:
     """Shared assembly for the contact detail page. The Company Details page reuses this verbatim with
     show_financials=False / show_delete=False / show_contact_addresses=False (the company is its own
     customer+vendor self-contact, and it has no financial-summary-against-itself) - one page layout, no
@@ -837,7 +861,9 @@ async def build_contact_detail(contact: dict, docs: list, vocab: list, company: 
         autofocus_script,
         action_bar,
         delete_btn,
-        *([_financial_summary(docs, contact_id=cid, fiscal_year_start=fiscal_year_start)] if show_financials else []),
+        *([_financial_summary(docs, contact_id=cid, fiscal_year_start=fiscal_year_start,
+                              consigned_total=consigned_total, on_memo_total=on_memo_total)]
+          if show_financials else []),
         Div(
             Div(
                 _contact_info_card(contact),
@@ -1147,7 +1173,23 @@ def setup_routes(app):
         except Exception:
             company = {}
 
-        return await build_contact_detail(contact, docs, vocab, company, request, contact_id=contact_id)
+        # Live holdings behind the On Memo / Consignment cards. limit=1 because only the
+        # scope-wide value_total is needed here; the full list is the click-through.
+        # None (API unreachable, or costs hidden from this role) makes the card degrade
+        # rather than assert a wrong figure.
+        async def _holdings_total(param: str) -> float | None:
+            try:
+                resp = await api.list_items(token, {param: contact_id, "limit": 1})
+            except Exception:
+                return None
+            return resp.get("value_total") if isinstance(resp, dict) else None
+
+        on_memo_total, consigned_total = await _asyncio.gather(
+            _holdings_total("on_memo_to"), _holdings_total("consigned_from"),
+        )
+
+        return await build_contact_detail(contact, docs, vocab, company, request, contact_id=contact_id,
+                                          on_memo_total=on_memo_total, consigned_total=consigned_total)
 
     # ── Company Details (Finance) ─────────────────────────────────────────
     # The company is its own customer+vendor self-contact, so this page is the same contact-detail

--- a/ui/routes/documents.py
+++ b/ui/routes/documents.py
@@ -3424,10 +3424,21 @@ celerpUpdateBulkAlloc();
         token = _token(request)
         if not token:
             return _R("", status_code=401, headers={"HX-Redirect": "/login"})
+        import re as _re_qty
         form = await request.form()
         line_entity_ids = list(form.getlist("selected"))
+        # qty[<entity_id>] marks a line where only part of the lot is coming back.
+        quantities: dict[str, float] = {}
+        for key, value in form.multi_items():
+            m = _re_qty.match(r"qty\[(.+)\]$", key)
+            if not m or not str(value).strip():
+                continue
+            try:
+                quantities[m.group(1)] = float(value)
+            except (TypeError, ValueError):
+                return _action_error(f"Invalid returned quantity for {m.group(1)}")
         try:
-            await api.unfulfill_lines(token, entity_id, line_entity_ids)
+            await api.unfulfill_lines(token, entity_id, line_entity_ids, quantities=quantities or None)
         except APIError as e:
             if e.status == 401:
                 return _R("", status_code=401, headers={"HX-Redirect": "/login"})
@@ -5394,7 +5405,7 @@ def _li_bulk_toolbar(entity_id: str, is_list: bool, labels_only: bool = False, s
                     hx_post=f"/docs/{entity_id}/revert-lines",
                     hx_swap="none",
                     hx_confirm=f"{_revert_label}?",
-                    onsubmit="return submitLiBulkAction(this)",
+                    onsubmit="return submitLiRevertAction(this)",
                 ),
             ]
     return Div(
@@ -6161,7 +6172,12 @@ def _doc_detail(doc: dict, locations: list | None = None, ledger: list | None = 
             if pol["counting"]:
                 _desc_cell = Td(li.get("description") or li.get("name") or "--", cls="col-desc")
             cells = [
-                Td(Input(type="checkbox", cls="li-select", value=li_entity_id), cls="col-checkbox li-checkbox-cell"),
+                # data-* carries what the line currently has out, so a revert can offer to take
+                # back part of it instead of writing the whole lot off as returned.
+                Td(Input(type="checkbox", cls="li-select", value=li_entity_id,
+                         **{"data-item-status": str((item_status_map or {}).get(li_entity_id, "")),
+                            "data-out-qty": f"{float(li.get('quantity') or 0):g}"}),
+                   cls="col-checkbox li-checkbox-cell"),
                 Td(_static_ident_cell_content(li) if pol["counting"]
                    else _sku_input(li.get("sku", "") or "", li_entity_id, li.get("barcode", "") or ""),
                    cls="col-sku"),
@@ -7654,6 +7670,25 @@ async function celerpCsvImport(input, entityId) {{
       var inp=document.createElement('input');inp.type='hidden';inp.name='selected';inp.value=cb.value;
       formEl.appendChild(inp);
     }});
+    return true;
+  }};
+  // Revert: when a single memo line is selected, offer to take back part of it. Anything
+  // not returned stays out with the customer instead of being written off as back in stock.
+  window.submitLiRevertAction=function(formEl){{
+    formEl.querySelectorAll('input[name^="qty["]').forEach(function(el){{el.remove();}});
+    if(!submitLiBulkAction(formEl)) return false;
+    var checked=table?Array.prototype.slice.call(table.querySelectorAll('.li-select:checked')):[];
+    if(checked.length!==1) return true;
+    var cb=checked[0];
+    var outQty=parseFloat(cb.getAttribute('data-out-qty')||'0');
+    if(cb.getAttribute('data-item-status')!=='memo_out'||!(outQty>1)) return true;
+    var answer=window.prompt('How many are coming back? Leave as '+outQty+' to take back all of it. Anything less stays out with the customer.',String(outQty));
+    if(answer===null) return false;
+    var qty=parseFloat(answer);
+    if(!(qty>0)||qty>outQty){{ alert('Enter a quantity between 0 and '+outQty+'.'); return false; }}
+    if(qty===outQty) return true;
+    var inp=document.createElement('input');inp.type='hidden';inp.name='qty['+cb.value+']';inp.value=String(qty);
+    formEl.appendChild(inp);
     return true;
   }};
 }})();

--- a/ui/routes/inventory.py
+++ b/ui/routes/inventory.py
@@ -371,6 +371,10 @@ def _parse_params(request: Request) -> dict:
         "location_id": q.get("location_id", ""),  # column-filter funnel (csv of location ids)
         "source": q.get("source", ""),  # connector source filter (e.g. ?source=shopify)
         "filter": q.get("filter", ""),  # semantic filter (e.g. ?filter=low_stock)
+        # Contact-scoped holdings: goods out on memo to a customer, or held on
+        # consignment from a supplier. Backs the contact page's On Memo / Consignment cards.
+        "on_memo_to": q.get("on_memo_to", ""),
+        "consigned_from": q.get("consigned_from", ""),
         # Category-attribute column funnels: every ?attr.<key>=csv pair, keyed by <key>.
         "attr_filters": {k[len("attr."):]: v for k, v in q.items() if k.startswith("attr.") and v},
         "sort": q.get("sort", ""),
@@ -382,7 +386,8 @@ def _parse_params(request: Request) -> dict:
 
 def _base_state(p: dict, include_page: bool = False) -> dict:
     state = {}
-    for k in ("q", "skus", "status", "category", "inventory_type", "location_id", "source", "filter", "sort", "dir"):
+    for k in ("q", "skus", "status", "category", "inventory_type", "location_id", "source", "filter",
+              "on_memo_to", "consigned_from", "sort", "dir"):
         if p.get(k):
             state[k] = p[k]
     for akey, aval in (p.get("attr_filters") or {}).items():
@@ -395,6 +400,32 @@ def _base_state(p: dict, include_page: bool = False) -> dict:
     if include_page and p.get("page", 1) > 1:
         state["page"] = str(p["page"])
     return state
+
+
+def _holdings_scope_banner(p: dict, holdings_total: float | None, currency: str | None) -> FT:
+    """Banner for the contact-scoped holdings views, with a way back to all inventory.
+
+    Under a scope the Value column is not the catalog price: for memo it is the price the
+    customer was quoted, for consignment it is what the goods cost us. Say so, so the
+    figure is never read as a list price.
+    """
+    from ui.components.table import fmt_money
+
+    on_memo, consigned = p.get("on_memo_to", ""), p.get("consigned_from", "")
+    if not (on_memo or consigned):
+        return ""
+    if on_memo:
+        label, basis = "Out on memo to this customer", "Value shown is the price quoted to the customer."
+    else:
+        label, basis = "Held on consignment from this supplier", "Value shown is cost."
+    total_el = (Span(fmt_money(holdings_total, currency), cls="holdings-scope-total")
+                if holdings_total is not None else "")
+    return Div(
+        Div(Span(label, cls="holdings-scope-label"), total_el, cls="holdings-scope-heading"),
+        Div(basis, cls="holdings-scope-basis"),
+        A("Clear filter", href="/inventory", cls="btn btn--xs btn--secondary"),
+        cls="holdings-scope-banner",
+    )
 
 
 def _inventory_column_filters(eff_schema: list[dict], global_schema: list[dict], locations: list[dict],
@@ -462,6 +493,10 @@ async def _inventory_content(
             params["source"] = p["source"]
         if p.get("filter"):
             params["filter"] = p["filter"]
+        if p.get("on_memo_to"):
+            params["on_memo_to"] = p["on_memo_to"]
+        if p.get("consigned_from"):
+            params["consigned_from"] = p["consigned_from"]
         for akey, aval in (p.get("attr_filters") or {}).items():
             if aval:
                 params[f"attr.{akey}"] = aval
@@ -477,6 +512,8 @@ async def _inventory_content(
         # valuation's unfiltered item_count — otherwise a search shows pages that don't exist
         # and clicking them lands on a blank page.
         list_total = items_resp.get("total", len(items))
+        # Present only under a contact holdings scope: the value of the whole scoped set.
+        holdings_total = items_resp.get("value_total")
         attribute_facets = items_resp.get("attribute_facets", {})
         unit_names: list[str] = [u["name"] for u in units_resp if u.get("name")]
         units_map: dict[str, dict] = {u["name"]: u for u in units_resp if u.get("name")}
@@ -487,6 +524,7 @@ async def _inventory_content(
     except APIError:
         valuation, items, unit_names, units_map, category_label_map, attribute_facets = {}, [], [], {}, {}, {}
         list_total = 0
+        holdings_total = None
 
     currency = company.get("currency")
     vertical = company.get("settings", {}).get("vertical", "") if isinstance(company.get("settings"), dict) else ""
@@ -503,7 +541,27 @@ async def _inventory_content(
         else f
         for f in eff_schema
     ]
+    # Under a contact holdings scope the meaningful per-row value is the scope value the
+    # total is summed from (quoted memo price / consignment cost), not the catalog price.
+    # Surface it as a read-only column so the rows visibly add up to the banner figure.
+    scope_value_label = ""
+    if p.get("on_memo_to"):
+        scope_value_label = "Quoted"
+    elif p.get("consigned_from"):
+        scope_value_label = "Cost"
+    if scope_value_label and any(i.get("holding_value") is not None for i in items):
+        eff_schema = eff_schema + [{
+            "key": "holding_value", "label": scope_value_label, "type": "money",
+            "editable": False, "required": False, "options": [], "visible_to_roles": [],
+            "position": 99, "show_in_table": True,
+        }]
+    else:
+        scope_value_label = ""
+
     visible_cols = _resolve_visible_cols(eff_schema, col_prefs, active_cat, p.get("cols") or [])
+    if scope_value_label and "holding_value" not in visible_cols:
+        # Saved column prefs predate this column, so make sure the scope value is shown.
+        visible_cols = visible_cols + ["holding_value"]
     # Inject resolved cols into URL state so sort links and pagination always carry
     # the exact column set being rendered, even when it came from col_prefs not URL params.
     p_with_cols = {**p, "cols": visible_cols}
@@ -511,6 +569,7 @@ async def _inventory_content(
     total_items = valuation.get("item_count", 0)
 
     return Div(
+        _holdings_scope_banner(p, holdings_total, currency),
         _category_tabs(category_counts, p, total_scoped=total_scoped, label_map=category_label_map),
         _inventory_type_tabs(p),
         _valuation_bar(valuation, currency, lang, status=p.get("status", "")),

--- a/ui/static/app.css
+++ b/ui/static/app.css
@@ -1918,6 +1918,13 @@ option.unit-unknown-option { color: var(--c-red, #ef4444); font-style: italic; }
 .financial-card--link { text-decoration: none; color: inherit; cursor: pointer; }
 .financial-card--link:hover { background: var(--c-bg-hover, #f0f0f0); }
 .financial-card-value { font-size: 1.3rem; font-weight: 700; margin-top: 0.25rem; }
+/* Contact-scoped holdings view (inventory filtered to one contact's memo / consignment goods). */
+.holdings-scope-banner { display: flex; align-items: center; gap: 1rem; flex-wrap: wrap; border: 1px solid var(--c-border); border-left: 3px solid var(--c-primary); border-radius: var(--radius); padding: 0.6rem 0.9rem; margin-bottom: 1rem; background: var(--c-bg-alt, #f8f9fa); }
+.holdings-scope-heading { display: flex; align-items: baseline; gap: 0.6rem; }
+.holdings-scope-label { font-weight: 600; }
+.holdings-scope-total { font-size: 1.15rem; font-weight: 700; }
+.holdings-scope-basis { font-size: 0.8rem; color: var(--c-text-muted); margin-right: auto; }
+
 .section-card { margin-bottom: 1.5rem; }
 /* Contact Info / Settings cards: inset the header + table so they aren't flush against the card border. */
 .detail-card.section-card { padding: 12px 14px; }


### PR DESCRIPTION
Closes #243.

## What this adds

Two questions that previously meant opening memo and consignment documents one at a time:

- **What does this customer still have of ours on memo?** Consolidated across however many open memos they have.
- **What are we still holding on consignment from this supplier?**

The contact page gains an **On Memo** card and computes the existing **Consignment** card from live stock. Each shows what is outstanding right now and links straight to the inventory list filtered to exactly those items.

Backed by two parameters on the item list:

```
GET /items?on_memo_to=<contact_id>
GET /items?consigned_from=<contact_id>
```

## Value basis

The two directions are valued differently, and the view labels which is which:

- **On memo** is valued at the price quoted to the customer on the memo line, which can differ from the catalogue price.
- **Consignment** is valued at cost, and honours `view_inventory_costs` like every other cost figure.

The list endpoint returns a per-item value and a total over the whole scoped set, and the contact card reads that same total. The number on the card is therefore, by construction, the value of the list it opens.

## Returning part of a memo

Alongside the view, `revert-lines` now accepts `quantities={item_id: qty_coming_back}` so a customer can send back part of what they hold. Anything less than the whole lot splits the returned amount off as its own in-stock parcel and leaves the remainder out on memo, so the balance stays visible and billable. This mirrors fulfillment, which already splits when only part of a parcel goes out.

Omitting `quantities`, or passing the whole quantity, is the previous whole-line revert, unchanged. The document page prompts for the quantity when a single memo line is reverted. Partial returns apply to goods out on memo; taking back part of a sale goes through a credit note, which has its own path.

## Supporting changes

Each is its own commit, separate from the feature.

- Registers the `doc.items_returned` schema so supplier returns record end to end, plus a guard test asserting every `EventType` member has an emit schema.
- Carries `consignment_flag` through the `item.quantity.adjusted` reducer, so a lot returned in full to its supplier is no longer counted as still held. Applied only when present, leaving ordinary stock adjustments untouched.
- Scales a lot's goods cost with a partial supplier return, keeping per-unit cost constant, which is the same result splitting the lot would give. Returns do not post journal entries, so this affects the item's cost and the valuation read from it, not the ledger.
- Converting a memo carries the quantity still out with the customer, so an invoice raised after a partial return reflects the current balance. Line totals scale, so per-line discounts survive.
- Supplier returns validate that goods are on hand before recording, and point to bringing them back into stock first if not.

## Goods-movement consistency

Every document endpoint that moves goods was reviewed against one rule: goods arriving as a distinct parcel need a split or a creation, goods leaving entirely can reduce in place. Receive and receive-return create parcels, fulfill and revert split, and return-items reduces in place, which suits units that leave the building. The undo paths require every affected item to be untouched. The last two supporting changes above came out of that review.

One item is left for a considered fix rather than a quick one: `return-items` does not verify that an item came from the document being returned against. Enforcing that naively would block splitting a received lot by hand and returning the offcut, so it needs parentage tracing through splits.

## Python 3.10

The package declares support for 3.10, and the suite now runs there. One test module used a nested same-quote f-string, which the parser accepts only from 3.12, and `test_config.py` imported `tomllib` directly, which is stdlib from 3.11; it now falls back to `tomli` exactly as `celerp.config` does.

## Testing

New coverage spans the resolver in isolation, both endpoint directions, the partial return flow, and the UI.

Membership is pinned from both ends: items out to another customer, returned, sold, owned rather than consigned, or from a different supplier are all asserted excluded, and multiple memos to one customer are asserted to consolidate. A dedicated test proves a quoted price that differs from the catalogue price is the figure that shows and totals. Others assert the card total always equals the sum of the rows shown, that a partial return leaves the balance out with the customer at the quoted value while the returned part re-enters stock, that converting afterwards bills the balance, and that per-unit cost survives a partial return.

The full suite passes locally on Python 3.10 and 3.12.
