### PR TITLE
Allow the same ingredient more than once in a recipe

### DIFF
--- a/tests/test_browser/test_manufacturing_recipe.py
+++ b/tests/test_browser/test_manufacturing_recipe.py
@@ -208,6 +208,47 @@ def test_labor_type_toggles_applicable_fields(page, ui_server, api):
     assert got["labor"][0]["kind"] == "fixed" and got["labor"][0]["amount"] == 40.0
 
 
+def test_same_component_can_be_added_twice(page, ui_server, api):
+    """A process recipe can use the same ingredient in more than one step (e.g. water
+    added in two stages of bread dough), so a BOM must allow an ingredient more than once:
+    the picker keeps offering an already-added ingredient, and each added line is
+    independent and its cost counts on its own."""
+    raw_id = api.post("/items", json={"sku": "DUP-WATER", "name": "Water", "quantity": 100,
+                                      "sell_by": "gram", "cost_total": 1000,
+                                      "inventory_type": "component"}).json()["id"]  # unit 10
+    fg = api.post("/items", json={"sku": "DUP-BREAD", "name": "Bread", "quantity": 0,
+                                  "sell_by": "piece"}).json()["id"]
+    page.set_viewport_size({"width": 1440, "height": 1000})
+    _open_tab(page, ui_server, fg)
+
+    # Step 1's water.
+    _ghost_pick(page, "DUP-WATER")
+    page.wait_for_selector('td[data-col="recipe__components__0__quantity"]', timeout=8000)
+    _set_cell(page, "recipe__components__0__quantity", "2")
+    page.wait_for_selector("#recipe-cost-card:has-text('20')", timeout=8000)
+
+    # The picker must still offer the same ingredient so it can be used in a second step.
+    box = page.locator(".recipe-add-row .combobox-input").first
+    box.click()
+    box.fill("DUP-WATER")
+    page.wait_for_selector(".combobox-list.open", timeout=3000)
+    offered = page.locator(".combobox-list.open .combobox-option:not(.combobox-option--empty)"
+                           ":not(.combobox-option--pinned):not(.combobox-option--new):visible")
+    assert offered.count() >= 1, "an already-added ingredient is not offered again, so it cannot be used in a second step"
+
+    # Step 2's water: add the same ingredient a second time.
+    _ghost_pick(page, "DUP-WATER")
+    page.wait_for_selector('td[data-col="recipe__components__1__quantity"]', timeout=8000)
+    _set_cell(page, "recipe__components__1__quantity", "3")
+    page.wait_for_selector("#recipe-cost-card:has-text('50')", timeout=8000)  # 2x10 + 3x10, each line counts
+
+    got = api.get(f"/items/{fg}").json()["recipe"]
+    comps = got["components"]
+    assert len(comps) == 2, f"the same ingredient was not added twice: {comps!r}"
+    assert all(c["item_id"] == raw_id for c in comps), f"both lines should be the same ingredient: {comps!r}"
+    assert got["unit_cost"] == 50.0  # both lines' costs count independently
+
+
 def test_add_row_validation_flashes_empty_required_field(page, ui_server, api):
     """Clicking + Add with no operation/description flashes the field red (no silent failure)."""
     fg = api.post("/items", json={"sku": "AV-FG", "name": "FG", "quantity": 0, "sell_by": "piece"}).json()["id"]

--- a/ui/routes/inventory.py
+++ b/ui/routes/inventory.py
@@ -1628,7 +1628,10 @@ function celerpPrintLabel(entityId, templateId) {
                     show_all = new_id == "__scope__all"
                     changed = False
                 else:
-                    changed = bool(new_id) and new_id not in {c.get("item_id") for c in recipe["components"]}
+                    # A process recipe can use the same ingredient in more than one step
+                    # (water added in two stages of dough), so the same component may appear
+                    # more than once; each line carries its own quantity and cost.
+                    changed = bool(new_id)
                     if changed:
                         recipe["components"].append({"item_id": new_id, "quantity": 1})
             elif action == "add_labor":
@@ -5919,8 +5922,9 @@ def _recipe_section(entity_id: str, item: dict, items: list[dict], currency: str
     # The add-picker searches COMPONENTS only by default. Scope is controlled inside the
     # dropdown itself (the common footer-action pattern): a pinned "Search all items…"
     # option widens this picker only, and the last option creates a brand-new component.
-    selected_ids = {c.get("item_id") for c in components}
-    base_opts = [o for o in item_opts if o[0] not in selected_ids and (show_all or o[0] in component_ids)]
+    # Already-added components stay in the picker: a process recipe can use the same
+    # ingredient in more than one step, so an added item must remain addable again.
+    base_opts = [o for o in item_opts if show_all or o[0] in component_ids]
     scope_opt = ("__scope__components", "Show components only…") if show_all else ("__scope__all", "Search all items…")
     comp_opts = base_opts + [scope_opt, ("__new__:/inventory/new?type=component", "+ Add new component")]
 


### PR DESCRIPTION
Process recipes use an ingredient in more than one step. Bread dough adds water in two stages in separate quantities, so a bill of materials must let an ingredient appear more than once. The recipe editor previously refused a duplicate: the add-component picker dropped any item already in the recipe, and the add action ignored a repeat.

A recipe was already stored and edited by row position, so each line carries its own quantity and cost independently and the cost summary counts every line. The picker now keeps offering an ingredient after it has been added, and adding it again appends a fresh line. Removing and editing a line remain per row, so two lines of the same ingredient are managed separately. The printed worksheet lists each line, so a repeated ingredient shows once per step.

A browser test adds the same ingredient twice, confirms the picker still offers it, and confirms both lines persist and both costs count.