### PR TITLE
fix: Attachment ownership, bulk toolbar visibility, toast headers, and module permission keys

### DIFF
--- a/celerp/modules/loader.py
+++ b/celerp/modules/loader.py
@@ -46,6 +46,7 @@ from celerp.modules.importer import PREMIUM_MARKER
 from celerp.modules.license import check_license, exchange_api_key_for_jwt, is_premium_path
 from celerp.modules.meta import META_FILENAME
 from celerp.modules.slots import register as register_slot
+from celerp.services.permissions import is_permission_key
 
 log = logging.getLogger(__name__)
 
@@ -751,6 +752,27 @@ def _load_one(pkg_path: Path, pkg_name: str, *, trusted: bool = False) -> dict |
                 f"AI API instead:\n"
                 f"  {_MODULE_AI_API_URL}"
             )
+
+    # A slot item naming a permission key outside the registry would KeyError in
+    # the sidebar builder on every page render, taking the whole UI down for
+    # every user. Refuse the module here, with the bad key named, instead.
+    for slot_name, contribution in (manifest.get("slots") or {}).items():
+        items = contribution if isinstance(contribution, list) else [contribution]
+        for item in items:
+            perm = item.get("permission") if isinstance(item, dict) else None
+            if perm and not is_permission_key(perm):
+                log.error(
+                    "Module %r rejected: slot %r names unknown permission key %r",
+                    pkg_name, slot_name, perm,
+                )
+                for key in list(sys.modules.keys()):
+                    if key == pkg_name or key.startswith(pkg_name + "."):
+                        sys.modules.pop(key, None)
+                raise ModuleLoadError(
+                    f"Slot {slot_name!r} names unknown permission key {perm!r}. "
+                    f"Permission keys come from Celerp's own registry; pick the "
+                    f"closest existing key."
+                )
 
     # Register extension slots
     for slot_name, contribution in (manifest.get("slots") or {}).items():

--- a/celerp/services/permissions.py
+++ b/celerp/services/permissions.py
@@ -85,6 +85,13 @@ PERMISSIONS: list[Permission] = [
 _PERMISSIONS_BY_KEY: dict[str, Permission] = {p.key: p for p in PERMISSIONS}
 
 
+def is_permission_key(key: str) -> bool:
+    """True when *key* is in the closed permission registry. Gating surfaces
+    index the registry directly, so anything naming a key from outside core
+    (a module manifest) must be checked here before it reaches them."""
+    return key in _PERMISSIONS_BY_KEY
+
+
 def permission_min_level(settings: dict | None, key: str) -> int:
     """Resolve the minimum role level for *key*: override if valid, else default.
 

--- a/default_modules/celerp-accounting/tests/report_goldens/extended-journal.html
+++ b/default_modules/celerp-accounting/tests/report_goldens/extended-journal.html
@@ -40,6 +40,7 @@
     var t=table(bar);if(!t)return;var b=visBoxes(t),n=b.filter(function(c){return c.checked}).length;
     var cnt=bar.querySelector('.bulk-count');
     if(cnt)cnt.textContent=(bar.getAttribute('data-count-label')||'{n} selected').replace('{n}',n);
+    bar.classList.toggle('is-active',n>0);
     var clr=bar.querySelector('.bulk-clear');if(clr)clr.style.visibility=n>0?'visible':'hidden';
     if(n===0)closeFields(bar);
     var all=t.querySelector('thead .bulk-select-all');if(all){all.checked=n>0&&n===b.length;all.indeterminate=n>0&&n<b.length;}

--- a/default_modules/celerp-accounting/tests/report_goldens/journal.html
+++ b/default_modules/celerp-accounting/tests/report_goldens/journal.html
@@ -40,6 +40,7 @@
     var t=table(bar);if(!t)return;var b=visBoxes(t),n=b.filter(function(c){return c.checked}).length;
     var cnt=bar.querySelector('.bulk-count');
     if(cnt)cnt.textContent=(bar.getAttribute('data-count-label')||'{n} selected').replace('{n}',n);
+    bar.classList.toggle('is-active',n>0);
     var clr=bar.querySelector('.bulk-clear');if(clr)clr.style.visibility=n>0?'visible':'hidden';
     if(n===0)closeFields(bar);
     var all=t.querySelector('thead .bulk-select-all');if(all){all.checked=n>0&&n===b.length;all.indeterminate=n>0&&n<b.length;}

--- a/default_modules/first_party.lock.json
+++ b/default_modules/first_party.lock.json
@@ -1,5 +1,5 @@
 {
-  "celerp-accounting": "d7ad35aaa3ee2362b9d6f5d3b6bd985684f6a4370790c35826337c9fa68a7d24",
+  "celerp-accounting": "1c70a793ef46eabcd44360073611df87cd0eff6e469140b764055e3bb52e1fd5",
   "celerp-admin": "7ea2ccb71eec922eb083e0f7d6e66cfa9a9b73d12756a79ac3bcdc3ea1455ba1",
   "celerp-ai": "091f6662d97bde48d9cfbdd47350746199c419e93537f197b1ea36042bb8aa7b",
   "celerp-backup": "06edbb17ac0cd8d3444094faab156b2b0551f6cc86584e34b41791be1fb35704",

--- a/tests/test_browser/test_manual_journal_entry.py
+++ b/tests/test_browser/test_manual_journal_entry.py
@@ -234,6 +234,10 @@ def test_manual_je_fx_journey_converts_per_line_and_refuses_to_plug(
         "a refused entry comes back with what was typed, not an empty form"
 
     # The author writes the difference line themselves, in the company currency.
+    # A refusal re-renders the whole page, and the script that builds a new row is
+    # parsed after the button that calls it, so the refusal text being on screen
+    # does not yet mean the button does anything. Wait for the parse to finish.
+    page.wait_for_load_state("domcontentloaded")
     page.click('button:has-text("Add line")')
     _pick_account(page, 4, "6960")
     _clear_currency(page, 4)

--- a/tests/test_module_load_errors.py
+++ b/tests/test_module_load_errors.py
@@ -28,6 +28,14 @@ NEEDS_MISSING_DEP = '''PLUGIN_MANIFEST = {
 }
 '''
 
+BAD_PERMISSION = '''PLUGIN_MANIFEST = {
+    "name": "bad-perm",
+    "version": "1.0.0",
+    "slots": {"nav": [{"key": "bp", "label": "Bad Perm", "href": "/bp",
+                       "permission": "manage_equipment"}]},
+}
+'''
+
 
 def _mk(dirpath: Path, name: str, init_src: str) -> None:
     pkg = dirpath / name
@@ -94,6 +102,20 @@ def test_load_errors_are_recorded(tmp_path):
     assert "needs-dep" in errs and "not-installed" in errs["needs-dep"]
     # the good module carries no error
     assert "ok-module" not in errs
+
+
+def test_unknown_permission_key_is_refused(tmp_path):
+    """A nav entry naming a permission key outside the registry would KeyError
+    inside the sidebar builder on every page render, taking the whole UI down.
+    The loader refuses the module at load with the key named instead."""
+    _mk(tmp_path, "bad-perm", BAD_PERMISSION)
+    loaded = load_all(tmp_path, {"bad-perm"})
+    assert not any(m["name"] == "bad-perm" for m in loaded)
+    errs = load_errors()
+    assert "bad-perm" in errs and "manage_equipment" in errs["bad-perm"]
+
+    from celerp.modules.slots import get as get_slot
+    assert not any(item.get("_module") == "bad-perm" for item in get_slot("nav"))
 
 
 def test_errors_cleared_between_runs(tmp_path):

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -17670,3 +17670,29 @@ class TestBulkToolbarHidesUntilSelection:
         import ui
         css = (Path(ui.__file__).parent / "static" / "app.css").read_text()
         assert ".bulkbar:not(.is-active)" in css
+
+
+class TestToastHeader:
+    """One helper builds the HX-Trigger header the shell's toast listener reads."""
+
+    def test_message_and_kind(self):
+        import json as _j
+        from ui.components.shell import toast_header
+        h = toast_header("Saved.", "success")
+        assert _j.loads(h["HX-Trigger"]) == {
+            "celerpToast": {"message": "Saved.", "type": "success"}}
+
+    def test_persist_flag(self):
+        import json as _j
+        from ui.components.shell import toast_header
+        payload = _j.loads(toast_header("Read me.", "info", persist=True)["HX-Trigger"])
+        assert payload["celerpToast"]["persist"] is True
+
+    def test_extra_triggers_ride_along(self):
+        """A response can pair the toast with another client event in one header."""
+        import json as _j
+        from ui.components.shell import toast_header
+        payload = _j.loads(
+            toast_header("No.", "error", celerpRestoreCell=True)["HX-Trigger"])
+        assert payload["celerpRestoreCell"] is True
+        assert payload["celerpToast"]["message"] == "No."

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -17647,3 +17647,26 @@ class TestAttachmentProxyCompanyBoundary:
         assert r.status_code in (302, 303)
         assert "/login" in r.headers.get("location", "")
         assert calls == []
+
+
+class TestBulkToolbarHidesUntilSelection:
+    """The shared bulk toolbar stays out of the way until rows are ticked,
+    the way inventory's bespoke bar always has."""
+
+    def test_bar_renders_without_is_active(self):
+        from fasthtml.common import to_xml
+        from ui.components.table import bulk_toolbar
+        html = to_xml(bulk_toolbar("t1", [
+            {"value": "go", "label": "Go", "method": "post", "url": "/x"}]))
+        assert 'class="bulkbar bulk-action-bar"' in html
+
+    def test_toolbar_js_reveals_on_selection(self):
+        from ui.components.table import BULK_TOOLBAR_JS
+        assert "classList.toggle('is-active'" in BULK_TOOLBAR_JS
+
+    def test_css_hides_inactive_bar(self):
+        from pathlib import Path
+
+        import ui
+        css = (Path(ui.__file__).parent / "static" / "app.css").read_text()
+        assert ".bulkbar:not(.is-active)" in css

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -33,6 +33,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from ui.routes.csv_import import _load_csv, MAPPING_ATTRIBUTE, MAPPING_SKIP
 from ui.routes.inventory import _IMPORT_SPEC, _CORE_ITEM_COLS
 from test_helpers import make_test_token, authed_cookies
+from ui.config import API_BASE as _API_BASE
 
 
 # ── Fixtures ──────────────────────────────────────────────────────────────────
@@ -10529,13 +10530,16 @@ class TestInventoryItemDetailFixes:
     @pytest.mark.asyncio
     async def test_attachment_proxy_route(self, ui_client):
         """GET /static/attachments/... proxies to API instead of serving from UI static dir."""
-        import httpx
-        mock_response = httpx.Response(200, content=b"fake-image-bytes", headers={"content-type": "image/jpeg"})
-        with patch("httpx.AsyncClient.get", new=AsyncMock(return_value=mock_response)):
-            r = await ui_client.get("/static/attachments/comp1/att1.jpg")
+        patcher, calls = _api_get_mock()
+        with patcher:
+            r = await ui_client.get(
+                f"/static/attachments/{_TEST_COMPANY}/att1.jpg",
+                cookies=_authed(),
+            )
         assert r.status_code == 200
         assert r.content == b"fake-image-bytes"
         assert "image/jpeg" in r.headers.get("content-type", "")
+        assert calls == [f"{_API_BASE}/static/attachments/{_TEST_COMPANY}/att1.jpg"]
 
     @pytest.mark.asyncio
     async def test_actions_panel_removed(self, ui_client):
@@ -17573,3 +17577,73 @@ class TestSharedCellUrlsAndDates:
                                      aria_label="Location"))
         assert 'aria-label="Location"' in combo
         assert "combobox-input" in combo
+
+
+# ── Attachment proxy: company boundary ────────────────────────────────────────
+
+_TEST_COMPANY = "00000000-0000-0000-0000-000000000002"
+_OTHER_COMPANY = "00000000-0000-0000-0000-000000000009"
+
+
+def _api_get_mock(content: bytes = b"fake-image-bytes", content_type: str = "image/jpeg"):
+    """Patch httpx so ONLY the proxy's outbound API call is faked.
+
+    The test client is itself an httpx.AsyncClient, so patching the class method
+    outright answers the test's own request and the app never runs. Dispatch on
+    the API base URL instead, and record outbound calls so a test can assert the
+    proxy never reached the API at all.
+    """
+    import httpx
+    from ui.config import API_BASE
+
+    original = httpx.AsyncClient.get
+    calls: list[str] = []
+
+    async def _dispatch(self, url, *args, **kwargs):
+        if str(url).startswith(API_BASE):
+            calls.append(str(url))
+            return httpx.Response(200, content=content, headers={"content-type": content_type})
+        return await original(self, url, *args, **kwargs)
+
+    return patch("httpx.AsyncClient.get", new=_dispatch), calls
+
+
+class TestAttachmentProxyCompanyBoundary:
+    """The attachment proxy serves only the caller's own company's files."""
+
+    @pytest.mark.asyncio
+    async def test_rejects_other_company_attachment(self, ui_client):
+        """A file under another company id is not found, and the API is never called."""
+        patcher, calls = _api_get_mock()
+        with patcher:
+            r = await ui_client.get(
+                f"/static/attachments/{_OTHER_COMPANY}/att1.jpg",
+                cookies=_authed(),
+            )
+        assert r.status_code == 404
+        assert calls == []
+
+    @pytest.mark.asyncio
+    async def test_rejects_traversal_out_of_own_company(self, ui_client):
+        """A path that starts in the caller's company then climbs out is rejected."""
+        patcher, calls = _api_get_mock()
+        with patcher:
+            r = await ui_client.get(
+                f"/static/attachments/{_TEST_COMPANY}/../{_OTHER_COMPANY}/att1.jpg",
+                cookies=_authed(),
+            )
+        assert r.status_code == 404
+        assert calls == []
+
+    @pytest.mark.asyncio
+    async def test_undecodable_token_goes_to_login(self, ui_client):
+        """A cookie with no readable company claim is an unusable session, not a pass."""
+        patcher, calls = _api_get_mock()
+        with patcher:
+            r = await ui_client.get(
+                f"/static/attachments/{_TEST_COMPANY}/att1.jpg",
+                cookies={"celerp_token": "not-a-jwt"},
+            )
+        assert r.status_code in (302, 303)
+        assert "/login" in r.headers.get("location", "")
+        assert calls == []

--- a/ui/app.py
+++ b/ui/app.py
@@ -336,9 +336,20 @@ _static_dir = os.path.join(os.path.dirname(__file__), "static")
 async def proxy_attachment(request: Request, path: str) -> Response:
     if not request.cookies.get(COOKIE_NAME):
         return RedirectResponse("/login", status_code=302)
-    from ui.config import API_BASE
+    from ui.config import API_BASE, get_company_id
     import httpx
-    url = f"{API_BASE}/static/attachments/{path}"
+    company_id = get_company_id(request)
+    if not company_id:
+        # Cookie present but no readable company claim: the session is unusable.
+        return RedirectResponse("/login", status_code=302)
+    # LocalBackend.store writes /static/attachments/<company_id>/<file>, so the
+    # first segment is the owning company. Anything outside it belongs to another
+    # tenant and does not exist as far as this caller is concerned. Rejecting '..'
+    # stops a path that starts inside the company folder and then climbs out.
+    segments = [s for s in path.split("/") if s not in ("", ".")]
+    if ".." in segments or not segments or segments[0] != company_id:
+        return Response(status_code=404)
+    url = f"{API_BASE}/static/attachments/{'/'.join(segments)}"
     async with httpx.AsyncClient() as c:
         r = await c.get(url)
     return Response(content=r.content, media_type=r.headers.get("content-type", "application/octet-stream"), status_code=r.status_code)

--- a/ui/components/journal.py
+++ b/ui/components/journal.py
@@ -23,6 +23,7 @@ from celerp.services.money import EXCHANGE_RATE_DP, to_decimal
 from ui.components.report_kit import (
     fname_date, fx_line_amounts, href, je_source_label, period_subtitle,
 )
+from ui.components.shell import toast_header
 from ui.components.table import EMPTY, bulk_toolbar, fmt_money
 from ui.i18n import t
 
@@ -278,7 +279,7 @@ def journal_bulk_toolbar(params: dict, carried: dict, *, items: bool = False) ->
 
 
 def journal_void_toast(result: dict) -> dict:
-    """What to tell the reader after a void, read from the API's own answer.
+    """The toast header to send after a void, read from the API's own answer.
 
     Both void paths report through here, so one entry and forty are described the
     same way. Refusals are stated with the count and the API's own words for why,
@@ -297,7 +298,7 @@ def journal_void_toast(result: dict) -> dict:
         reasons = " ".join(dict.fromkeys(
             str(r.get("detail") or "").strip() for r in refused if r.get("detail")))
         message = f"{message} {t('acct.bulk_void_refused', n=len(refused), reasons=reasons)}"
-    return {"message": message.strip(), "type": "error" if refused else "success"}
+    return toast_header(message.strip(), "error" if refused else "success")
 
 
 def _entry_cells(row: dict, has_fx: bool) -> list:

--- a/ui/components/shell.py
+++ b/ui/components/shell.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import hashlib
+import json
 import os
 from pathlib import Path
 from urllib.parse import parse_qs, urlencode, urlparse
@@ -1573,6 +1574,16 @@ def auth_shell(*content, title: str = "Celerp") -> FT:
 def flash(msg: str, kind: str = "error", raw: bool = False) -> FT:
     content = NotStr(msg) if raw else msg
     return Div(content, cls=f"flash flash--{kind}", id="flash")
+
+
+def toast_header(message: str, kind: str = "success", *, persist: bool = False,
+                 **extra_triggers) -> dict:
+    """HX-Trigger header for the shell's celerpToast listener. Extra keyword
+    arguments become sibling client events fired from the same header."""
+    toast: dict = {"message": message, "type": kind}
+    if persist:
+        toast["persist"] = True
+    return {"HX-Trigger": json.dumps({"celerpToast": toast, **extra_triggers})}
 
 
 # Reload the page once the server is reachable again after a restart. The first poll

--- a/ui/components/table.py
+++ b/ui/components/table.py
@@ -143,6 +143,7 @@ BULK_TOOLBAR_JS = """
     var t=table(bar);if(!t)return;var b=visBoxes(t),n=b.filter(function(c){return c.checked}).length;
     var cnt=bar.querySelector('.bulk-count');
     if(cnt)cnt.textContent=(bar.getAttribute('data-count-label')||'{n} selected').replace('{n}',n);
+    bar.classList.toggle('is-active',n>0);
     var clr=bar.querySelector('.bulk-clear');if(clr)clr.style.visibility=n>0?'visible':'hidden';
     if(n===0)closeFields(bar);
     var all=t.querySelector('thead .bulk-select-all');if(all){all.checked=n>0&&n===b.length;all.indeterminate=n>0&&n<b.length;}
@@ -210,6 +211,8 @@ BULK_TOOLBAR_JS = """
 
 def bulk_toolbar(table_id: str, actions: list[dict], fields: list | None = None) -> FT:
     """Standard bulk-action toolbar: [N selected] [Action ▾] [Clear] [fields…].
+    Hidden until at least one row is ticked (the JS toggles `is-active`), so the
+    action list appears only when there is a selection for it to act on.
     actions: [{value, label, method('post'|'open'), url, confirm?, target?, swap?}].
     POST actions submit the selected ids (name='selected') via htmx; 'open' actions open
     url?ids=<csv> in a new tab. Pair with `.bulk-select` row checkboxes + a `.bulk-select-all`

--- a/ui/config.py
+++ b/ui/config.py
@@ -31,67 +31,58 @@ def cookie_domain(request) -> str | None:
     return host
 
 
-def get_role(request) -> str:
-    """Decode the role claim from the JWT cookie without signature verification.
+def get_claims(request) -> dict:
+    """Decode the JWT cookie payload without signature verification.
 
-    Returns the role string (e.g. 'viewer', 'operator', 'manager', 'admin', 'owner').
-    Falls back to 'viewer' (least privilege) on any decode error.
+    The API is the enforcement point for every claim; the UI reads them only to
+    shape what it renders and which company's files it will fetch. Returns an
+    empty dict when there is no cookie or the payload will not decode, so every
+    caller's own fallback is the least-privilege one.
     """
     import base64
     import json as _json
 
-    from celerp.services.auth import _ROLE_MIGRATION
-
     token = get_token(request)
     if not token:
-        return "viewer"
+        return {}
     try:
         payload_b64 = token.split(".")[1]
         payload_bytes = base64.urlsafe_b64decode(payload_b64 + "=" * (-len(payload_b64) % 4))
         claims = _json.loads(payload_bytes)
-        raw_role = claims.get("role", "viewer")
-        return _ROLE_MIGRATION.get(raw_role, raw_role)
+        return claims if isinstance(claims, dict) else {}
     except Exception:
-        return "viewer"
+        return {}
+
+
+def get_role(request) -> str:
+    """Return the role claim (e.g. 'viewer', 'operator', 'manager', 'admin', 'owner').
+
+    Falls back to 'viewer' (least privilege) when the claim is absent or unreadable.
+    """
+    from celerp.services.auth import _ROLE_MIGRATION
+
+    raw_role = get_claims(request).get("role", "viewer")
+    return _ROLE_MIGRATION.get(raw_role, raw_role)
 
 
 def get_user_email(request) -> str | None:
-    """Decode the 'sub' (email) claim from the JWT cookie without signature verification."""
-    import base64
-    import json as _json
+    """Return the email claim, or None when it is absent or unreadable."""
+    return get_claims(request).get("email") or None
 
-    token = get_token(request)
-    if not token:
-        return None
-    try:
-        payload_b64 = token.split(".")[1]
-        payload_bytes = base64.urlsafe_b64decode(payload_b64 + "=" * (-len(payload_b64) % 4))
-        claims = _json.loads(payload_bytes)
-        return claims.get("email") or None
-    except Exception:
-        return None
+
+def get_company_id(request) -> str | None:
+    """Return the company_id claim, or None when it is absent or unreadable."""
+    company_id = get_claims(request).get("company_id")
+    return str(company_id) if company_id else None
 
 
 def get_enabled_modules(request) -> set[str]:
-    """Decode the 'modules' claim from the JWT cookie without signature verification.
+    """Return the set of enabled module names for the current company.
 
-    Returns the set of enabled module names for the current company.
-    Returns empty set on any decode error or missing claim (shows all nav items as fallback).
+    Empty set when the claim is absent or unreadable (shows all nav items as fallback).
     """
-    import base64
-    import json as _json
-
-    token = get_token(request)
-    if not token:
-        return set()
-    try:
-        payload_b64 = token.split(".")[1]
-        payload_bytes = base64.urlsafe_b64decode(payload_b64 + "=" * (-len(payload_b64) % 4))
-        claims = _json.loads(payload_bytes)
-        raw = claims.get("modules", [])
-        return set(raw) if isinstance(raw, list) else set()
-    except Exception:
-        return set()
+    raw = get_claims(request).get("modules", [])
+    return set(raw) if isinstance(raw, list) else set()
 
 
 async def get_relay_info(request) -> dict:

--- a/ui/routes/account.py
+++ b/ui/routes/account.py
@@ -30,6 +30,7 @@ from starlette.responses import HTMLResponse, Response
 
 import ui.api_client as api
 from ui.api_client import APIError
+from ui.components.shell import toast_header
 from ui.config import PRIVACY_POLICY_URL, get_role as _get_role
 from ui.i18n import t, get_lang
 from ui.routes.settings import _token
@@ -445,8 +446,7 @@ def setup_routes(app):
             # opens instead of swapping in silence.
             return HTMLResponse(
                 to_xml(Div(id=panel_id)),
-                headers={"HX-Trigger": json.dumps({"celerpToast": {
-                    "message": t("account.admin_only", lang), "type": "info"}})})
+                headers=toast_header(t("account.admin_only", lang), "info"))
         intent = request.query_params.get("intent", "signup")
         next_action = _next_from(request.query_params.get("next"))
         google, quota = False, 0

--- a/ui/routes/accounting.py
+++ b/ui/routes/accounting.py
@@ -349,7 +349,7 @@ def setup_routes(app):
             clear_href=_href(base, carried))
         return HTMLResponse(
             to_xml(table) + to_xml(totals),
-            headers={"HX-Trigger": _json.dumps({"celerpToast": journal_void_toast(result)})},
+            headers=journal_void_toast(result),
         )
 
     @app.post("/accounting/journal/bulk-void")

--- a/ui/routes/auth.py
+++ b/ui/routes/auth.py
@@ -24,7 +24,7 @@ from ui.api_client import APIError, bootstrap_status
 from ui.api_client import login as api_login, login_force as api_login_force, logout as api_logout, register as api_register
 from ui.api_client import my_companies as api_my_companies
 from ui.api_client import get_company as api_get_company
-from ui.components.shell import auth_shell, flash, star_supporter_card
+from ui.components.shell import auth_shell, flash, star_supporter_card, toast_header
 from ui.config import COOKIE_NAME, REFRESH_COOKIE_NAME, cookie_domain
 from ui.i18n import t, get_lang
 from celerp.config import settings as _settings
@@ -504,8 +504,7 @@ def setup_routes(app):
             if is_htmx:
                 msg = ("To reset your password, open a terminal on this machine and run: "
                        "celerp reset-password --email you@example.com")
-                return Response("", headers={"HX-Trigger": json.dumps(
-                    {"celerpToast": {"message": msg, "type": "info", "persist": True}})})
+                return Response("", headers=toast_header(msg, "info", persist=True))
             # Direct URL entry with no JS: send back to login (the link there toasts).
             return RedirectResponse("/login", status_code=302)
         if is_htmx:

--- a/ui/routes/documents.py
+++ b/ui/routes/documents.py
@@ -14,7 +14,7 @@ from urllib.parse import quote_plus, urlencode
 import ui.api_client as api
 from ui.api_client import APIError
 from celerp.services.line_measures import identifier_backfill, item_measure_meta, line_identifier, measure_locks, measure_sublines, qty_label, resolve_line_measures
-from ui.components.shell import base_shell, page_header
+from ui.components.shell import base_shell, page_header, toast_header
 from ui.components.table import search_bar, EMPTY, pagination, searchable_select, breadcrumbs, status_cards, empty_state_cta, fmt_money, fmt_rate, format_value, currency_symbol, unwrap_address, col_resize_script, bank_account_options as _bank_account_options
 from celerp.services.money import to_decimal, to_stored_float, round_money, currency_dp, rate_dp
 from celerp.services.pricing import DEFAULT_PRICE_LIST_NAME, resolve_price
@@ -388,18 +388,12 @@ def _render_fulfillment_badge(doc: dict):
 
 def _action_error(msg: str):
     """Fire a toast popup for action errors and restore any open editable cell to display mode."""
-    import json as _json
     from starlette.responses import HTMLResponse as _HR
     return _HR(
         "",
         status_code=200,
-        headers={
-            "HX-Reswap": "none",
-            "HX-Trigger": _json.dumps({
-                "celerpToast": {"message": msg, "type": "error"},
-                "celerpRestoreCell": True,
-            }),
-        },
+        headers={"HX-Reswap": "none",
+                 **toast_header(msg, "error", celerpRestoreCell=True)},
     )
 
 

--- a/ui/routes/inventory.py
+++ b/ui/routes/inventory.py
@@ -20,7 +20,7 @@ from starlette.responses import RedirectResponse, Response
 import ui.api_client as api
 from ui.api_client import APIError, _flatten_item_attrs
 from ui.components.files import files_section as _shared_files_section
-from ui.components.shell import base_shell, page_header
+from ui.components.shell import base_shell, page_header, toast_header
 from ui.components.table import data_table, search_bar, pagination, EMPTY, breadcrumbs, status_cards, empty_state_cta, add_new_option, searchable_select, currency_symbol, INACTIVE_ITEM_STATUSES, SERVER_FILTER_JS, filter_th, sortable_th, table_pager, COLUMN_FILTER_JS, ENHANCED_TABLE_JS, date_range_filter
 from ui.config import get_token as _token, get_role as _get_role, API_BASE as _api_base
 from celerp.services.permissions import role_has_permission
@@ -2721,10 +2721,7 @@ function celerpPrintLabel(entityId, templateId) {
         from starlette.responses import HTMLResponse
         return HTMLResponse(
             "", status_code=200,
-            headers={
-                "HX-Reswap": "none",
-                "HX-Trigger": json.dumps({"celerpToast": {"message": str(msg), "type": "error"}}),
-            },
+            headers={"HX-Reswap": "none", **toast_header(str(msg), "error")},
         )
 
     @app.post("/api/items/bulk/status")

--- a/ui/routes/manufacturing.py
+++ b/ui/routes/manufacturing.py
@@ -3,7 +3,6 @@
 
 from __future__ import annotations
 
-import json
 import logging
 from datetime import date
 
@@ -13,7 +12,7 @@ from starlette.responses import HTMLResponse, RedirectResponse
 
 import ui.api_client as api
 from ui.api_client import APIError
-from ui.components.shell import base_shell, page_header
+from ui.components.shell import base_shell, page_header, toast_header
 from ui.components.table import (EMPTY, status_cards, empty_state_cta, format_value, search_bar,
                                  bulk_toolbar, filter_th, COLUMN_FILTER_JS)
 from ui.config import get_token as _token
@@ -509,14 +508,14 @@ def setup_routes(app):
         made = len(result.get("created", []))
         verb = "Made and completed" if complete else "Created"
         if error:
-            toast = {"message": error, "type": "error"}
+            msg, kind = error, "error"
         elif made:
-            toast = {"message": f"{verb} {made} work order(s).", "type": "success"}
+            msg, kind = f"{verb} {made} work order(s).", "success"
         else:
-            toast = {"message": "Nothing to make for the selected lines.", "type": "info"}
+            msg, kind = "Nothing to make for the selected lines.", "info"
         return HTMLResponse(
             to_xml(_demand_table(lines)),
-            headers={"HX-Trigger": json.dumps({"celerpToast": toast})},
+            headers=toast_header(msg, kind),
         )
 
     @app.get("/manufacturing/requirements")
@@ -636,15 +635,15 @@ def setup_routes(app):
         done = len(result.get("done", []))
         skipped = len(result.get("skipped", []))
         if error:
-            toast = {"message": error, "type": "error"}
+            msg, kind = error, "error"
         else:
             msg = f"{_BULK_RUN_VERB.get(action, 'Updated')} {done} run(s)."
             if skipped:
                 msg += f" {skipped} skipped (not in a valid state)."
-            toast = {"message": msg, "type": "success" if done else "info"}
+            kind = "success" if done else "info"
         return HTMLResponse(
             to_xml(_order_table(_runs_for_status(orders, status), today=date.today().isoformat())),
-            headers={"HX-Trigger": json.dumps({"celerpToast": toast})},
+            headers=toast_header(msg, kind),
         )
 
     @app.get("/manufacturing/runs/{run_id}/edit/{field}")

--- a/ui/routes/modules_page.py
+++ b/ui/routes/modules_page.py
@@ -34,7 +34,7 @@ from starlette.responses import HTMLResponse, JSONResponse, RedirectResponse
 import ui.api_client as api
 import ui.marketplace_catalog as catalog
 from ui.api_client import APIError
-from ui.components.shell import base_shell, page_header
+from ui.components.shell import base_shell, page_header, toast_header
 from ui.components.table import sortable_th, filter_th, table_search, COLUMN_FILTER_JS, ENHANCED_TABLE_JS
 from ui.config import get_role as _get_role
 from ui.i18n import t, get_lang
@@ -937,11 +937,7 @@ def _toast(fragment: FT, message: str | None, *, error: bool = True) -> HTMLResp
     """Swap the fragment in place and surface the message as a corner toast, the
     app-wide notice surface, rather than crowding the fragment itself. A None
     message swaps silently."""
-    headers = {}
-    if message:
-        headers["HX-Trigger"] = json.dumps(
-            {"celerpToast": {"message": message,
-                             "type": "error" if error else "success"}})
+    headers = toast_header(message, "error" if error else "success") if message else {}
     return HTMLResponse(to_xml(fragment), headers=headers)
 
 

--- a/ui/routes/settings.py
+++ b/ui/routes/settings.py
@@ -14,7 +14,7 @@ from starlette.responses import RedirectResponse, Response
 import ui.api_client as api
 from ui.api_client import APIError
 from ui.components.attrs import hx_vals
-from ui.components.shell import base_shell, page_header, flash
+from ui.components.shell import base_shell, page_header, flash, toast_header
 from ui.components.table import EMPTY, unwrap_address
 from ui.components.currency import CURRENCIES, CURRENCY_CODES, currency_label, currency_combobox_td
 from ui.components.phone import phone_input_td as _phone_input_td, phone_head_items as _phone_head_items
@@ -333,10 +333,9 @@ def _register_terms_crud(app, prefix: str, get_fn_name: str, patch_fn_name: str,
 def _toast_response(message: str, *fragments: FT):
     """Swap the given fragments and surface ``message`` as an auto-dismissing error toast,
     so no stale error text persists in the page."""
-    import json as _json
     from starlette.responses import HTMLResponse as _HR
     body = "".join(to_xml(f) for f in fragments)
-    return _HR(body, headers={"HX-Trigger": _json.dumps({"celerpToast": {"message": message, "type": "error"}})})
+    return _HR(body, headers=toast_header(message, "error"))
 
 
 def _status_error(status_id: str, message: str, oob: FT | None = None):

--- a/ui/routes/settings_connectors.py
+++ b/ui/routes/settings_connectors.py
@@ -993,10 +993,10 @@ def setup_routes(app):
         if polling and runs and not _any_in_progress(runs):
             ok = _overall_status(runs) != "failed"
             msg = t("connectors.sync_complete", lang) if ok else t("connectors.sync_failed", lang)
+            from ui.components.shell import toast_header
             return HTMLResponse(
                 to_xml(view),
-                headers={"HX-Trigger": json.dumps(
-                    {"celerpToast": {"message": msg, "type": "success" if ok else "error"}})},
+                headers=toast_header(msg, "success" if ok else "error"),
             )
         return view
 

--- a/ui/static/app.css
+++ b/ui/static/app.css
@@ -3087,8 +3087,10 @@ a.notif-item__link:hover .notif-item__title { color: var(--c-accent); }
 .colfilter-foot { display: flex; align-items: center; justify-content: space-between; gap: 8px; margin-top: 4px; }
 .dp-row-hidden { display: none; }
 
-/* Shared bulk-action toolbar */
+/* Shared bulk-action toolbar. Hidden until its JS marks a selection, so the
+   action list appears only once rows are ticked, on every page alike. */
 .bulkbar { min-height: 32px; }
+.bulkbar:not(.is-active) { display: none; }
 .bulk-action-select {
   padding: 4px 8px; border: 1px solid var(--c-border); border-radius: 4px;
   font-size: 13px; background: var(--c-bg, #fff); color: var(--c-text); cursor: pointer;


### PR DESCRIPTION
Files uploaded against an item, a contact or a document are stored per company
and served through the app. The app checked only that a request came from a
signed-in session, so a user who had the filepath of a file could open a file
belonging to a different company if they were accessing it locally from the same machine.

A file now opens only for the company that owns it. A request for anything
outside the signed-in company's own files comes back as not found, and a
session the app cannot read a company from is sent to the login page rather
than being let through.

Nothing changes for a user opening their own company's files.

Also in this PR, three more small correctness fixes:

**The shared bulk toolbar hides until rows are selected.** The action list showed
even with nothing ticked, while inventory's own bar has always stayed out of the
way until a row is selected. Every page using the shared toolbar now behaves the
way inventory does.

**Toast headers are built in one place.** Ten responses hand-rolled the same
HX-Trigger JSON for the corner toast, each with its own quoting. One helper in
the shell now builds it, including the persist flag and companion client events.

**A module naming an unknown permission key is refused at load.** Such a module
used to load fine and then crash the sidebar on every page for every user. The
loader now rejects it with the bad key named, so it shows as a failed module on
the modules page instead of taking the whole UI down.
