### PR TITLE
Freeze the header row on the list tables while scrolling

### DIFF
--- a/tests/test_browser/test_sticky_header.py
+++ b/tests/test_browser/test_sticky_header.py
@@ -61,6 +61,34 @@ def _thead_top(page):
     )
 
 
+def _phantom_h(page):
+    # height of the phantom top-scrollbar element (16px whenever it exists), 0 if absent.
+    return page.evaluate(
+        "() => { var p=document.querySelector('#data-table-wrap > .table-top-scroll');"
+        " return p ? p.getBoundingClientRect().height : 0; }"
+    )
+
+
+def _phantom_top(page):
+    return page.evaluate(
+        "() => { var p=document.querySelector('#data-table-wrap > .table-top-scroll');"
+        " return p ? p.getBoundingClientRect().top : null; }"
+    )
+
+
+def _phantom_pinned(page) -> bool:
+    return page.evaluate(
+        "() => { var p=document.querySelector('#data-table-wrap > .table-top-scroll');"
+        " return !!(p && p.classList.contains('top-scroll-pinned')); }"
+    )
+
+
+def _top_scroll_spacers(page) -> int:
+    return page.evaluate(
+        "() => document.querySelectorAll('#data-table-wrap > .top-scroll-spacer').length"
+    )
+
+
 def _data_keys(page):
     return page.evaluate(
         "() => Array.from(document.querySelectorAll('#data-table thead th[data-key]'))"
@@ -167,7 +195,8 @@ def test_header_freezes_at_viewport_top(page, ui_server, sticky_inventory):
     # (b) scroll the table top above the viewport top: frozen at top, columns aligned.
     _scroll_to_pin(page)
     assert _pinned(page)
-    assert abs(_thead_top(page)) <= 1.5
+    # this fixture has a phantom top-scrollbar, so the header freezes directly below it.
+    assert abs(_thead_top(page) - _phantom_h(page)) <= 2
     key = _data_keys(page)[0]
     lefts = _col_lefts(page, key)
     assert lefts is not None and abs(lefts[0] - lefts[1]) <= 1.5
@@ -178,7 +207,7 @@ def test_header_unpins_past_table_end(page, ui_server, sticky_inventory):
     _goto(page, ui_server)
     _add_scroll_room(page)
     _scroll_to_pin(page)
-    assert _pinned(page) and abs(_thead_top(page)) <= 1.5
+    assert _pinned(page) and abs(_thead_top(page) - _phantom_h(page)) <= 2
     # scroll until the table BOTTOM is above the viewport top.
     for _ in range(40):
         bottom = page.evaluate("() => document.querySelector('#data-table').getBoundingClientRect().bottom")
@@ -213,7 +242,7 @@ def test_pinned_header_stays_interactive(page, ui_server, sticky_inventory):
         _wait_swap(page, page.locator(f'#data-table thead th[data-key="{key}"] a.sort-link').first)
         after = _col_values(page, key)
     assert after != before, "sort from the pinned header did not reorder the rows"
-    assert _pinned(page) and abs(_thead_top(page)) <= 2
+    assert _pinned(page) and abs(_thead_top(page) - _phantom_h(page)) <= 2
 
     # (iii) column filter from the pinned header applies server-side (fresh load resets the URL).
     _goto(page, ui_server)
@@ -291,7 +320,7 @@ def test_pinned_header_survives_htmx_swap(page, ui_server, sticky_inventory):
     assert _pinned(page)
     key = _data_keys(page)[0]
     _wait_swap(page, page.locator(f'#data-table thead th[data-key="{key}"] a.sort-link').first)
-    assert _pinned(page) and abs(_thead_top(page)) <= 2
+    assert _pinned(page) and abs(_thead_top(page) - _phantom_h(page)) <= 2
     counts = page.evaluate(
         "() => ({pinned: document.querySelectorAll('.hdr-pinned').length,"
         " spacer: document.querySelectorAll('.hdr-spacer').length})"
@@ -338,3 +367,82 @@ def test_beforeprint_unpins_pinned_header(page, ui_server, sticky_inventory):
 
 
 
+
+# ── the phantom top-scrollbar freezes in the top band, stacked directly above the header ────
+def test_phantom_scrollbar_freezes_above_header(page, ui_server, sticky_inventory):
+    _goto(page, ui_server)
+    # this fixture renders > 10 rows, so the phantom top-scrollbar exists.
+    assert _phantom_h(page) > 0, "fixture table should render the phantom scrollbar"
+    _scroll_to_pin(page)
+    assert _pinned(page)
+    # phantom frozen in the top band...
+    ptop = _phantom_top(page)
+    assert ptop is not None and abs(ptop) <= 2, f"phantom not frozen at the top band: {ptop}"
+    assert _phantom_pinned(page)
+    # ...and the header sits directly beneath it, offset by exactly the phantom height.
+    assert abs(_thead_top(page) - _phantom_h(page)) <= 2
+
+
+# ── while frozen, the phantom stays on-screen and its scrollLeft tracks the body ───────────
+def test_phantom_scrollbar_tracks_horizontal_scroll(page, ui_server, sticky_inventory):
+    _goto(page, ui_server)
+    _scroll_to_pin(page)
+    assert _pinned(page) and _phantom_pinned(page)
+    page.evaluate(
+        "() => { var w=document.querySelector('#data-table-wrap .table-scroll-wrap');"
+        " w.scrollLeft = 120; w.dispatchEvent(new Event('scroll')); }"
+    )
+    page.wait_for_timeout(100)
+    ptop = _phantom_top(page)
+    assert ptop is not None and abs(ptop) <= 2, "frozen phantom left the top band on horizontal scroll"
+    synced = page.evaluate(
+        "() => { var w=document.querySelector('#data-table-wrap .table-scroll-wrap');"
+        " var p=document.querySelector('#data-table-wrap > .table-top-scroll');"
+        " return Math.abs(w.scrollLeft - p.scrollLeft); }"
+    )
+    assert synced <= 2, "phantom scrollLeft did not track the wrap"
+
+
+# ── unpinning restores the phantom to normal flow: no pin class, no spacer, no inline style ─
+def test_phantom_scrollbar_restores_on_unpin(page, ui_server, sticky_inventory):
+    _goto(page, ui_server)
+    _scroll_to_pin(page)
+    assert _pinned(page) and _phantom_pinned(page)
+    assert _top_scroll_spacers(page) >= 1, "a spacer should hold the phantom's place while frozen"
+    _scroll_to_top(page)
+    page.wait_for_function(_UNPINNED_JS, timeout=6000)
+    assert not _phantom_pinned(page)
+    assert _top_scroll_spacers(page) == 0
+    style = page.evaluate(
+        "() => { var p=document.querySelector('#data-table-wrap > .table-top-scroll');"
+        " return {left: p.style.left, width: p.style.width}; }"
+    )
+    assert style["left"] == "" and style["width"] == ""
+
+
+# ── after an htmx re-render while pinned, exactly one phantom is frozen and no spacer piles up ─
+def test_phantom_survives_htmx_swap(page, ui_server, sticky_inventory):
+    _goto(page, ui_server)
+    _scroll_to_pin(page)
+    assert _pinned(page) and _phantom_pinned(page)
+    key = _data_keys(page)[0]
+    _wait_swap(page, page.locator(f'#data-table thead th[data-key="{key}"] a.sort-link').first)
+    assert _pinned(page) and _phantom_pinned(page)
+    counts = page.evaluate(
+        "() => ({pinned: document.querySelectorAll('.table-top-scroll.top-scroll-pinned').length,"
+        " spacer: document.querySelectorAll('#data-table-wrap > .top-scroll-spacer').length})"
+    )
+    assert counts["pinned"] == 1, "exactly one phantom should be frozen after the swap"
+    assert counts["spacer"] <= 1, "no orphaned top-scroll spacer from the old table"
+
+
+# ── beforeprint clears the frozen phantom and its spacer, same as the header ───────────────
+def test_phantom_scrollbar_cleared_on_print(page, ui_server, sticky_inventory):
+    _goto(page, ui_server)
+    _scroll_to_pin(page)
+    assert _pinned(page) and _phantom_pinned(page)
+    assert _top_scroll_spacers(page) >= 1
+    page.evaluate("() => window.dispatchEvent(new Event('beforeprint'))")
+    page.wait_for_timeout(150)
+    assert not _pinned(page) and not _phantom_pinned(page)
+    assert _top_scroll_spacers(page) == 0

--- a/tests/test_browser/test_sticky_header.py
+++ b/tests/test_browser/test_sticky_header.py
@@ -1,0 +1,343 @@
+# Copyright (c) 2026 Noah Severs
+# SPDX-License-Identifier: LicenseRef-Proprietary
+"""Playwright: the frozen (pinned) table header on excel-style data-table list pages.
+
+The header row is inline until the top of the table reaches the top of the viewport, then
+freezes at the top while the body scrolls underneath, and leaves with the table once the body
+scrolls off screen. While frozen it stays fully functional (select-all, sort, column filter,
+column reorder), tracks horizontal scroll, survives an htmx re-render, realigns on a resize,
+and unpins for print. Exercised on the inventory list, which renders the shared data_table.
+"""
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.browser
+
+
+# ── seed: a table taller than the viewport, across two named locations for the funnel ──────
+@pytest.fixture(scope="module")
+def sticky_inventory(api):
+    """Thirty inventory rows split across two distinctly named locations. Names/SKUs are unique
+    to this file so accumulated rows from other browser tests never collide with the funnel."""
+    alpha = api.post("/companies/me/locations", json={"name": "Sticky Loc Alpha", "type": "warehouse"}).json()["id"]
+    beta = api.post("/companies/me/locations", json={"name": "Sticky Loc Beta", "type": "warehouse"}).json()["id"]
+    for i in range(15):
+        api.post("/items", json={"sku": f"PINHDR-A-{i:03d}", "name": f"Pinned alpha {i}",
+                                 "quantity": i + 1, "sell_by": "piece", "location_id": alpha})
+        api.post("/items", json={"sku": f"PINHDR-B-{i:03d}", "name": f"Pinned beta {i}",
+                                 "quantity": i + 1, "sell_by": "piece", "location_id": beta})
+    return {"alpha": alpha, "beta": beta}
+
+
+# ── helpers (viewport-relative geometry; controller-agnostic scroll) ───────────────────────
+def _goto(page, ui_server):
+    page.set_viewport_size({"width": 1440, "height": 900})
+    page.goto(f"{ui_server}/inventory", wait_until="domcontentloaded")
+    page.wait_for_selector("#data-table thead th[data-key]", timeout=10000)
+
+
+def _pinned(page) -> bool:
+    return page.evaluate(
+        "() => { var th=document.querySelector('#data-table thead');"
+        " return !!(th && th.classList.contains('hdr-pinned')); }"
+    )
+
+
+def _thead_top(page):
+    return page.evaluate(
+        "() => { var th=document.querySelector('#data-table thead');"
+        " return th ? th.getBoundingClientRect().top : null; }"
+    )
+
+
+def _data_keys(page):
+    return page.evaluate(
+        "() => Array.from(document.querySelectorAll('#data-table thead th[data-key]'))"
+        ".map(function(th){return th.dataset.key;})"
+    )
+
+
+def _col_lefts(page, key):
+    """[header th left, first body-cell left] for a column, viewport-relative, or None."""
+    return page.evaluate(
+        "(k) => { var th=document.querySelector('#data-table thead th[data-key=\"'+k+'\"]');"
+        " var td=document.querySelector('#data-table tbody tr.data-row td[data-col=\"'+k+'\"]');"
+        " if(!th||!td) return null;"
+        " return [th.getBoundingClientRect().left, td.getBoundingClientRect().left]; }",
+        key,
+    )
+
+
+def _col_values(page, key):
+    return page.evaluate(
+        "(k) => Array.from(document.querySelectorAll('#data-table tbody tr.data-row td[data-col=\"'+k+'\"]'))"
+        ".map(function(td){return td.textContent.trim();})",
+        key,
+    )
+
+
+def _scroll_delta(page, delta):
+    """Scroll by `delta` px on whichever vertical scroller actually moves the table (window or
+    the nearest scrollable ancestor). Returns the table's new viewport-relative top."""
+    return page.evaluate(
+        """(delta) => {
+          var t=document.querySelector('#data-table');
+          var y=window.scrollY; window.scrollBy(0, delta);
+          if (window.scrollY === y) {
+            var n=t.parentElement;
+            while(n){
+              var s=getComputedStyle(n);
+              if(/(auto|scroll)/.test(s.overflowY) || /(auto|scroll)/.test(s.overflowX)){
+                var b=n.scrollTop; n.scrollTop += delta; if(n.scrollTop !== b) break;
+              }
+              n=n.parentElement;
+            }
+          }
+          return t.getBoundingClientRect().top;
+        }""",
+        delta,
+    )
+
+
+def _scroll_to_top(page):
+    page.evaluate(
+        """() => {
+          window.scrollTo(0,0);
+          var t=document.querySelector('#data-table'), n=t?t.parentElement:null;
+          while(n){ try{ n.scrollTop=0; }catch(e){} n=n.parentElement; }
+        }"""
+    )
+
+
+def _scroll_to_pin(page, margin=40):
+    """Scroll until the table top passes `margin` px above the viewport top and the header pins."""
+    for _ in range(30):
+        top = _thead_top(page)
+        cur = page.evaluate("() => { var t=document.querySelector('#data-table'); return t? t.getBoundingClientRect().top : null; }")
+        if cur is None or cur <= -margin + 1:
+            break
+        _scroll_delta(page, cur + margin)
+    page.wait_for_function(
+        "() => { var th=document.querySelector('#data-table thead');"
+        " return !!(th && th.classList.contains('hdr-pinned')); }",
+        timeout=6000,
+    )
+
+
+def _add_scroll_room(page):
+    page.evaluate(
+        "() => { var host=document.querySelector('.main-content')||document.body;"
+        " var d=document.createElement('div'); d.style.height='2000px'; d.setAttribute('data-scrollroom','1');"
+        " host.appendChild(d); }"
+    )
+
+
+def _wait_swap(page, click_target):
+    """Mark the current #data-table, click something that triggers an htmx outerHTML swap, and
+    wait until the table node is replaced, then re-pinned."""
+    page.evaluate("() => { var t=document.querySelector('#data-table'); if(t) t.setAttribute('data-swaptmp','1'); }")
+    click_target.click()
+    page.wait_for_function(
+        "() => { var t=document.querySelector('#data-table'); return !!t && !t.hasAttribute('data-swaptmp'); }",
+        timeout=8000,
+    )
+    page.wait_for_function(
+        "() => { var th=document.querySelector('#data-table thead');"
+        " return !!(th && th.classList.contains('hdr-pinned')); }",
+        timeout=6000,
+    )
+
+
+# ── behaviors (a) + (b): inline before the top, frozen once the table top reaches it ───────
+def test_header_freezes_at_viewport_top(page, ui_server, sticky_inventory):
+    _goto(page, ui_server)
+    # (a) at the top: inline, not frozen.
+    assert not _pinned(page)
+    assert page.evaluate("() => getComputedStyle(document.querySelector('#data-table thead')).position") == "static"
+    # (a) after a short scroll that leaves the table top still below the viewport top: still inline.
+    cur = page.evaluate("() => document.querySelector('#data-table').getBoundingClientRect().top")
+    if cur > 160:
+        _scroll_delta(page, cur - 80)
+        still = page.evaluate("() => document.querySelector('#data-table').getBoundingClientRect().top")
+        if still > 1:
+            assert not _pinned(page), "header pinned before the table reached the viewport top"
+    # (b) scroll the table top above the viewport top: frozen at top, columns aligned.
+    _scroll_to_pin(page)
+    assert _pinned(page)
+    assert abs(_thead_top(page)) <= 1.5
+    key = _data_keys(page)[0]
+    lefts = _col_lefts(page, key)
+    assert lefts is not None and abs(lefts[0] - lefts[1]) <= 1.5
+
+
+# ── behavior (c): the frozen header leaves with the table once the body scrolls off ────────
+def test_header_unpins_past_table_end(page, ui_server, sticky_inventory):
+    _goto(page, ui_server)
+    _add_scroll_room(page)
+    _scroll_to_pin(page)
+    assert _pinned(page) and abs(_thead_top(page)) <= 1.5
+    # scroll until the table BOTTOM is above the viewport top.
+    for _ in range(40):
+        bottom = page.evaluate("() => document.querySelector('#data-table').getBoundingClientRect().bottom")
+        if bottom <= -5:
+            break
+        _scroll_delta(page, bottom + 40)
+    page.wait_for_function(
+        "() => { var th=document.querySelector('#data-table thead');"
+        " return !!(th && !th.classList.contains('hdr-pinned')); }",
+        timeout=6000,
+    )
+    assert not _pinned(page)
+    assert _thead_top(page) < 0  # the header left with the table, no longer stuck at 0
+
+
+# ── the frozen header stays functional: select-all, sort, column filter ────────────────────
+def test_pinned_header_stays_interactive(page, ui_server, sticky_inventory):
+    _goto(page, ui_server)
+    _scroll_to_pin(page)
+    assert _pinned(page)
+
+    # (i) select-all from the pinned header checks every row checkbox.
+    page.locator("#data-table thead #select-all-rows").check()
+    page.wait_for_function(
+        "() => { var b=Array.from(document.querySelectorAll('#data-table tbody tr.data-row input.row-select'));"
+        " return b.length>0 && b.every(function(x){return x.checked;}); }",
+        timeout=4000,
+    )
+
+    # (ii) sort from the pinned header reorders rows; the re-rendered header re-pins.
+    key = _data_keys(page)[0]
+    before = _col_values(page, key)
+    _wait_swap(page, page.locator(f'#data-table thead th[data-key="{key}"] a.sort-link').first)
+    after = _col_values(page, key)
+    if after == before:  # already in this direction; toggle to the other
+        _wait_swap(page, page.locator(f'#data-table thead th[data-key="{key}"] a.sort-link').first)
+        after = _col_values(page, key)
+    assert after != before, "sort from the pinned header did not reorder the rows"
+    assert _pinned(page) and abs(_thead_top(page)) <= 2
+
+    # (iii) column filter from the pinned header applies server-side (fresh load resets the URL).
+    _goto(page, ui_server)
+    _scroll_to_pin(page)
+    page.locator("#data-table thead .colfilter[data-param='location_id']").first.click()
+    page.wait_for_selector(".colfilter-pop", timeout=4000)
+    page.locator(".colfilter-pop .colfilter-item", has_text="Sticky Loc Beta").locator("input").uncheck()
+    page.locator(".colfilter-pop .colfilter-foot button:has-text('Apply')").click()
+    page.wait_for_load_state("domcontentloaded")
+    page.wait_for_selector("#data-table", timeout=10000)
+    assert "location_id=" in page.url
+    body = page.locator("#data-table").inner_text()
+    assert "PINHDR-A-000" in body and "PINHDR-B-000" not in body
+
+
+# ── column reorder still works while frozen, and the header stays aligned after it ─────────
+def test_pinned_header_column_reorder_works(page, ui_server, sticky_inventory):
+    _goto(page, ui_server)
+    _scroll_to_pin(page)
+    assert _pinned(page)
+    keys_before = _data_keys(page)
+    # drag the 2nd data column ahead of the 1st (HTML5 drag; the handler reads a module-level key).
+    page.evaluate(
+        """([s,t]) => {
+          var thead=document.querySelector('#data-table thead tr');
+          var src=thead.querySelector('th[data-key=\"'+s+'\"]');
+          var tgt=thead.querySelector('th[data-key=\"'+t+'\"]');
+          var dt=new DataTransfer();
+          function fire(el,type){ el.dispatchEvent(new DragEvent(type,{bubbles:true,cancelable:true,dataTransfer:dt})); }
+          fire(src,'dragstart'); fire(tgt,'dragover'); fire(tgt,'drop'); fire(src,'dragend');
+        }""",
+        [keys_before[1], keys_before[0]],
+    )
+    keys_after = _data_keys(page)
+    assert keys_after != keys_before, "column order did not change after the drag"
+    first = keys_after[0]
+    lefts = _col_lefts(page, first)
+    assert lefts is not None and abs(lefts[0] - lefts[1]) <= 1.5
+    assert _pinned(page)
+
+
+# ── horizontal lockstep: the frozen header tracks the body sideways ────────────────────────
+def test_pinned_header_tracks_horizontal_scroll(page, ui_server, sticky_inventory):
+    _goto(page, ui_server)
+    # widen the first column so the table overflows its wrap horizontally.
+    page.evaluate(
+        "() => { var th=document.querySelector('#data-table thead th[data-key]'); if(th) th.style.width='900px'; }"
+    )
+    _scroll_to_pin(page)
+    page.evaluate(
+        "() => { var w=document.querySelector('.table-scroll-wrap'); w.scrollLeft=300; w.dispatchEvent(new Event('scroll')); }"
+    )
+    page.wait_for_timeout(200)
+    first = _data_keys(page)[0]
+    lefts = _col_lefts(page, first)
+    assert lefts is not None and abs(lefts[0] - lefts[1]) <= 2
+
+
+# ── scrolling back to the top restores the inline header (no pin, no spacer, no inline style) ─
+def test_scroll_back_up_restores_inline_header(page, ui_server, sticky_inventory):
+    _goto(page, ui_server)
+    _scroll_to_pin(page)
+    assert _pinned(page)
+    _scroll_to_top(page)
+    page.wait_for_function(
+        "() => { var th=document.querySelector('#data-table thead');"
+        " return !!(th && !th.classList.contains('hdr-pinned')); }",
+        timeout=6000,
+    )
+    assert not _pinned(page)
+    assert page.evaluate("() => getComputedStyle(document.querySelector('#data-table thead')).position") == "static"
+    assert page.evaluate("() => document.querySelectorAll('#data-table .hdr-spacer').length") == 0
+
+
+# ── the controller re-scans after an htmx swap; no stale pinned node is left behind ─────────
+def test_pinned_header_survives_htmx_swap(page, ui_server, sticky_inventory):
+    _goto(page, ui_server)
+    _scroll_to_pin(page)
+    assert _pinned(page)
+    key = _data_keys(page)[0]
+    _wait_swap(page, page.locator(f'#data-table thead th[data-key="{key}"] a.sort-link').first)
+    assert _pinned(page) and abs(_thead_top(page)) <= 2
+    counts = page.evaluate(
+        "() => ({pinned: document.querySelectorAll('.hdr-pinned').length,"
+        " spacer: document.querySelectorAll('.hdr-spacer').length})"
+    )
+    assert counts["pinned"] == 1, "exactly one header should be pinned after the swap"
+    assert counts["spacer"] <= 1, "no orphaned spacer row from the old table"
+
+
+# ── a column resized while pinned recomputes geometry so the header stays aligned ──────────
+def test_pinned_header_resize_realigns(page, ui_server, sticky_inventory):
+    _goto(page, ui_server)
+    _scroll_to_pin(page)
+    keys = _data_keys(page)
+    page.evaluate(
+        "(k) => { var th=document.querySelector('#data-table thead th[data-key=\"'+k+'\"]');"
+        " th.style.width=(th.getBoundingClientRect().width+180)+'px'; }",
+        keys[0],
+    )
+    page.wait_for_timeout(250)
+    lefts = _col_lefts(page, keys[1])
+    assert lefts is not None and abs(lefts[0] - lefts[1]) <= 2
+    dims = page.evaluate(
+        "() => [document.querySelector('#data-table thead').getBoundingClientRect().width,"
+        " document.querySelector('#data-table').getBoundingClientRect().width]"
+    )
+    assert abs(dims[0] - dims[1]) <= 3, "pinned header width should track the body width"
+
+
+# ── beforeprint actively clears the pin so no overlay/spacer/pixel-widths reach print ──────
+def test_beforeprint_unpins_pinned_header(page, ui_server, sticky_inventory):
+    _goto(page, ui_server)
+    _scroll_to_pin(page)
+    assert _pinned(page)
+    assert page.evaluate("() => document.querySelectorAll('#data-table .hdr-spacer').length") >= 1
+    page.evaluate("() => window.dispatchEvent(new Event('beforeprint'))")
+    page.wait_for_timeout(150)
+    assert not _pinned(page)
+    assert page.evaluate("() => document.querySelectorAll('#data-table .hdr-spacer').length") == 0
+    inline = page.evaluate(
+        "() => { var th=document.querySelector('#data-table thead');"
+        " return {position: th.style.position, left: th.style.left, width: th.style.width}; }"
+    )
+    assert inline["position"] == "" and inline["left"] == "" and inline["width"] == ""

--- a/tests/test_browser/test_sticky_header.py
+++ b/tests/test_browser/test_sticky_header.py
@@ -37,11 +37,21 @@ def _goto(page, ui_server):
     page.wait_for_selector("#data-table thead th[data-key]", timeout=10000)
 
 
+# The controller marks the opted-in table with .hdr-pinned; the CSS rule
+# .data-table.sticky-head.hdr-pinned > thead then fixes the header. The class lives
+# on the table, so every pinned/unpinned check reads the table, not the thead.
+_PINNED_JS = (
+    "() => { var t=document.querySelector('#data-table');"
+    " return !!(t && t.classList.contains('hdr-pinned')); }"
+)
+_UNPINNED_JS = (
+    "() => { var t=document.querySelector('#data-table');"
+    " return !!(t && !t.classList.contains('hdr-pinned')); }"
+)
+
+
 def _pinned(page) -> bool:
-    return page.evaluate(
-        "() => { var th=document.querySelector('#data-table thead');"
-        " return !!(th && th.classList.contains('hdr-pinned')); }"
-    )
+    return page.evaluate(_PINNED_JS)
 
 
 def _thead_top(page):
@@ -118,11 +128,7 @@ def _scroll_to_pin(page, margin=40):
         if cur is None or cur <= -margin + 1:
             break
         _scroll_delta(page, cur + margin)
-    page.wait_for_function(
-        "() => { var th=document.querySelector('#data-table thead');"
-        " return !!(th && th.classList.contains('hdr-pinned')); }",
-        timeout=6000,
-    )
+    page.wait_for_function(_PINNED_JS, timeout=6000)
 
 
 def _add_scroll_room(page):
@@ -142,11 +148,7 @@ def _wait_swap(page, click_target):
         "() => { var t=document.querySelector('#data-table'); return !!t && !t.hasAttribute('data-swaptmp'); }",
         timeout=8000,
     )
-    page.wait_for_function(
-        "() => { var th=document.querySelector('#data-table thead');"
-        " return !!(th && th.classList.contains('hdr-pinned')); }",
-        timeout=6000,
-    )
+    page.wait_for_function(_PINNED_JS, timeout=6000)
 
 
 # ── behaviors (a) + (b): inline before the top, frozen once the table top reaches it ───────
@@ -183,11 +185,7 @@ def test_header_unpins_past_table_end(page, ui_server, sticky_inventory):
         if bottom <= -5:
             break
         _scroll_delta(page, bottom + 40)
-    page.wait_for_function(
-        "() => { var th=document.querySelector('#data-table thead');"
-        " return !!(th && !th.classList.contains('hdr-pinned')); }",
-        timeout=6000,
-    )
+    page.wait_for_function(_UNPINNED_JS, timeout=6000)
     assert not _pinned(page)
     assert _thead_top(page) < 0  # the header left with the table, no longer stuck at 0
 
@@ -280,11 +278,7 @@ def test_scroll_back_up_restores_inline_header(page, ui_server, sticky_inventory
     _scroll_to_pin(page)
     assert _pinned(page)
     _scroll_to_top(page)
-    page.wait_for_function(
-        "() => { var th=document.querySelector('#data-table thead');"
-        " return !!(th && !th.classList.contains('hdr-pinned')); }",
-        timeout=6000,
-    )
+    page.wait_for_function(_UNPINNED_JS, timeout=6000)
     assert not _pinned(page)
     assert page.evaluate("() => getComputedStyle(document.querySelector('#data-table thead')).position") == "static"
     assert page.evaluate("() => document.querySelectorAll('#data-table .hdr-spacer').length") == 0
@@ -341,3 +335,6 @@ def test_beforeprint_unpins_pinned_header(page, ui_server, sticky_inventory):
         " return {position: th.style.position, left: th.style.left, width: th.style.width}; }"
     )
     assert inline["position"] == "" and inline["left"] == "" and inline["width"] == ""
+
+
+

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -2393,6 +2393,38 @@ class TestCSSConsistency:
         m = re.search(r"@media print\s*\{.*?\.hdr-spacer[^}]*display:\s*none[^}]*\}", css, re.S)
         assert m, "no @media print rule hiding .hdr-spacer"
 
+    @pytest.mark.asyncio
+    async def test_sticky_scrollbar_css_present(self):
+        """The pinned phantom top-scrollbar rules must fix it above the header, gate the header
+        drop on a phantom being present, single-source its height, and hide its print spacer.
+
+        Red at merge-base: none of .top-scroll-pinned, the .has-top-phantom header offset,
+        the --top-scroll-h var, or the .top-scroll-spacer print rule exist yet.
+        """
+        import pathlib
+        import re
+        css = pathlib.Path(__file__).parent.parent.joinpath("ui/static/app.css").read_text()
+        # (1) the frozen phantom is fixed at the very top, above the header (z-index above the thead).
+        pin = re.search(
+            r"\.table-top-scroll\.top-scroll-pinned\s*\{[^}]*position:\s*fixed[^}]*\}", css
+        )
+        assert pin, "no fixed-position rule for the pinned phantom scrollbar"
+        assert "top: 0" in pin.group(0) or "top:0" in pin.group(0)
+        # (2) the header drop is gated on .has-top-phantom, so a phantom-less table keeps top:0.
+        off = re.search(
+            r"\.data-table\.sticky-head\.hdr-pinned\.has-top-phantom\s*>\s*thead\s*\{[^}]*top:\s*var\(--top-scroll-h\)[^}]*\}",
+            css,
+        )
+        assert off, "header offset rule must require .has-top-phantom and use var(--top-scroll-h)"
+        # (3) the phantom height is single-sourced through the CSS variable.
+        assert re.search(r"--top-scroll-h:\s*16px", css), "no --top-scroll-h definition"
+        assert re.search(r"\.table-top-scroll\s*\{[^}]*height:\s*var\(--top-scroll-h\)", css), \
+            "the phantom height must read var(--top-scroll-h), not a literal"
+        # (4) the pin lives on screen only, and the print spacer is hidden like the header spacer.
+        assert "@media screen" in css
+        assert re.search(r"@media print\s*\{.*?\.top-scroll-spacer[^}]*display:\s*none[^}]*\}", css, re.S), \
+            "no @media print rule hiding .top-scroll-spacer"
+
 
 class TestSearchableSelect:
     """Verify the searchable_select component renders correctly."""

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -2362,6 +2362,37 @@ class TestCSSConsistency:
         assert ".combobox-list" in css
         assert ".combobox-option" in css
 
+    @pytest.mark.asyncio
+    async def test_sticky_header_css_present(self):
+        """The pinned sticky header rule must fix the thead to the viewport top, screen-only.
+
+        Red at merge-base: no .sticky-head / .hdr-pinned styling exists yet, so the regex
+        for a fixed-position pinned thead finds nothing.
+        """
+        import pathlib
+        import re
+        css = pathlib.Path(__file__).parent.parent.joinpath("ui/static/app.css").read_text()
+        m = re.search(
+            r"\.data-table\.sticky-head\.hdr-pinned\s*>\s*thead\s*\{[^}]*position:\s*fixed[^}]*\}",
+            css,
+        )
+        assert m, "no fixed-position rule for the pinned sticky-head thead"
+        assert "top: 0" in m.group(0) or "top:0" in m.group(0)
+        # The pin is confined to on-screen rendering, never print.
+        assert "@media screen" in css
+
+    @pytest.mark.asyncio
+    async def test_sticky_header_print_spacer_hidden(self):
+        """The header-height spacer row must be hidden in print so it leaves no blank gap.
+
+        Red at merge-base: no .hdr-spacer print rule exists yet.
+        """
+        import pathlib
+        import re
+        css = pathlib.Path(__file__).parent.parent.joinpath("ui/static/app.css").read_text()
+        m = re.search(r"@media print\s*\{.*?\.hdr-spacer[^}]*display:\s*none[^}]*\}", css, re.S)
+        assert m, "no @media print rule hiding .hdr-spacer"
+
 
 class TestSearchableSelect:
     """Verify the searchable_select component renders correctly."""
@@ -3574,6 +3605,24 @@ class TestColumnDefaults:
         css = open(pathlib.Path(__file__).parent.parent / "ui/static/app.css").read()
         assert "col-resize-handle" in css
         assert "cursor: col-resize" in css
+
+    @pytest.mark.asyncio
+    async def test_sticky_header_optin_on_list_pages(self, ui_client):
+        """List pages opt the shared data-table into the sticky header, and the pin controller
+        ships so every data-table.sticky-head list page freezes its header.
+
+        Red at merge-base: neither the sticky-head opt-in class nor the controller exist yet.
+        """
+        schema = [{"key": "sku", "label": "SKU", "type": "text", "editable": True}]
+        items = [{"entity_id": "item:1", "sku": "SKU-1", "name": "Widget"}]
+        with (
+            patch("ui.api_client.get_item_schema", new=AsyncMock(return_value=schema)),
+            patch("ui.api_client.list_items", new=AsyncMock(return_value={"items": items, "total": len(items)})),
+            patch("ui.api_client.get_valuation", new=AsyncMock(return_value={"item_count": 1, "cost_total": 0, "retail_total": 0, "wholesale_total": 0, "active_item_count": 1, "category_counts": {}})),
+        ):
+            r = await ui_client.get("/inventory", cookies=_authed())
+        assert b"sticky-head" in r.content
+        assert b"table.data-table.sticky-head" in r.content
 
 
 # ===========================================================================

--- a/ui/components/shell.py
+++ b/ui/components/shell.py
@@ -1064,6 +1064,16 @@ _STICKY_HEADER_JS = """
 
   function isPinned(t){ return t.classList.contains('hdr-pinned'); }
 
+  // The phantom top-scrollbar (.table-top-scroll) is a sibling of the table's .table-scroll-wrap,
+  // both under #data-table-wrap, and exists only when the table has enough rows to warrant it
+  // (ui/components/table.py). When the header freezes, the phantom must freeze stacked directly
+  // above it so a user scrolled mid-table can still scroll left/right; it is null when absent.
+  function wrapOf(t){ return t.closest('.table-scroll-wrap'); }
+  function phantomOf(t){
+    var w = wrapOf(t); var c = w && w.parentElement;
+    return c ? c.querySelector(':scope > .table-top-scroll') : null;
+  }
+
   // Every DOM write the controller makes (colgroup, spacer row, thead styles, the pinned class)
   // is itself a mutation. MutationObserver callbacks are async microtasks, so a boolean "busy"
   // guard is already reset by the time the callback runs and cannot suppress them - the observer
@@ -1080,6 +1090,15 @@ _STICKY_HEADER_JS = """
     // rect.left already reflects the wrap's horizontal scroll, so it is the body's content left.
     thead.style.left = rect.left + 'px';
     thead.style.width = rect.width + 'px';
+    // Keep the frozen phantom aligned with the on-screen wrap so its track spans the visible body.
+    // Its scrollLeft stays synced to the wrap by the existing bidirectional listener, unaffected
+    // by fixing position (that sync is scrollLeft-based, not layout-based).
+    var ph = phantomOf(t);
+    if(ph && ph.classList.contains('top-scroll-pinned')){
+      var w = wrapOf(t); var wr = w.getBoundingClientRect();
+      ph.style.left = wr.left + 'px';
+      ph.style.width = w.clientWidth + 'px';
+    }
   }
 
   // Remove every colgroup/spacer the controller has ever added to this table. querySelectorAll,
@@ -1090,6 +1109,12 @@ _STICKY_HEADER_JS = """
     for(var i=0;i<cgs.length;i++) cgs[i].remove();
     var tb = t.tBodies[0];
     if(tb){ var sps = tb.querySelectorAll(':scope > tr.hdr-spacer'); for(var j=0;j<sps.length;j++) sps[j].remove(); }
+    // Revert the frozen phantom scrollbar and drop every top-scroll spacer this table ever added.
+    var ph = phantomOf(t);
+    if(ph){ ph.classList.remove('top-scroll-pinned'); ph.style.left = ''; ph.style.width = ''; }
+    t.classList.remove('has-top-phantom');
+    var wrap = wrapOf(t); var cont = wrap && wrap.parentElement;
+    if(cont){ var tss = cont.querySelectorAll(':scope > .top-scroll-spacer'); for(var k=0;k<tss.length;k++) tss[k].remove(); }
   }
 
   function pin(t){
@@ -1119,6 +1144,18 @@ _STICKY_HEADER_JS = """
     thead.style.display = 'table';
     thead.style.tableLayout = 'fixed';
     for(i=0;i<cells.length;i++) cells[i].style.width = widths[i] + 'px';
+    // Freeze the phantom top-scrollbar stacked directly above the header when one exists. The
+    // has-top-phantom class shifts the fixed thead down by the phantom height (CSS) so they stack;
+    // a spacer where the phantom sat keeps the content below from jumping up as it leaves flow.
+    var ph = phantomOf(t);
+    if(ph){
+      t.classList.add('has-top-phantom');
+      ph.classList.add('top-scroll-pinned');
+      var cont = wrapOf(t).parentElement;
+      var sp2 = document.createElement('div'); sp2.className = 'top-scroll-spacer';
+      sp2.style.height = ph.getBoundingClientRect().height + 'px';
+      cont.insertBefore(sp2, ph);
+    }
     t.classList.add('hdr-pinned');
     reposition(t);
   }

--- a/ui/components/shell.py
+++ b/ui/components/shell.py
@@ -1055,11 +1055,24 @@ _STICKY_HEADER_JS = """
   // clips position:sticky), so this pins the LIVE thead with position:fixed (from CSS) and keeps
   // the whole table's column geometry aligned. See app.css .data-table.sticky-head.hdr-pinned.
   var SEL = 'table.data-table.sticky-head';
-  var busy = false;
   var mqPrint = window.matchMedia ? window.matchMedia('print') : null;
+  var mo = null;
+  // Set the moment print is requested and cleared when it ends. beforeprint fires before some
+  // browsers flip the print media query, and a mutation arriving in that gap would otherwise
+  // re-pin the header we just cleared; this flag keeps the controller a no-op through print.
+  var printing = false;
 
-  function scrollerOf(t){ return t.closest('.table-scroll-wrap') || t.closest('.main-content'); }
   function isPinned(t){ return t.classList.contains('hdr-pinned'); }
+
+  // Every DOM write the controller makes (colgroup, spacer row, thead styles, the pinned class)
+  // is itself a mutation. MutationObserver callbacks are async microtasks, so a boolean "busy"
+  // guard is already reset by the time the callback runs and cannot suppress them - the observer
+  // would re-fire on its own writes forever. Disconnect it for the duration of every write pass
+  // instead; genuine external mutations (rows added, an inline edit) still fire once we reconnect.
+  function pauseObserver(fn){
+    if(mo){ mo.disconnect(); }
+    try { fn(); } finally { observe(); }
+  }
 
   function reposition(t){
     var thead = t.tHead; if(!thead) return;
@@ -1069,9 +1082,20 @@ _STICKY_HEADER_JS = """
     thead.style.width = rect.width + 'px';
   }
 
+  // Remove every colgroup/spacer the controller has ever added to this table. querySelectorAll,
+  // not querySelector: a re-render can leave the artifacts in place while stripping the pinned
+  // class, so pin/unpin must clear ALL of them or a duplicate survives every later cycle.
+  function clearPinArtifacts(t){
+    var cgs = t.querySelectorAll(':scope > colgroup.hdr-cg');
+    for(var i=0;i<cgs.length;i++) cgs[i].remove();
+    var tb = t.tBodies[0];
+    if(tb){ var sps = tb.querySelectorAll(':scope > tr.hdr-spacer'); for(var j=0;j<sps.length;j++) sps[j].remove(); }
+  }
+
   function pin(t){
     var thead = t.tHead; if(!thead || !thead.rows.length) return;
-    busy = true;
+    // Idempotent: drop any stale artifacts before recapturing, so re-pinning never duplicates them.
+    clearPinArtifacts(t);
     var cells = thead.rows[0].cells;
     var widths = [], i;
     for(i=0;i<cells.length;i++) widths.push(cells[i].getBoundingClientRect().width);
@@ -1097,46 +1121,45 @@ _STICKY_HEADER_JS = """
     for(i=0;i<cells.length;i++) cells[i].style.width = widths[i] + 'px';
     t.classList.add('hdr-pinned');
     reposition(t);
-    busy = false;
   }
 
   function unpin(t){
-    busy = true;
     t.classList.remove('hdr-pinned');
     var thead = t.tHead;
     if(thead){
       thead.style.display = ''; thead.style.tableLayout = ''; thead.style.width = ''; thead.style.left = '';
       if(thead.rows.length){ var cells = thead.rows[0].cells; for(var i=0;i<cells.length;i++) cells[i].style.width = ''; }
     }
-    var cg = t.querySelector(':scope > colgroup.hdr-cg'); if(cg) cg.remove();
     t.style.tableLayout = ''; t.style.width = '';
-    var tb = t.tBodies[0];
-    if(tb){ var sp = tb.querySelector(':scope > tr.hdr-spacer'); if(sp) sp.remove(); }
-    busy = false;
+    clearPinArtifacts(t);
   }
 
   function unpinAll(){
-    var tables = document.querySelectorAll(SEL);
-    for(var i=0;i<tables.length;i++) if(isPinned(tables[i])) unpin(tables[i]);
+    pauseObserver(function(){
+      var tables = document.querySelectorAll(SEL);
+      for(var i=0;i<tables.length;i++) if(isPinned(tables[i])) unpin(tables[i]);
+    });
   }
 
   function evaluate(full){
-    if(mqPrint && mqPrint.matches){ unpinAll(); return; }
-    var tables = document.querySelectorAll(SEL);
-    for(var i=0;i<tables.length;i++){
-      var t = tables[i];
-      var thead = t.tHead; if(!thead){ continue; }
-      // On a full re-evaluate (resize, re-render, reorder) drop stale geometry so widths recapture.
-      if(full && isPinned(t)) unpin(t);
-      var rect = t.getBoundingClientRect();
-      var theadH = thead.getBoundingClientRect().height;
-      var shouldPin = rect.top <= 0 && (rect.bottom - theadH) > 0;
-      if(shouldPin){
-        if(!isPinned(t)) pin(t); else reposition(t);
-      } else if(isPinned(t)){
-        unpin(t);
+    if(printing || (mqPrint && mqPrint.matches)){ unpinAll(); return; }
+    pauseObserver(function(){
+      var tables = document.querySelectorAll(SEL);
+      for(var i=0;i<tables.length;i++){
+        var t = tables[i];
+        var thead = t.tHead; if(!thead){ continue; }
+        // On a full re-evaluate (resize, re-render, reorder) drop stale geometry so widths recapture.
+        if(full && isPinned(t)) unpin(t);
+        var rect = t.getBoundingClientRect();
+        var theadH = thead.getBoundingClientRect().height;
+        var shouldPin = rect.top <= 0 && (rect.bottom - theadH) > 0;
+        if(shouldPin){
+          if(!isPinned(t)) pin(t); else reposition(t);
+        } else if(isPinned(t)){
+          unpin(t);
+        }
       }
-    }
+    });
   }
 
   function onScroll(){ evaluate(false); }
@@ -1147,14 +1170,15 @@ _STICKY_HEADER_JS = """
   // and so the wrap's horizontal scroll repositions the frozen header in lockstep with the body.
   document.addEventListener('scroll', onScroll, true);
   window.addEventListener('resize', onFull);
-  document.body && document.body.addEventListener('htmx:afterSwap', onFull);
   document.addEventListener('htmx:afterSwap', onFull);
   document.addEventListener('celerp:col-reorder', onFull);
-  window.addEventListener('beforeprint', unpinAll);
-  window.addEventListener('afterprint', onScroll);
+  window.addEventListener('beforeprint', function(){ printing = true; unpinAll(); });
+  window.addEventListener('afterprint', function(){ printing = false; onScroll(); });
 
-  var mo = new MutationObserver(function(){ if(busy) return; onFull(); });
-  function observe(){ if(document.body) mo.observe(document.body, {childList:true, subtree:true, attributes:true}); }
+  mo = new MutationObserver(onFull);
+  // attributes:true catches a column-resize style write on a th; the controller's own writes
+  // never re-fire it because pauseObserver disconnects the observer for the duration of each pass.
+  function observe(){ if(mo && document.body) mo.observe(document.body, {childList:true, subtree:true, attributes:true}); }
   if(document.body) observe(); else document.addEventListener('DOMContentLoaded', observe);
 })();
 """

--- a/ui/components/shell.py
+++ b/ui/components/shell.py
@@ -1047,6 +1047,119 @@ def star_supporter_card(medium: str = "dashboard") -> FT:
     )
 
 
+_STICKY_HEADER_JS = """
+(function(){
+  // Freeze the header row of the excel-style list tables while the table body is on screen.
+  // Opt-in by class: only table.data-table.sticky-head is touched. The header cannot both live
+  // inside the horizontal-scroll wrap and stick to the window via pure CSS (the overflow-x wrap
+  // clips position:sticky), so this pins the LIVE thead with position:fixed (from CSS) and keeps
+  // the whole table's column geometry aligned. See app.css .data-table.sticky-head.hdr-pinned.
+  var SEL = 'table.data-table.sticky-head';
+  var busy = false;
+  var mqPrint = window.matchMedia ? window.matchMedia('print') : null;
+
+  function scrollerOf(t){ return t.closest('.table-scroll-wrap') || t.closest('.main-content'); }
+  function isPinned(t){ return t.classList.contains('hdr-pinned'); }
+
+  function reposition(t){
+    var thead = t.tHead; if(!thead) return;
+    var rect = t.getBoundingClientRect();
+    // rect.left already reflects the wrap's horizontal scroll, so it is the body's content left.
+    thead.style.left = rect.left + 'px';
+    thead.style.width = rect.width + 'px';
+  }
+
+  function pin(t){
+    var thead = t.tHead; if(!thead || !thead.rows.length) return;
+    busy = true;
+    var cells = thead.rows[0].cells;
+    var widths = [], i;
+    for(i=0;i<cells.length;i++) widths.push(cells[i].getBoundingClientRect().width);
+    var theadH = thead.getBoundingClientRect().height;
+    var tableW = t.getBoundingClientRect().width;
+    // Lock the whole table's columns so the body does not re-resolve once the thead leaves flow.
+    var cg = document.createElement('colgroup'); cg.className = 'hdr-cg';
+    for(i=0;i<widths.length;i++){ var col = document.createElement('col'); col.style.width = widths[i] + 'px'; cg.appendChild(col); }
+    t.insertBefore(cg, t.firstChild);
+    t.style.tableLayout = 'fixed';
+    t.style.width = tableW + 'px';
+    // Spacer row keeps the body from jumping up by the header's height while it is fixed.
+    var tb = t.tBodies[0];
+    if(tb){
+      var sp = document.createElement('tr'); sp.className = 'hdr-spacer';
+      var td = document.createElement('td'); td.colSpan = cells.length;
+      td.style.padding = '0'; td.style.border = '0'; td.style.height = theadH + 'px';
+      sp.appendChild(td); tb.insertBefore(sp, tb.firstChild);
+    }
+    // The fixed thead is its own table box so its cells lay out at the captured widths.
+    thead.style.display = 'table';
+    thead.style.tableLayout = 'fixed';
+    for(i=0;i<cells.length;i++) cells[i].style.width = widths[i] + 'px';
+    t.classList.add('hdr-pinned');
+    reposition(t);
+    busy = false;
+  }
+
+  function unpin(t){
+    busy = true;
+    t.classList.remove('hdr-pinned');
+    var thead = t.tHead;
+    if(thead){
+      thead.style.display = ''; thead.style.tableLayout = ''; thead.style.width = ''; thead.style.left = '';
+      if(thead.rows.length){ var cells = thead.rows[0].cells; for(var i=0;i<cells.length;i++) cells[i].style.width = ''; }
+    }
+    var cg = t.querySelector(':scope > colgroup.hdr-cg'); if(cg) cg.remove();
+    t.style.tableLayout = ''; t.style.width = '';
+    var tb = t.tBodies[0];
+    if(tb){ var sp = tb.querySelector(':scope > tr.hdr-spacer'); if(sp) sp.remove(); }
+    busy = false;
+  }
+
+  function unpinAll(){
+    var tables = document.querySelectorAll(SEL);
+    for(var i=0;i<tables.length;i++) if(isPinned(tables[i])) unpin(tables[i]);
+  }
+
+  function evaluate(full){
+    if(mqPrint && mqPrint.matches){ unpinAll(); return; }
+    var tables = document.querySelectorAll(SEL);
+    for(var i=0;i<tables.length;i++){
+      var t = tables[i];
+      var thead = t.tHead; if(!thead){ continue; }
+      // On a full re-evaluate (resize, re-render, reorder) drop stale geometry so widths recapture.
+      if(full && isPinned(t)) unpin(t);
+      var rect = t.getBoundingClientRect();
+      var theadH = thead.getBoundingClientRect().height;
+      var shouldPin = rect.top <= 0 && (rect.bottom - theadH) > 0;
+      if(shouldPin){
+        if(!isPinned(t)) pin(t); else reposition(t);
+      } else if(isPinned(t)){
+        unpin(t);
+      }
+    }
+  }
+
+  function onScroll(){ evaluate(false); }
+  function onFull(){ evaluate(true); }
+
+  document.addEventListener('DOMContentLoaded', onFull);
+  // Capture phase so whichever element scrolls vertically (window or an inner wrap) is caught,
+  // and so the wrap's horizontal scroll repositions the frozen header in lockstep with the body.
+  document.addEventListener('scroll', onScroll, true);
+  window.addEventListener('resize', onFull);
+  document.body && document.body.addEventListener('htmx:afterSwap', onFull);
+  document.addEventListener('htmx:afterSwap', onFull);
+  document.addEventListener('celerp:col-reorder', onFull);
+  window.addEventListener('beforeprint', unpinAll);
+  window.addEventListener('afterprint', onScroll);
+
+  var mo = new MutationObserver(function(){ if(busy) return; onFull(); });
+  function observe(){ if(document.body) mo.observe(document.body, {childList:true, subtree:true, attributes:true}); }
+  if(document.body) observe(); else document.addEventListener('DOMContentLoaded', observe);
+})();
+"""
+
+
 async def base_shell(*content, title: str = "Celerp", nav_active: str = "", companies: list[dict] | None = None, extra_head: list | None = None, lang: str = "en", request=None, company_settings: dict | None = None) -> FT:
     """Outer chrome: sidebar nav + top header + content area."""
     from ui.config import get_user_email, get_relay_info, get_token
@@ -1079,6 +1192,7 @@ async def base_shell(*content, title: str = "Celerp", nav_active: str = "", comp
         Script(_USER_MENU_JS),
         Script(_BUG_LINK_JS),
         Script(_STAR_CTA_JS),
+        Script(_STICKY_HEADER_JS),
     ]
     if extra_head:
         head_items.extend(extra_head)

--- a/ui/components/table.py
+++ b/ui/components/table.py
@@ -1994,7 +1994,7 @@ function sendToTypeChanged(docType){
     return Div(
         top_scroll,
         Div(
-            Table(header, Tbody(*[_row(r) for r in rows]), cls="data-table", id="data-table"),
+            Table(header, Tbody(*[_row(r) for r in rows]), cls="data-table sticky-head", id="data-table"),
             cls="table-scroll-wrap",
         ),
         *scripts,

--- a/ui/routes/contacts.py
+++ b/ui/routes/contacts.py
@@ -498,7 +498,7 @@ def _documents_tab(docs: list[dict], contact: dict | None = None, contact_id: st
         docs_section = Table(
             Thead(Tr(Th(t("th.doc")), Th(t("th.doc_type")), Th(t("th.date")), Th(t("th.total")), Th(t("th.status")))),
             Tbody(*rows),
-            cls="data-table",
+            cls="data-table sticky-head",
         )
 
     # Files / upload section (suppressed on the Company Details page - files live on Company Files)

--- a/ui/routes/documents.py
+++ b/ui/routes/documents.py
@@ -3319,7 +3319,7 @@ celerpUpdateBulkAlloc();
         payment_table = Table(
             Thead(Tr(Th(t("th.date")), Th(t("th.document")), Th(t("page.contact_detail")), Th(t("label.method")), Th(t("label.reference")), Th(t("label.amount")), Th(t("th.status")))),
             Tbody(*[_pay_row(p) for p in payments_list]) if payments_list else Tbody(Tr(Td(t("doc.no_payments_found"), colspan="7", cls="empty-state-msg"))),
-            cls="data-table", id="payments-table",
+            cls="data-table sticky-head", id="payments-table",
         )
 
         lang = get_lang(request)
@@ -4854,7 +4854,7 @@ def _doc_table(
                 _th("Status", "status"),
             )),
             Tbody(*[_row(d) for d in docs]),
-            cls="data-table",
+            cls="data-table sticky-head",
         ),
         bulk_js,
         id="doc-table",
@@ -8574,7 +8574,7 @@ def _list_table(lists: list[dict], lang: str = "en") -> FT:
             Th(t("th.status")),
         )),
         Tbody(*[_row(d) for d in lists]),
-        cls="data-table",
+        cls="data-table sticky-head",
         id="list-table",
     )
 

--- a/ui/routes/settings.py
+++ b/ui/routes/settings.py
@@ -3302,7 +3302,7 @@ def _terms_conditions_tab(templates: list[dict], prefix: str = "terms-conditions
         Table(
             Thead(Tr(Th(t("th.name")), Th(t("th.text")), Th(t("th.document_types")), Th(t("th.default_for")), Th(""))),
             Tbody(*[_row(gi, tpl) for gi, tpl in filtered]),
-            cls="data-table",
+            cls="data-table sticky-head",
         ),
         cls="settings-card",
     )
@@ -3621,7 +3621,7 @@ def _schema_tab(schema: list[dict], cat_schemas: dict, cat_tab: str = "") -> FT:
             Table(
                 Thead(Tr(Th("Order", title="Display order - click to change"), Th("Name"), Th(t("th.doc_type")), Th("Req"), Th("Edit"), Th("In Table"), Th(t("th.options")), Th(""))),
                 Tbody(*[_cat_row(i, f) for i, f in enumerate(sorted_schema)], add_row),
-                cls="data-table",
+                cls="data-table sticky-head",
             ),
             cls="settings-card",
         )
@@ -3650,7 +3650,7 @@ def _schema_tab(schema: list[dict], cat_schemas: dict, cat_tab: str = "") -> FT:
         Table(
             Thead(Tr(Th("#"), Th(t("th.key")), Th(t("th.label")), Th(t("th.doc_type")), Th(t("th.required")), Th(t("th.editable")), Th(t("th.show_in_table")), Th(t("th.options")))),
             Tbody(*[_row(i, f) for i, f in enumerate(sorted_schema)]),
-            cls="data-table",
+            cls="data-table sticky-head",
         ),
         cls="settings-card",
     )
@@ -3698,7 +3698,7 @@ def _locations_tab(locations: list[dict], lang: str = "en") -> FT:
         Table(
             Thead(Tr(Th(t("th.name")), Th(t("th.doc_type")), Th(t("th.address")), Th(t("th.default")), Th(""))),
             Tbody(*[_row(l) for l in locations]) if locations else Tbody(Tr(Td(t("settings.no_locations_yet"), colspan="5", cls="empty-state-msg"))),
-            cls="data-table",
+            cls="data-table sticky-head",
         ),
         cls="settings-card",
     )
@@ -4161,7 +4161,7 @@ def _import_history_tab(batches: list[dict]) -> FT:
             Tbody(*[_row(b) for b in batches]) if batches else Tbody(
                 Tr(Td(t("settings.no_imports_yet"), colspan="6", cls="empty-state-msg"))
             ),
-            cls="data-table",
+            cls="data-table sticky-head",
         ),
         cls="settings-card",
     )

--- a/ui/routes/settings_accounting.py
+++ b/ui/routes/settings_accounting.py
@@ -327,7 +327,7 @@ def _chart_table(chart: list[dict]) -> FT:
         Thead(Tr(Th(t("th.code")), Th(t("th.name")), Th(t("th.doc_type")), Th(t("th.parent")),
                  Th(t("th.cash_flow_section")), Th(t("th.status")), Th(""))),
         Tbody(*sections),
-        cls="data-table",
+        cls="data-table sticky-head",
     )
 
 

--- a/ui/routes/settings_inventory.py
+++ b/ui/routes/settings_inventory.py
@@ -291,7 +291,7 @@ def _categories_tab(
                          Th(t("th.required")), Th(t("th.editable")), Th(t("th.show_in_table")),
                          Th(t("th.options")), Th(""))),
                 Tbody(*[_cat_row(i, f) for i, f in enumerate(sorted_fields)], add_row),
-                cls="data-table",
+                cls="data-table sticky-head",
             ),
             cls="settings-card",
         )

--- a/ui/static/app.css
+++ b/ui/static/app.css
@@ -298,6 +298,19 @@ a:hover { text-decoration: underline; }
   user-select: none; overflow: hidden;
 }
 .data-table th[draggable="true"] { cursor: grab; }
+/* Sticky (frozen) table header. A JS controller (_STICKY_HEADER_JS) pins the live
+   thead while the table body is on screen, adding .hdr-pinned to the opted-in table.
+   Screen only: print keeps the native per-page thead repeat, so position/top/z-index
+   live here and are never set inline. The opaque background matches .data-table thead
+   above so body rows never show through the frozen header. */
+@media screen {
+  .data-table.sticky-head.hdr-pinned > thead {
+    position: fixed;
+    top: 0;
+    z-index: 5;
+    background: var(--c-bg3);
+  }
+}
 .data-table th[draggable="true"]:active { cursor: grabbing; }
 .data-table th.col-dragging { opacity: 0.5; }
 .data-table th.col-drag-over { border-left: 2px solid var(--c-accent); }
@@ -1356,6 +1369,9 @@ option.unit-unknown-option { color: var(--c-red, #ef4444); font-style: italic; }
 
   /* Always hide the bulk toolbar and checkboxes in print */
   .li-bulk-toolbar, #li-bulk-toolbar, .li-checkbox-cell { display: none !important; }
+
+  /* Sticky-header spacer row is screen-only scaffolding; never print it as a blank gap */
+  .hdr-spacer { display: none !important; }
 }
 
 /* Line item checkbox column */

--- a/ui/static/app.css
+++ b/ui/static/app.css
@@ -37,6 +37,8 @@
   --c-amber: #d97706;
   --c-amber-dark: #92400e;
   --c-drafts: #e6a817;
+  /* Height of the phantom top-scrollbar; the frozen header offsets down by this so they stack. */
+  --top-scroll-h: 16px;
   /* Recon-specific semantic colors */
   --c-green-bg: #f0fdf4;
   --c-green-text: #166534;
@@ -273,7 +275,7 @@ a:hover { text-decoration: underline; }
 .table-scroll-wrap { overflow-x: auto; width: 100%; }
 /* Phantom top scrollbar: mirrors .table-scroll-wrap, sits directly above the table body.
    overflow-x:auto on a zero-height div shows only the scrollbar track. */
-.table-top-scroll { overflow-x: auto; overflow-y: hidden; width: 100%; height: 16px; }
+.table-top-scroll { overflow-x: auto; overflow-y: hidden; width: 100%; height: var(--top-scroll-h); }
 /* Catalog autocomplete dropdowns must escape table overflow */
 .data-table {
   width: max-content;
@@ -308,6 +310,18 @@ a:hover { text-decoration: underline; }
     position: fixed;
     top: 0;
     z-index: 5;
+    background: var(--c-bg3);
+  }
+  /* When a phantom top-scrollbar exists it freezes stacked directly above the header, so the
+     frozen header drops down by the scrollbar height. Tables with no phantom keep top:0. The
+     JS controller adds .has-top-phantom to the table and .top-scroll-pinned to the phantom. */
+  .data-table.sticky-head.hdr-pinned.has-top-phantom > thead {
+    top: var(--top-scroll-h);
+  }
+  .table-top-scroll.top-scroll-pinned {
+    position: fixed;
+    top: 0;
+    z-index: 6;
     background: var(--c-bg3);
   }
 }
@@ -1370,8 +1384,8 @@ option.unit-unknown-option { color: var(--c-red, #ef4444); font-style: italic; }
   /* Always hide the bulk toolbar and checkboxes in print */
   .li-bulk-toolbar, #li-bulk-toolbar, .li-checkbox-cell { display: none !important; }
 
-  /* Sticky-header spacer row is screen-only scaffolding; never print it as a blank gap */
-  .hdr-spacer { display: none !important; }
+  /* Sticky-header spacer row and top-scroll spacer are screen-only scaffolding; never print them as a blank gap */
+  .hdr-spacer, .top-scroll-spacer { display: none !important; }
 }
 
 /* Line item checkbox column */


### PR DESCRIPTION
On the excel-style list tables (inventory, contacts, the document lists, and the settings lists), the header row now stays in view while you scroll through a long table.

## Behaviour

- Before you reach the table, the header sits in its normal place; nothing changes.
- Once the top of the table reaches the top of the screen, the header row freezes there and the rows keep scrolling underneath it.
- When you scroll past the end of the table, the header scrolls away with it. The header is frozen only while the table body is on screen.

The frozen header stays fully functional: sorting, the column filter funnels, the select-all checkbox, and dragging columns to reorder all work exactly as they do when the header is in its normal position. Column widths and alignment stay locked to the body underneath, and the header tracks sideways when you scroll a wide table left or right.

Printing is unchanged: the header repeats per page as before, with no frozen overlay.
