### PR TITLE
You can now change which account this computer is linked to using Google sign-in in settings

### DIFF
--- a/celerp/routers/health.py
+++ b/celerp/routers/health.py
@@ -366,28 +366,49 @@ async def cloud_instance_id() -> dict:
 async def account_methods_api() -> dict:
     """Which optional sign-in methods the relay offers, plus the browser URL for
     the Google flow (started in the system browser, bound to this instance).
-    Degrades to email-only when the relay is unreachable - never an error."""
+    Degrades to email-only when the relay is unreachable - never an error.
+
+    An activated install exchanges its gateway credential for a JWT and asks
+    the relay for an owner-initiated start URL: that sign-in may CHANGE which
+    account this computer is linked to, which the open door refuses. Fresh
+    installs (no credential yet) get the open-door URL - they have no link to
+    change. The UI fetches this at click time, so the URL is always fresh."""
     import httpx
-    from celerp.config import ensure_instance_id
+    from celerp.config import settings as _s, ensure_instance_id
     from celerp.gateway.state import relay_http_url as _rhu
     relay_base = _rhu()
     iid = ensure_instance_id()
     google = False
     free_email_quota = 0
+    start_url = f"{relay_base}/auth/google/start?instance_id={iid}"
     try:
         async with httpx.AsyncClient(timeout=6.0) as c:
             r = await c.get(f"{relay_base}/auth/methods")
-        if r.status_code == 200:
-            data = r.json()
-            if isinstance(data, dict):
-                google = bool(data.get("google"))
-                free_email_quota = int(data.get("free_email_quota") or 0)
+            if r.status_code == 200:
+                data = r.json()
+                if isinstance(data, dict):
+                    google = bool(data.get("google"))
+                    free_email_quota = int(data.get("free_email_quota") or 0)
+            api_key = _s.gateway_token
+            if google and api_key:
+                tok_r = await c.post(f"{relay_base}/auth/token",
+                                     json={"api_key": api_key})
+                if tok_r.status_code == 200:
+                    su = await c.get(
+                        f"{relay_base}/auth/google/start-url",
+                        params={"instance_id": iid},
+                        headers={"Authorization":
+                                 f"Bearer {tok_r.json()['access_token']}"})
+                    if su.status_code == 200:
+                        su_data = su.json()
+                        if isinstance(su_data, dict) and su_data.get("url"):
+                            start_url = str(su_data["url"])
     except Exception:
         pass
     return {
         "google": google,
         "free_email_quota": free_email_quota,
-        "google_start_url": f"{relay_base}/auth/google/start?instance_id={iid}",
+        "google_start_url": start_url,
     }
 
 

--- a/tests/test_relay_account_proxy.py
+++ b/tests/test_relay_account_proxy.py
@@ -224,3 +224,83 @@ async def test_account_methods_proxy_reports_free_email_quota():
         from celerp.routers.health import account_methods_api
         data = await account_methods_api()
     assert data["free_email_quota"] == 0
+
+
+@pytest.mark.asyncio
+async def test_account_methods_owner_initiated_start_url_when_credentialed():
+    """An activated install proves its credential and gets the relay's
+    owner-initiated Google start URL, which lets the sign-in change this
+    computer's account link instead of being refused."""
+    def _get_router(url, **kw):
+        resp = MagicMock()
+        resp.status_code = 200
+        if url.endswith("/auth/methods"):
+            resp.json = MagicMock(return_value={"google": True, "free_email_quota": 5})
+        elif url.endswith("/auth/google/start-url"):
+            assert kw["headers"]["Authorization"] == "Bearer jwt-abc"
+            resp.json = MagicMock(return_value={
+                "url": "https://accounts.google.com/o/oauth2/v2/auth?state=signed"})
+        return resp
+
+    factory, client = _mock_httpx()
+    client.get = AsyncMock(side_effect=_get_router)
+    with (
+        patch("celerp.config.settings.gateway_token", "api-key-123"),
+        patch("celerp.gateway.state.relay_http_url", return_value="https://relay.test"),
+        patch("httpx.AsyncClient", factory),
+    ):
+        from celerp.routers.health import account_methods_api
+        data = await account_methods_api()
+    assert data["google"] is True
+    assert data["google_start_url"] == (
+        "https://accounts.google.com/o/oauth2/v2/auth?state=signed")
+    assert any(c[0][0].endswith("/auth/token") for c in client.post.call_args_list)
+
+
+@pytest.mark.asyncio
+async def test_account_methods_open_door_url_without_credential():
+    """A fresh install (no gateway_token yet) keeps the open-door start URL -
+    it has no existing link to change, and the relay would 403 it anyway."""
+    factory, client = _mock_httpx()
+    methods_resp = MagicMock()
+    methods_resp.status_code = 200
+    methods_resp.json = MagicMock(return_value={"google": True, "free_email_quota": 0})
+    client.get = AsyncMock(return_value=methods_resp)
+    with (
+        patch("celerp.config.settings.gateway_token", ""),
+        patch("celerp.config.ensure_instance_id", return_value="i-77"),
+        patch("celerp.gateway.state.relay_http_url", return_value="https://relay.test"),
+        patch("httpx.AsyncClient", factory),
+    ):
+        from celerp.routers.health import account_methods_api
+        data = await account_methods_api()
+    assert data["google_start_url"] == "https://relay.test/auth/google/start?instance_id=i-77"
+    assert not client.post.call_args_list
+
+
+@pytest.mark.asyncio
+async def test_account_methods_falls_back_when_start_url_fetch_fails():
+    """A relay that doesn't serve /auth/google/start-url (or a failed token
+    exchange) degrades to the open-door URL, never to a broken button."""
+    def _get_router(url, **kw):
+        resp = MagicMock()
+        if url.endswith("/auth/methods"):
+            resp.status_code = 200
+            resp.json = MagicMock(return_value={"google": True, "free_email_quota": 0})
+        else:
+            resp.status_code = 404
+            resp.json = MagicMock(return_value={"detail": "no such endpoint"})
+        return resp
+
+    factory, client = _mock_httpx()
+    client.get = AsyncMock(side_effect=_get_router)
+    with (
+        patch("celerp.config.settings.gateway_token", "api-key-123"),
+        patch("celerp.config.ensure_instance_id", return_value="i-77"),
+        patch("celerp.gateway.state.relay_http_url", return_value="https://relay.test"),
+        patch("httpx.AsyncClient", factory),
+    ):
+        from celerp.routers.health import account_methods_api
+        data = await account_methods_api()
+    assert data["google"] is True
+    assert data["google_start_url"] == "https://relay.test/auth/google/start?instance_id=i-77"


### PR DESCRIPTION
Signing in with a different Google account from the settings page now switches which account this computer is linked to, instead of being refused with "This Celerp install is already linked".

Celerp proves it holds this install's credential before the sign-in starts, so only someone using Celerp on this computer can make the change. Your previous account is never deleted: you can pull it back onto any computer at any time with Link by email. Fresh installs and older relays keep the existing sign-in flow unchanged.