### PR TITLE
Add a Duplicate bulk action to the inventory list

### DIFF
--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -5623,6 +5623,175 @@ class TestInventoryBulkActions:
         assert b"delete failed" in r.content
 
 
+class TestBulkDuplicate:
+    """Bulk Duplicate action: create a copy of each selected item from the inventory list."""
+
+    @staticmethod
+    def _page_patches():
+        from contextlib import ExitStack
+        stack = ExitStack()
+        for target, val in (
+            ("get_item_schema", _SCHEMA),
+            ("get_all_category_schemas", {}),
+            ("get_company_category_schemas", {}),
+            ("get_column_prefs", {}),
+            ("get_valuation", {"item_count": 0, "category_counts": {}}),
+            ("get_company", {}),
+            ("get_locations", {"items": [], "total": 0}),
+            ("list_items", {"items": [], "total": 0}),
+            ("list_import_batches", {"batches": []}),
+            ("get_units", []),
+            ("get_price_lists", []),
+        ):
+            stack.enter_context(patch(f"ui.api_client.{target}", new=AsyncMock(return_value=val)))
+        return stack
+
+    @pytest.mark.asyncio
+    async def test_bulk_duplicate_option_gated_on_edit_permission(self, ui_client):
+        """Duplicate option is offered to an edit_inventory role and withheld from one without it."""
+        with self._page_patches():
+            owner = await ui_client.get("/inventory", cookies=_authed())
+        assert owner.status_code == 200
+        assert b'value="duplicate"' in owner.content
+        with self._page_patches():
+            viewer = await ui_client.get("/inventory", cookies=_authed(role="viewer"))
+        assert viewer.status_code == 200
+        assert b'value="duplicate"' not in viewer.content
+
+    @pytest.mark.asyncio
+    async def test_bulk_duplicate_creates_a_copy_per_selected_item(self, ui_client):
+        create = AsyncMock(return_value={"id": "item:new", "event_id": "e1"})
+        with (
+            patch("ui.api_client.get_item", new=AsyncMock(return_value=_ITEM)),
+            patch("ui.api_client.list_items", new=AsyncMock(return_value={"items": [], "total": 0})),
+            patch("ui.api_client.get_company", new=AsyncMock(return_value={"settings": {}})),
+            patch("ui.api_client.create_item", new=create),
+        ):
+            r = await ui_client.post(
+                "/api/items/bulk/duplicate",
+                content=b"selected=gc%3A123&selected=gc%3A456", headers={"content-type": "application/x-www-form-urlencoded"},
+                cookies=_authed(),
+            )
+        assert r.status_code == 200
+        assert b"2 item(s) duplicated" in r.content
+        assert create.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_bulk_duplicate_generates_distinct_skus_within_batch(self, ui_client):
+        """Two selected items sharing one source SKU receive distinct generated copy SKUs."""
+        skus = []
+        async def _cap(token, data):
+            skus.append(data.get("sku"))
+            return {"id": "item:copy", "event_id": "e1"}
+        with (
+            patch("ui.api_client.get_item", new=AsyncMock(return_value={**_ITEM, "sku": "ABC"})),
+            patch("ui.api_client.list_items", new=AsyncMock(return_value={"items": [], "total": 0})),
+            patch("ui.api_client.get_company", new=AsyncMock(return_value={"settings": {}})),
+            patch("ui.api_client.create_item", new=_cap),
+        ):
+            await ui_client.post(
+                "/api/items/bulk/duplicate",
+                content=b"selected=gc%3A123&selected=gc%3A456", headers={"content-type": "application/x-www-form-urlencoded"},
+                cookies=_authed(),
+            )
+        assert sorted(skus) == ["ABC-copy", "ABC-copy2"]
+
+    @pytest.mark.asyncio
+    async def test_bulk_duplicate_reports_partial_failure(self, ui_client):
+        from ui.api_client import APIError
+        create = AsyncMock(side_effect=[{"id": "item:ok", "event_id": "e1"}, APIError(500, "create failed")])
+        with (
+            patch("ui.api_client.get_item", new=AsyncMock(return_value=_ITEM)),
+            patch("ui.api_client.list_items", new=AsyncMock(return_value={"items": [], "total": 0})),
+            patch("ui.api_client.get_company", new=AsyncMock(return_value={"settings": {}})),
+            patch("ui.api_client.create_item", new=create),
+        ):
+            r = await ui_client.post(
+                "/api/items/bulk/duplicate",
+                content=b"selected=gc%3A123&selected=gc%3A456", headers={"content-type": "application/x-www-form-urlencoded"},
+                cookies=_authed(),
+            )
+        assert r.status_code == 200
+        assert b"1 item(s) duplicated, 1 failed" in r.content
+        assert b"flash--warning" in r.content
+        assert create.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_bulk_duplicate_all_fail_error_flash(self, ui_client):
+        from ui.api_client import APIError
+        create = AsyncMock(side_effect=APIError(500, "create failed"))
+        with (
+            patch("ui.api_client.get_item", new=AsyncMock(return_value=_ITEM)),
+            patch("ui.api_client.list_items", new=AsyncMock(return_value={"items": [], "total": 0})),
+            patch("ui.api_client.get_company", new=AsyncMock(return_value={"settings": {}})),
+            patch("ui.api_client.create_item", new=create),
+        ):
+            r = await ui_client.post(
+                "/api/items/bulk/duplicate",
+                content=b"selected=gc%3A123&selected=gc%3A456", headers={"content-type": "application/x-www-form-urlencoded"},
+                cookies=_authed(),
+            )
+        assert r.status_code == 200
+        assert b"flash--error" in r.content
+        assert b"Failed to duplicate" in r.content
+        assert b"duplicated." not in r.content
+        assert create.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_bulk_duplicate_rejects_empty_selection(self, ui_client):
+        create = AsyncMock(return_value={"id": "item:new"})
+        with patch("ui.api_client.create_item", new=create):
+            r = await ui_client.post(
+                "/api/items/bulk/duplicate",
+                content=b"", headers={"content-type": "application/x-www-form-urlencoded"},
+                cookies=_authed(),
+            )
+        assert r.status_code == 200
+        assert b"No items selected" in r.content
+        assert create.call_count == 0
+
+    @pytest.mark.asyncio
+    async def test_bulk_duplicate_dedupes_repeated_ids(self, ui_client):
+        """The same id repeated in the POST creates exactly one copy, not one per repeat."""
+        create = AsyncMock(return_value={"id": "item:new", "event_id": "e1"})
+        with (
+            patch("ui.api_client.get_item", new=AsyncMock(return_value=_ITEM)),
+            patch("ui.api_client.list_items", new=AsyncMock(return_value={"items": [], "total": 0})),
+            patch("ui.api_client.get_company", new=AsyncMock(return_value={"settings": {}})),
+            patch("ui.api_client.create_item", new=create),
+        ):
+            r = await ui_client.post(
+                "/api/items/bulk/duplicate",
+                content=b"selected=gc%3A123&selected=gc%3A123", headers={"content-type": "application/x-www-form-urlencoded"},
+                cookies=_authed(),
+            )
+        assert r.status_code == 200
+        assert b"1 item(s) duplicated" in r.content
+        assert create.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_bulk_duplicate_denied_without_edit_permission(self, ui_client):
+        create = AsyncMock(return_value={"id": "item:new"})
+        with (
+            patch("ui.api_client.get_company", new=AsyncMock(return_value={"settings": {}})),
+            patch("ui.api_client.create_item", new=create),
+        ):
+            r = await ui_client.post(
+                "/api/items/bulk/duplicate",
+                content=b"selected=gc%3A123", headers={"content-type": "application/x-www-form-urlencoded"},
+                cookies=_authed(role="viewer"),
+            )
+        assert r.status_code == 200
+        assert b"Unauthorized" in r.content
+        assert create.call_count == 0
+
+    def test_bulkActionChanged_handles_duplicate(self):
+        """The bulk toolbar JS routes the duplicate option to the bulk-duplicate endpoint."""
+        src = pathlib.Path(__file__).resolve().parents[1].joinpath("ui", "components", "table.py").read_text()
+        assert "action==='duplicate'" in src
+        assert "/api/items/bulk/duplicate" in src
+
+
 class TestBulkActionsPhase1to5:
     """Phases 1-5: persistent selection, context-sensitive toolbar, merge/split/expire/archive."""
 

--- a/ui/components/table.py
+++ b/ui/components/table.py
@@ -1656,6 +1656,10 @@ function bulkActionChanged(action){
     if(!confirm('Delete selected items? This cannot be undone.')) return;
     _bulkImmediate('/api/items/bulk/delete',null,null);return;
   }
+  if(action==='duplicate'){
+    if(!confirm('Duplicate selected items? A copy of each will be created.')) return;
+    _bulkImmediate('/api/items/bulk/duplicate',null,null);return;
+  }
   // Context-driven actions - clone template (includes module actions via mod: prefix)
   // mod: actions use tpl-mod-{action_id} where action_id strips the mod: prefix.
   // The option value and template id must be derived the same way to stay in sync.

--- a/ui/locales/en.json
+++ b/ui/locales/en.json
@@ -685,6 +685,7 @@
   "inv.custom_columns_in_your_csv_will_be_imported_as_ite": "Custom columns in your CSV will be imported as item attributes. ",
   "inv.customize_fields": "Customize Fields",
   "inv.document_type": "Document type...",
+  "inv.duplicate": "Duplicate",
   "inv.edit_the_global_fields_shown_for_all_items_regardl": "Edit the global fields shown for all items (regardless of category).",
   "inv.enter_at_least_one_split_quantity": "Enter at least one split quantity.",
   "inv.enter_commaseparated_quantities_eg_321": "Enter comma-separated quantities (e.g. 3,2,1).",

--- a/ui/routes/inventory.py
+++ b/ui/routes/inventory.py
@@ -611,6 +611,49 @@ async def _import_export_allowed(request: Request, token: str) -> bool:
     return role_has_permission(settings, _get_role(request), "import_export_data")
 
 
+def _duplicate_payload(source: dict, new_sku: str) -> dict:
+    """Build a create payload from an existing item, carrying every field except
+    id, status, location_name, created_at, updated_at (status is reset by the create
+    path). Core columns and any *_price stay top-level; everything else goes into
+    attributes. Shared by the single-item and bulk duplicate paths."""
+    _SKIP = {"id", "status", "location_name", "created_at", "updated_at"}
+    _CORE = {"sku", "name", "quantity", "category", "location_id",
+             "description", "unit", "sell_by", "tax_codes"}
+    payload: dict = {"sku": new_sku}
+    attrs: dict = {}
+    for k, v in source.items():
+        if k in _SKIP or k == "sku" or v is None:
+            continue
+        if k in _CORE or k.endswith("_price"):
+            payload[k] = v
+        else:
+            attrs[k] = v
+    if attrs:
+        payload["attributes"] = attrs
+    return payload
+
+
+async def _gen_copy_sku(token: str, orig: str, reserved: set[str] | None = None) -> str:
+    """Generate a unique copy SKU for a source SKU: {orig}-copy, -copy2, -copy3 ...
+    skipping any SKU that already exists (scanned via api.list_items) and any already
+    in `reserved` (copies generated earlier in the same batch). When `reserved` is
+    given, the chosen SKU is added to it so the next call in the batch skips it."""
+    candidate = f"{orig}-copy"
+    try:
+        resp = await api.list_items(token, {"q": orig, "limit": 100, "status": "all"})
+        existing_skus = {str(it.get("sku", "")) for it in (resp.get("items", []) if isinstance(resp, dict) else resp)}
+    except Exception:
+        existing_skus = set()
+    taken = existing_skus | (reserved or set())
+    n = 2
+    while candidate in taken:
+        candidate = f"{orig}-copy{n}"
+        n += 1
+    if reserved is not None:
+        reserved.add(candidate)
+    return candidate
+
+
 def setup_routes(app):
 
     @app.get("/inventory")
@@ -2701,16 +2744,17 @@ function celerpPrintLabel(entityId, templateId) {
 
     # ── Bulk actions (list-level) ─────────────────────────────────────────────
 
-    def _bulk_destructive_success(message: str, redirect_qs: str = "") -> Response:
-        """Return a bulk-action success response that clears the client-side selection.
+    def _bulk_destructive_success(message: str, redirect_qs: str = "", cls: str = "flash--success") -> Response:
+        """Return a bulk-action result response that clears the client-side selection.
 
         Sends HX-Trigger: celerpSelectionClear so the JS handler resets CelerpSelection
-        and the toolbar before the table reloads.  Used for all destructive bulk actions
-        (merge, delete, archive, expire) where source items leave the visible table.
+        and the toolbar before the table reloads.  Used for bulk actions (merge, delete,
+        archive, expire, duplicate) that reload the table; `cls` selects the flash
+        variant (success, or warning for a partial-success count).
         """
         from starlette.responses import HTMLResponse
         content = Div(
-            P(message, cls="flash flash--success"),
+            P(message, cls=f"flash {cls}"),
             id="bulk-action-result",
             hx_trigger="load delay:1s",
             hx_get=f"/inventory/content{redirect_qs}",
@@ -2819,6 +2863,41 @@ function celerpPrintLabel(entityId, templateId) {
             return Div(P(str(e.detail), cls="flash flash--error"), id="bulk-action-result")
         expired = result.get("expired", len(entity_ids))
         return _bulk_destructive_success(f"{expired} item(s) expired.")
+
+    # ── Bulk duplicate (create a copy of each selected item) ─────────────
+
+    @app.post("/api/items/bulk/duplicate")
+    async def bulk_item_duplicate(request: Request):
+        token = _token(request)
+        if not token:
+            return RedirectResponse("/login", status_code=302)
+        form = await request.form()
+        # Dedupe as well as filter: each id creates a new persistent entity, so a
+        # repeated id in a crafted POST must not multiply copies of one item.
+        entity_ids = list(dict.fromkeys(v.strip() for v in form.getlist("selected") if v.strip()))
+        if not entity_ids:
+            return Div(P(t("flash.no_items_selected"), cls="flash flash--warning"), id="bulk-action-result")
+        try:
+            settings = (await api.get_company(token)).get("settings") or {}
+        except APIError as e:
+            return Div(P(str(e.detail), cls="flash flash--error"), id="bulk-action-result")
+        if not role_has_permission(settings, _get_role(request), "edit_inventory"):
+            return Div(P(t("error.unauthorized"), cls="flash flash--error"), id="bulk-action-result")
+        reserved: set[str] = set()
+        ok = 0
+        failed = 0
+        for eid in entity_ids:
+            try:
+                source = await api.get_item(token, eid)
+                new_sku = await _gen_copy_sku(token, str(source.get("sku", "") or ""), reserved=reserved)
+                await api.create_item(token, _duplicate_payload(source, new_sku))
+                ok += 1
+            except APIError:
+                failed += 1
+        if ok == 0:
+            return Div(P(f"Failed to duplicate {failed} item(s).", cls="flash flash--error"), id="bulk-action-result")
+        msg = f"{ok} item(s) duplicated, {failed} failed." if failed else f"{ok} item(s) duplicated."
+        return _bulk_destructive_success(msg, cls="flash--warning" if failed else "flash--success")
 
     # ── Bulk merge (direct — no preview modal) ───────────────────────────
 
@@ -4005,35 +4084,8 @@ function celerpPrintLabel(entityId, templateId) {
         except APIError as e:
             return Div(Span(str(e.detail), cls="flash flash--error"), id="item-action-error")
         if not new_sku:
-            orig = str(source.get("sku", "") or "")
-            # Auto-generate: {sku}-copy, -copy2, -copy3 ...
-            candidate = f"{orig}-copy"
-            try:
-                resp = await api.list_items(token, {"q": orig, "limit": 100, "status": "all"})
-                existing_skus = {str(it.get("sku", "")) for it in (resp.get("items", []) if isinstance(resp, dict) else resp)}
-            except Exception:
-                existing_skus = set()
-            n = 2
-            while candidate in existing_skus:
-                candidate = f"{orig}-copy{n}"
-                n += 1
-            new_sku = candidate
-
-        # Build create payload from source — carry all fields except id, status, location_name
-        _SKIP = {"id", "status", "location_name", "created_at", "updated_at"}
-        _CORE = {"sku", "name", "quantity", "category", "location_id",
-                 "description", "unit", "sell_by", "tax_codes"}
-        payload: dict = {"sku": new_sku}
-        attrs: dict = {}
-        for k, v in source.items():
-            if k in _SKIP or k == "sku" or v is None:
-                continue
-            if k in _CORE or k.endswith("_price"):
-                payload[k] = v
-            else:
-                attrs[k] = v
-        if attrs:
-            payload["attributes"] = attrs
+            new_sku = await _gen_copy_sku(token, str(source.get("sku", "") or ""))
+        payload = _duplicate_payload(source, new_sku)
         try:
             result = await api.create_item(token, payload)
         except APIError as e:
@@ -4241,6 +4293,8 @@ def _bulk_toolbar(locations: list[dict], p: dict | None = None, total_items: int
     action_options.extend(module_action_opts)
     action_options.append(Option(t("inv.archive"), value="archive"))
     action_options.append(Option(t("inv.expire"), value="expire"))
+    if role_has_permission(settings or {}, role, "edit_inventory"):
+        action_options.append(Option(t("inv.duplicate"), value="duplicate"))
     # Restore and Delete only shown when viewing archived/expired items
     active_status = (p or {}).get("status", "")
     if active_status in ("archived", "expired"):


### PR DESCRIPTION
Adds a Duplicate action to the inventory list bulk-actions toolbar, so you can create new products from one or more existing ones without leaving the page.

Select the items you want to copy, choose Duplicate, and confirm. A copy of each selected item is created with its fields carried over and a fresh, auto-generated SKU (the original SKU plus a "-copy" suffix, numbered so copies never collide with existing items or with each other in the same run). The new copies appear at the top of the list, ready to edit in place.

Details:
- Status is reset on each copy, matching the single-item Duplicate on the product page.
- If some copies cannot be created, the result says how many succeeded and how many failed; the ones that succeeded are kept.
- The action is available only to roles with inventory edit rights, and is enforced on the server as well as hidden from the toolbar otherwise.
