### PR TITLE
Fix frozen header custom columns, independent role permissions, and sell unit gating

### DIFF
--- a/celerp/migrations/versions/b3c4d5e6f7a8_expand_role_permissions_to_role_grants.py
+++ b/celerp/migrations/versions/b3c4d5e6f7a8_expand_role_permissions_to_role_grants.py
@@ -1,0 +1,141 @@
+# Copyright (c) 2026 Noah Severs
+# SPDX-License-Identifier: BUSL-1.1
+
+"""expand the role_permissions threshold overrides into explicit role_grants sets
+
+Revision ID: b3c4d5e6f7a8
+Revises: f8a9b0c1d2e3
+Create Date: 2026-08-09
+
+The data half of the per-role permissions change. Role overrides used to be a
+single minimum-role threshold per permission (Company.settings["role_permissions"]
+= {permission_key: minimum_role_key}); every role at or above that threshold was
+granted, so the roles moved as a block. They are now an explicit set of granted
+roles per permission (Company.settings["role_grants"] = {permission_key:
+[role_key, ...]}), each role granted independently. This migration rewrites every
+stored threshold into the exact set of roles it used to grant, so no company's
+effective permissions change, then drops the retired key.
+
+Deltas only: it materializes a grant set for the keys a company actually
+overrode, never the whole catalogue; unoverridden keys keep resolving to their
+registry default. Each threshold expands to every role at or above it, clamped up
+to the permission's floor (so a grandfathered sub-floor override lands on the
+floor exactly as the resolver reads it). A threshold on a permission that is no
+longer overridable, unknown to the catalogue, or naming a role that no longer
+exists never resolved to anything but the default, so it becomes no delta and is
+left absent.
+
+Signature-less (data only), so the develop-to-release reconcile replays it on
+every create_all/restore database. Idempotent: guarded on the presence of the
+retired key, so a second application is a no-op. Forward-only in effect; the
+downgrade drops the new key.
+
+The catalogue (floor role and overridability per permission) and the role levels
+are snapshotted here as literals, because a migration is immutable history: it
+must expand exactly as the rules stood when it was written, even after the
+registry in celerp.services.permissions later changes.
+"""
+
+from __future__ import annotations
+
+import json
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "b3c4d5e6f7a8"
+down_revision = "f8a9b0c1d2e3"
+branch_labels = None
+depends_on = None
+
+# Snapshot of auth.ROLE_LEVELS at this revision.
+_ROLE_LEVELS = {"viewer": 1, "operator": 2, "manager": 3, "admin": 4, "owner": 5}
+
+# Snapshot of the permission catalogue at this revision: key -> (floor_role,
+# grantable). default_role is irrelevant here because every key processed carries
+# an explicit override; only the floor (which clamps the expansion) and whether
+# the key is overridable at all matter.
+_CATALOGUE = {
+    "view_dashboards": ("viewer", True),
+    "view_documents": ("viewer", True),
+    "view_contacts": ("viewer", True),
+    "view_inventory": ("viewer", True),
+    "edit_documents": ("viewer", True),
+    "edit_contacts": ("viewer", True),
+    "edit_inventory": ("viewer", True),
+    "edit_inventory_amounts": ("viewer", True),
+    "finalize_documents": ("viewer", True),
+    "fulfill_documents": ("viewer", True),
+    "record_payments": ("viewer", True),
+    "manage_labels": ("viewer", True),
+    "manage_manufacturing": ("viewer", True),
+    "use_ai_assistant": ("viewer", True),
+    "run_backups": ("viewer", True),
+    "view_subscriptions": ("viewer", True),
+    "view_inventory_costs": ("viewer", True),
+    "set_inventory_prices": ("viewer", True),
+    "set_sales_doc_prices": ("viewer", True),
+    "delete_documents": ("viewer", True),
+    "adjust_inventory": ("viewer", True),
+    "import_export_data": ("viewer", True),
+    "view_payments": ("viewer", True),
+    "view_financial_reports": ("viewer", True),
+    "manage_accounting": ("viewer", True),
+    "manage_module_settings": ("viewer", True),
+    "manage_users": ("viewer", True),
+    "manage_company_settings": ("admin", True),
+    "manage_integrations": ("viewer", True),
+    "manage_permissions": ("owner", False),
+    "manage_company_lifecycle": ("owner", False),
+    "manage_billing": ("owner", False),
+}
+
+
+def _expand(stored_role: str, floor_role: str) -> list[str]:
+    """The role keys a threshold used to grant: every role at or above the
+    threshold, clamped up to the floor, ordered low to high."""
+    threshold = max(_ROLE_LEVELS[stored_role], _ROLE_LEVELS[floor_role])
+    return sorted(
+        (r for r, lvl in _ROLE_LEVELS.items() if lvl >= threshold),
+        key=lambda r: _ROLE_LEVELS[r],
+    )
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    # Only companies that still carry the retired key; this is also the
+    # idempotency guard, so a replay after the key is stripped touches nothing.
+    rows = conn.execute(sa.text(
+        "SELECT id, settings FROM companies WHERE settings::jsonb ? 'role_permissions'"
+    )).fetchall()
+
+    for cid, settings in rows:
+        data = settings if isinstance(settings, dict) else json.loads(settings)
+        role_perms = data.get("role_permissions")
+        grants = dict(data.get("role_grants") or {})
+        if isinstance(role_perms, dict):
+            for key, stored_role in role_perms.items():
+                meta = _CATALOGUE.get(key)
+                if meta is None:
+                    continue  # unknown key: never resolved to an override
+                floor_role, grantable = meta
+                if not grantable:
+                    continue  # fixed permission: overrides were never honored
+                if stored_role not in _ROLE_LEVELS:
+                    continue  # stale role: resolved to the default, no delta
+                grants[key] = _expand(stored_role, floor_role)
+        if grants:
+            data["role_grants"] = grants
+        data.pop("role_permissions", None)
+        conn.execute(
+            sa.text("UPDATE companies SET settings = CAST(:s AS json) WHERE id = :id"),
+            {"s": json.dumps(data), "id": str(cid)},
+        )
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    conn.execute(sa.text(
+        "UPDATE companies SET settings = (settings::jsonb - 'role_grants')::json "
+        "WHERE settings::jsonb ? 'role_grants'"
+    ))

--- a/celerp/migrations/versions/b3c4d5e6f7a8_expand_role_permissions_to_role_grants.py
+++ b/celerp/migrations/versions/b3c4d5e6f7a8_expand_role_permissions_to_role_grants.py
@@ -27,8 +27,13 @@ left absent.
 
 Signature-less (data only), so the develop-to-release reconcile replays it on
 every create_all/restore database. Idempotent: guarded on the presence of the
-retired key, so a second application is a no-op. Forward-only in effect; the
-downgrade drops the new key.
+retired key, so a second application is a no-op. The downgrade is the best-effort
+inverse: it collapses each grant set back to a single threshold at its lowest
+granted role and restores the retired key, so a rollback to the threshold-reading
+code keeps a company's effective permissions. This round-trips exactly for the
+contiguous sets the upgrade produces; a hand-authored non-contiguous set is
+documented lossy (it collapses to its lowest role, which the older resolver then
+re-expands as a block).
 
 The catalogue (floor role and overridability per permission) and the role levels
 are snapshotted here as literals, because a migration is immutable history: it
@@ -101,6 +106,18 @@ def _expand(stored_role: str, floor_role: str) -> list[str]:
     )
 
 
+def _collapse(granted_roles: list[str]) -> str | None:
+    """Best-effort inverse of _expand: the threshold role at the lowest granted
+    level. Exact for a contiguous set (the shape upgrade produces); lossy for a
+    non-contiguous set, which no longer round-trips to the same set. None when no
+    granted role is known, leaving the permission absent (resolves to default)."""
+    levels = [_ROLE_LEVELS[r] for r in granted_roles if r in _ROLE_LEVELS]
+    if not levels:
+        return None
+    low = min(levels)
+    return next(r for r, lvl in _ROLE_LEVELS.items() if lvl == low)
+
+
 def upgrade() -> None:
     conn = op.get_bind()
     # Only companies that still carry the retired key; this is also the
@@ -135,7 +152,24 @@ def upgrade() -> None:
 
 def downgrade() -> None:
     conn = op.get_bind()
-    conn.execute(sa.text(
-        "UPDATE companies SET settings = (settings::jsonb - 'role_grants')::json "
-        "WHERE settings::jsonb ? 'role_grants'"
-    ))
+    # Only companies that carry the new key; this is also the idempotency guard.
+    rows = conn.execute(sa.text(
+        "SELECT id, settings FROM companies WHERE settings::jsonb ? 'role_grants'"
+    )).fetchall()
+
+    for cid, settings in rows:
+        data = settings if isinstance(settings, dict) else json.loads(settings)
+        grants = data.get("role_grants")
+        role_perms = dict(data.get("role_permissions") or {})
+        if isinstance(grants, dict):
+            for key, roles in grants.items():
+                threshold = _collapse(roles if isinstance(roles, list) else [])
+                if threshold is not None:
+                    role_perms[key] = threshold
+        if role_perms:
+            data["role_permissions"] = role_perms
+        data.pop("role_grants", None)
+        conn.execute(
+            sa.text("UPDATE companies SET settings = CAST(:s AS json) WHERE id = :id"),
+            {"s": json.dumps(data), "id": str(cid)},
+        )

--- a/celerp/routers/companies.py
+++ b/celerp/routers/companies.py
@@ -22,6 +22,7 @@ from celerp.services.permissions import (
     ROLES,
     get_current_company_settings,
     require_permission,
+    resolved_grant_roles,
     role_has_permission,
 )
 from celerp.tax_regimes import get_regime, TAX_REGIMES
@@ -286,6 +287,16 @@ async def patch_me(payload: CompanyPatch, company_id=Depends(get_current_company
     # and category_schemas whenever a caller sent only one field (the UI happens
     # to pre-merge, but partial callers — and a name-only patch — must be safe).
     if payload.settings:
+        # Role grants are owner-only and may be written only through the dedicated
+        # PATCH /me/role-permissions endpoint (manage_permissions). This door is
+        # admin-gated (manage_company_settings), so accepting role_grants here would
+        # let an admin self-escalate around the owner gate. role_permissions is the
+        # retired storage key; reject it too so it can never be re-introduced.
+        if "role_grants" in payload.settings or "role_permissions" in payload.settings:
+            raise HTTPException(
+                status_code=422,
+                detail="Role permissions are set through the permissions matrix, not company settings",
+            )
         merged = {**(company.settings or {}), **payload.settings}
         # Price config must pass the same gate as the dedicated endpoints: the read
         # path trusts stored config, so no door may store what the validator rejects.
@@ -309,12 +320,12 @@ async def patch_role_permissions(
     _: None = require_permission("manage_permissions"),
     session: AsyncSession = Depends(get_session),
 ) -> dict:
-    """Set one permission's minimum role from a matrix checkbox toggle.
+    """Toggle one (permission, role) cell from the matrix.
 
     Owner-only (manage_permissions is a fixed owner row, so no owner can revoke
     their own ability to edit permissions). A toggle names a (permission, role)
-    cell and whether that role should now hold the permission; the stored
-    override is the resulting threshold role, and every higher role inherits it.
+    cell and whether that role should now hold the permission; only that role's
+    membership changes - every other role keeps the grant it already had.
     """
     perm = next((p for p in PERMISSIONS if p.key == payload.perm_key), None)
     if perm is None:
@@ -324,31 +335,29 @@ async def patch_role_permissions(
     if not perm.grantable:
         raise HTTPException(status_code=403, detail=f"The {perm.key} permission is fixed and cannot be reassigned")
 
-    # Checking a role's box lowers the threshold to that role; unchecking raises it
-    # to the next role up, since every role at or above the threshold inherits.
-    if payload.granted:
-        new_threshold = payload.role_key
-    else:
-        higher = sorted((r for r in ROLES if r.level > ROLE_LEVELS[payload.role_key]), key=lambda r: r.level)
-        # The owner column is always granted and never rendered as an unchecked box,
-        # so there is always a higher role to raise the threshold to here.
-        new_threshold = higher[0].key
-    if ROLE_LEVELS[new_threshold] < ROLE_LEVELS[perm.floor_role]:
-        raise HTTPException(
-            status_code=422,
-            detail=f"The {perm.key} permission cannot go below the {perm.floor_role} role",
-        )
-
     company = await session.get(Company, company_id)
     if company is None:
         raise HTTPException(status_code=404, detail="Not found")
     settings = dict(company.settings or {})
-    overrides = dict(settings.get("role_permissions") or {})
-    overrides[perm.key] = new_threshold
-    settings["role_permissions"] = overrides
+    grants = dict(settings.get("role_grants") or {})
+    # Seed from the currently RESOLVED set on first touch, so toggling one role
+    # leaves every other role's grant exactly as it is today.
+    roles = set(resolved_grant_roles(settings, perm.key))
+    if payload.granted:
+        roles.add(payload.role_key)
+    else:
+        roles.discard(payload.role_key)
+    # Floor guard: no override may drop the permission below its floor role.
+    if payload.granted and ROLE_LEVELS[payload.role_key] < ROLE_LEVELS[perm.floor_role]:
+        raise HTTPException(
+            status_code=422,
+            detail=f"The {perm.key} permission cannot go below the {perm.floor_role} role",
+        )
+    grants[perm.key] = sorted(roles, key=lambda r: ROLE_LEVELS[r])
+    settings["role_grants"] = grants
     company.settings = settings
     await session.commit()
-    return {"ok": True, "perm_key": perm.key, "threshold_role": new_threshold}
+    return {"ok": True, "perm_key": perm.key, "roles": grants[perm.key]}
 
 
 # ---------------------------------------------------------------------------

--- a/celerp/services/field_schema.py
+++ b/celerp/services/field_schema.py
@@ -24,6 +24,13 @@ MIXED_VALUE = "Mixed"
 # COST_ITEM_KEYS precedent in celerp.services.cost_visibility.
 AMOUNT_ITEM_KEYS: frozenset[str] = frozenset({"quantity", "weight", "pieces", "gross_weight"})
 
+# Fields whose edit is gated by edit_inventory_amounts. Superset of the numeric
+# amount keys with sell_by added: changing the sell unit rewrites quantity, so it
+# carries the same authority as editing an amount directly. Kept distinct from
+# AMOUNT_ITEM_KEYS, which also drives the non-negative numeric validator on create
+# and import - sell_by is a unit string and must never reach that float() path.
+AMOUNT_EDIT_GATED_KEYS: frozenset[str] = AMOUNT_ITEM_KEYS | {"sell_by"}
+
 # Default price lists (used when company has none configured)
 _DEFAULT_PRICE_LISTS: list[dict] = [
     {"name": "Wholesale"},

--- a/celerp/services/permissions.py
+++ b/celerp/services/permissions.py
@@ -5,8 +5,10 @@
 ROLES derives from auth.ROLE_LEVELS so the numeric hierarchy stays
 single-sourced; PERMISSIONS is the ordered catalogue of every role-gated
 behavior, with per-company overrides stored under Company.settings
-["role_permissions"] as {permission_key: minimum_role_key}. Only changed
-permissions are stored; everything else resolves to its registry default.
+["role_grants"] as {permission_key: [role_key, ...]} - the explicit set of
+roles granted each overridden permission. Only changed permissions are stored;
+everything else resolves to its registry default set. Each role is granted
+independently: a grant to one role never implies a grant to any other.
 """
 from __future__ import annotations
 
@@ -96,28 +98,36 @@ def is_permission_key(key: str) -> bool:
     return key in _PERMISSIONS_BY_KEY
 
 
-def permission_min_level(settings: dict | None, key: str) -> int:
-    """Resolve the minimum role level for *key*: override if valid, else default.
+def resolved_grant_roles(settings: dict | None, key: str) -> set[str]:
+    """The set of role keys granted *key* for this company.
 
-    An override naming a role that no longer exists in ROLE_LEVELS is ignored
-    in favor of the default: never a crash, never an accidental grant.
+    Stored override (Company.settings["role_grants"][key]) if present, else the
+    registry default set {r : level(r) >= level(default_role)}. A stored set is
+    intersected with the roles at or above floor_role, so a grandfathered or
+    hand-edited grant can never drop a permission below its floor. A stored role
+    that no longer exists in ROLE_LEVELS is ignored: never a crash, never an
+    accidental grant. A fixed (non-grantable) permission never consults stored
+    grants, so no crafted role_grants entry can widen an owner-only permission.
+    Each role is resolved independently: membership carries no hierarchy.
     """
     perm = _PERMISSIONS_BY_KEY[key]
+    floor = ROLE_LEVELS[perm.floor_role]
     if perm.grantable:
-        overrides = (settings or {}).get("role_permissions") or {}
-        override_role = overrides.get(key)
-        if override_role in ROLE_LEVELS:
-            return max(ROLE_LEVELS[override_role], ROLE_LEVELS[perm.floor_role])
-    return ROLE_LEVELS[perm.default_role]
+        grants = (settings or {}).get("role_grants") or {}
+        if key in grants:
+            stored = grants.get(key) or []
+            return {r for r in stored if r in ROLE_LEVELS and ROLE_LEVELS[r] >= floor}
+    default = ROLE_LEVELS[perm.default_role]
+    return {r for r in ROLE_LEVELS if ROLE_LEVELS[r] >= default}
 
 
 def role_has_permission(settings: dict | None, role: str, key: str) -> bool:
-    """True when *role* meets the permission's resolved minimum.
+    """True when *role* is in the permission's resolved grant set.
 
     *role* is the already-migrated role key from get_current_role; an
-    unrecognized role resolves to level 0 and fails closed.
+    unrecognized role is absent from every set and so fails closed.
     """
-    return ROLE_LEVELS.get(role, 0) >= permission_min_level(settings, key)
+    return role in resolved_grant_roles(settings, key)
 
 
 def assert_role_permission(settings: dict | None, role: str, key: str) -> None:

--- a/default_modules/celerp-inventory/celerp_inventory/routes.py
+++ b/default_modules/celerp-inventory/celerp_inventory/routes.py
@@ -22,7 +22,7 @@ from celerp.models.projections import Projection
 from celerp.services.auth import get_current_company_id, get_current_user, get_current_role, ROLE_LEVELS
 from celerp.services.auto_je import create_for_item_transform
 from celerp.services.cost_visibility import COST_ITEM_KEYS, apply_field_visibility
-from celerp.services.field_schema import AMOUNT_ITEM_KEYS
+from celerp.services.field_schema import AMOUNT_EDIT_GATED_KEYS, AMOUNT_ITEM_KEYS
 from celerp.services.permissions import (
     assert_role_permission,
     get_current_company_settings,
@@ -1036,11 +1036,13 @@ async def patch_item(entity_id: str, payload: ItemPatch, company_id=Depends(get_
     restricted -= COST_ITEM_KEYS
     if not role_has_permission(settings, role, "set_inventory_prices"):
         restricted |= COST_ITEM_KEYS
-    # Amount fields (quantity/weight/pieces/gross_weight) are gated by
-    # edit_inventory_amounts, mirroring the cost gate above.
-    restricted -= AMOUNT_ITEM_KEYS
+    # Amount fields (quantity/weight/pieces/gross_weight) and the sell unit are
+    # gated by edit_inventory_amounts, mirroring the cost gate above. sell_by is
+    # included because changing it rewrites quantity, so it carries the same
+    # authority; the gate fires only on a real change (blocked = changed & restricted).
+    restricted -= AMOUNT_EDIT_GATED_KEYS
     if not role_has_permission(settings, role, "edit_inventory_amounts"):
-        restricted |= AMOUNT_ITEM_KEYS
+        restricted |= AMOUNT_EDIT_GATED_KEYS
     changed_keys = set(payload.fields_changed.keys())
     blocked = changed_keys & restricted
     if blocked:
@@ -2785,13 +2787,23 @@ async def batch_import_items(
         scoped_key = f"{company_id}:{rec.idempotency_key}"
         if scoped_key in existing:
             if body.upsert:
-                # Hand-editing an existing item's amount via CSV upsert is a genuine
-                # hand-edit surface, gated by edit_inventory_amounts. A create (below)
-                # defines the item and stays on edit_inventory.
-                if (AMOUNT_ITEM_KEYS & set(rec.data)) and not role_has_permission(settings, role, "edit_inventory_amounts"):
-                    errors.append(f"Row (SKU={rec.data.get('sku', '?')}): editing amount fields requires the edit_inventory_amounts permission")
-                    skipped += 1
-                    continue
+                # Hand-editing an existing item's amount or sell unit via CSV upsert is
+                # a genuine hand-edit surface, gated by edit_inventory_amounts. A create
+                # (below) defines the item and stays on edit_inventory. The amount keys
+                # are optional per row, so their presence already signals intent to
+                # change; sell_by is required on every row (validated above), so gating
+                # it on mere presence would block every upsert by an ungranted role.
+                # Gate sell_by on a real CHANGE against the stored value instead.
+                if not role_has_permission(settings, role, "edit_inventory_amounts"):
+                    gated = set(AMOUNT_ITEM_KEYS & set(rec.data))
+                    stored_proj = await session.get(Projection, {"company_id": company_id, "entity_id": rec.entity_id})
+                    stored_sell_by = str((stored_proj.state.get("sell_by") if stored_proj else "") or "").strip()
+                    if sell_by != stored_sell_by:
+                        gated.add("sell_by")
+                    if gated:
+                        errors.append(f"Row (SKU={rec.data.get('sku', '?')}): editing {sorted(gated)} requires the edit_inventory_amounts permission")
+                        skipped += 1
+                        continue
                 # Emit patch event with a upsert-specific idempotency key
                 upsert_idem = f"{scoped_key}:upsert"
                 upsert_existing = set(

--- a/default_modules/first_party.lock.json
+++ b/default_modules/first_party.lock.json
@@ -7,7 +7,7 @@
   "celerp-contacts": "899cf9febb388356290f6eb8c8ab6d67f1f92a9c9fa8377ebb6d46bf04cedbc3",
   "celerp-dashboard": "764c400fe2ae4a254389cc30945cd09cdd2301db83ed44ad67c325478bda572d",
   "celerp-docs": "e7d4672d016586d1733f35729e45625f6a82fbef314924512e3c6c1609bd531b",
-  "celerp-inventory": "a1cd12906b7b3d0dd777f5b364cd0a4147a8da5d320c89b380c5a8e552113dab",
+  "celerp-inventory": "8b79e29ad222647d34b04fef7ae7a58dc6d12d04e1e9124f1a9ed6c71f51deb7",
   "celerp-labels": "284087ba418c830a0eb147900f41a56512056575d552c959f73db918bd11b2cb",
   "celerp-manufacturing": "356d2211a68799315eade79b8b84662ce829d443f003806d9e9a6ffb8dbc5642",
   "celerp-reports": "f100f83b3fc3e4565685d3a0c8e62dcc724bb35d32238f051b05c5f97ae10d13",

--- a/test_helpers.py
+++ b/test_helpers.py
@@ -152,10 +152,27 @@ async def perm_setup(client, session):
 
 
 async def grant_permission(client, admin_headers: dict, permission: str, role: str) -> None:
-    """Set a company role_permissions override via the settings merge."""
-    r = await client.patch(
-        "/companies/me",
-        json={"settings": {"role_permissions": {permission: role}}},
-        headers=admin_headers,
-    )
-    assert r.status_code == 200, r.text
+    """Set *permission* so exactly *role* and the roles above it hold it, through the
+    owner-gated permissions matrix endpoint.
+
+    Role grants are per-role now, so this helper reproduces the single threshold its
+    callers rely on: it sets each role's cell to granted when the role is at or above
+    *role* (clamped up to the permission's floor) and to revoked when it is below.
+    That is the exact effect the old threshold override produced - every role above
+    the line holds the permission and every role below it does not - so callers that
+    "raise a key above operator" keep working unchanged. admin_headers must be an
+    owner token (register_admin creates the owner); grants can only be written
+    through this endpoint.
+    """
+    from celerp.services.auth import ROLE_LEVELS
+    from celerp.services.permissions import PERMISSIONS
+
+    perm = next(p for p in PERMISSIONS if p.key == permission)
+    target = max(ROLE_LEVELS[role], ROLE_LEVELS[perm.floor_role])
+    for role_key, level in ROLE_LEVELS.items():
+        r = await client.patch(
+            "/companies/me/role-permissions",
+            json={"perm_key": permission, "role_key": role_key, "granted": level >= target},
+            headers=admin_headers,
+        )
+        assert r.status_code == 200, r.text

--- a/tests/test_browser/test_sticky_header.py
+++ b/tests/test_browser/test_sticky_header.py
@@ -179,6 +179,20 @@ def _wait_swap(page, click_target):
     page.wait_for_function(_PINNED_JS, timeout=6000)
 
 
+def _drag_resize_handle(page, th_sel, dx):
+    """Press-drag-release the resize handle inside th_sel by dx px, via real mouse events (not
+    a direct style write) so the resizer's own mousedown/onMove/onUp - including its onUp ->
+    saveWidths() persistence - actually runs, the same as a user dragging a column wider."""
+    handle = page.locator(f"{th_sel} .col-resize-handle").first
+    handle.scroll_into_view_if_needed()
+    handle.hover()
+    box = handle.bounding_box()
+    assert box is not None, f"resize handle has no bounding box for {th_sel}"
+    page.mouse.down()
+    page.mouse.move(box["x"] + box["width"] / 2 + dx, box["y"] + box["height"] / 2, steps=12)
+    page.mouse.up()
+
+
 # ── behaviors (a) + (b): inline before the top, frozen once the table top reaches it ───────
 def test_header_freezes_at_viewport_top(page, ui_server, sticky_inventory):
     _goto(page, ui_server)
@@ -446,3 +460,91 @@ def test_phantom_scrollbar_cleared_on_print(page, ui_server, sticky_inventory):
     page.wait_for_timeout(150)
     assert not _pinned(page) and not _phantom_pinned(page)
     assert _top_scroll_spacers(page) == 0
+
+
+# ── a saved custom column layout must reach the pinned header's LOCKED geometry, not just ──
+# ── the live thead: the header pin captures widths once (colgroup + cell styles) and a ─────
+# ── later width restore can land after that capture without ever reaching the colgroup ─────
+def test_pinned_header_aligns_with_body_under_custom_layout(page, ui_server, sticky_inventory):
+    """With a saved custom column-width layout, the pinned header must line up with the body
+    columns. The load-time width restore is deferred (requestAnimationFrame) and can commit
+    after the pin has already captured and locked geometry into the colgroup - a real race that
+    depends on unobservable browser scheduling. This intercepts requestAnimationFrame so the
+    restore is queued but never auto-fires, scrolls to pin (capturing whatever geometry is live
+    at that moment, before any restore has run), then flushes the queued restore and reads
+    alignment in the same synchronous script - so no later async pass can paper over the exact
+    state right after the restore lands post-pin."""
+    # add_init_script runs a raw script at document-start; it must be a self-invoking
+    # expression, not a bare arrow, or the body never executes and the override is a no-op.
+    page.add_init_script(
+        "(() => { window.__pendingRaf = [];"
+        " window.requestAnimationFrame = function(cb) { window.__pendingRaf.push(cb); return window.__pendingRaf.length; };"
+        " window.__flushRaf = function() { var cbs = window.__pendingRaf.splice(0); cbs.forEach(function(cb){ cb(0); }); }; })()"
+    )
+    _goto(page, ui_server)
+    keys = _data_keys(page)
+    custom = {keys[0]: "300px", keys[1]: "80px"}
+    page.evaluate(
+        "(a) => localStorage.setItem(a[0], JSON.stringify(a[1]))",
+        ["celerp_col_widths_inventory", custom],
+    )
+    page.reload(wait_until="domcontentloaded")
+    page.wait_for_selector("#data-table thead th[data-key]", timeout=10000)
+    # scroll to pin BEFORE the deferred width restore has run at all (it is only queued,
+    # never auto-firing, under the requestAnimationFrame override above) - pin() captures
+    # whatever geometry is live right now, which is the server-rendered default.
+    _scroll_to_pin(page)
+    assert _pinned(page)
+    # now let the deferred restore land, after pin() already captured geometry - exactly the
+    # race in the bug report - and read alignment in the SAME synchronous call so no later
+    # MutationObserver-driven re-evaluate can run between the write and the read.
+    result = page.evaluate(
+        "(k) => { if (window.__flushRaf) window.__flushRaf();"
+        " var th=document.querySelector('#data-table thead th[data-key=\"'+k+'\"]');"
+        " var td=document.querySelector('#data-table tbody tr.data-row td[data-col=\"'+k+'\"]');"
+        " return th && td ? [th.getBoundingClientRect().left, td.getBoundingClientRect().left] : null; }",
+        keys[1],
+    )
+    assert result is not None, "missing header/body cell for the alignment check"
+    assert abs(result[0] - result[1]) <= 1.5, (
+        f"pinned header column '{keys[1]}' misaligned with its body column once the deferred "
+        f"custom-width restore landed after pin: header left {result[0]:.1f}, body left {result[1]:.1f}"
+    )
+
+
+# ── dragging a resize handle while the header is pinned must keep the dragged width, not ───
+# ── the pre-drag default the pin/unpin cycle recaptures when the drag's own style write ────
+# ── is mistaken for an external mutation ────────────────────────────────────────────────────
+def test_resize_while_pinned_persists(page, ui_server, sticky_inventory):
+    """A column resized WHILE the header is pinned must keep the dragged width (and persist it
+    to WIDTH_KEY), not silently revert to the pre-drag width. The resize handle's own onMove
+    writes th.style.width, which the sticky controller's MutationObserver cannot distinguish
+    from an external change: it clears the pinned header's captured widths and recaptures
+    fresh geometry - if that recapture happens while the drag's style write has been cleared,
+    the drag is lost even though the header stays visually aligned with the (also-reverted)
+    body. This drags the actual handle (mousedown/move/up), the only path that also exercises
+    the handle's onUp -> persistence, matching what a user does."""
+    _goto(page, ui_server)
+    page.evaluate("(k) => localStorage.removeItem(k)", "celerp_col_widths_inventory")
+    page.reload(wait_until="domcontentloaded")
+    page.wait_for_selector("#data-table thead th[data-key] .col-resize-handle", timeout=10000)
+    _scroll_to_pin(page)
+    assert _pinned(page)
+
+    key = _data_keys(page)[0]
+    th_sel = f'#data-table thead th[data-key="{key}"]'
+    before = page.evaluate("(s) => document.querySelector(s).getBoundingClientRect().width", th_sel)
+
+    _drag_resize_handle(page, th_sel, 220)
+    page.wait_for_timeout(250)  # let the pin/unpin churn the drag can trigger settle
+
+    after = page.evaluate("(s) => document.querySelector(s).getBoundingClientRect().width", th_sel)
+    assert after > before + 150, (
+        f"column '{key}' did not keep the width dragged while pinned: {before:.0f}px -> {after:.0f}px"
+    )
+    stored = page.evaluate("(k) => JSON.parse(localStorage.getItem(k) || 'null')", "celerp_col_widths_inventory")
+    assert stored and key in stored, f"resize while pinned was not persisted to localStorage: {stored}"
+    stored_px = float(str(stored[key]).replace("px", ""))
+    assert stored_px > before + 150, (
+        f"persisted width for '{key}' lost the drag: stored {stored_px:.0f}px, pre-drag {before:.0f}px"
+    )

--- a/tests/test_migrations/conftest.py
+++ b/tests/test_migrations/conftest.py
@@ -49,9 +49,10 @@ def _run_migration(engine, module_name: str, fn: str) -> None:
                     getattr(mig, fn)()
 
 
-def run_migration_ops(engine, module_name: str) -> None:
-    """Run versions/<module_name>.upgrade() through a REAL alembic Operations
-    context, in its own transaction.
+def run_migration_ops(engine, module_name: str, direction: str = "upgrade") -> None:
+    """Run versions/<module_name>.<direction>() through a REAL alembic Operations
+    context, in its own transaction. `direction` is "upgrade" (default) or
+    "downgrade".
 
     Unlike `_run_migration`'s MagicMock op (which only records calls and suits a
     raw-SQL migration reached via op.get_bind()), this binds a live Operations
@@ -70,7 +71,7 @@ def run_migration_ops(engine, module_name: str) -> None:
                 del sys.modules[full]
             with Operations.context(ctx):
                 mig = importlib.import_module(full)
-                mig.upgrade()
+                getattr(mig, direction)()
 
 
 class MigDB:

--- a/tests/test_modules/test_modules_api.py
+++ b/tests/test_modules/test_modules_api.py
@@ -621,14 +621,15 @@ class TestModuleDataPurge:
         from celerp.models.company import Company
         from sqlalchemy import select as sa_select
         ctx = await perm_setup(client, session)
-        # Simulate the pre-change grandfathered state the raised floor now bars:
-        # write manage_company_settings -> operator straight into company.settings
-        # (the save API would refuse it after the raise), predating the clamp.
+        # Simulate the pre-change grandfathered state the raised floor still bars:
+        # a stored grant of manage_company_settings down to operator written straight
+        # into company.settings. The floor (admin) clamps operator out at read, so
+        # the purge is still refused.
         company = (await session.execute(sa_select(Company))).scalars().first()
         settings = dict(company.settings or {})
-        rp = dict(settings.get("role_permissions") or {})
-        rp["manage_company_settings"] = "operator"
-        settings["role_permissions"] = rp
+        rg = dict(settings.get("role_grants") or {})
+        rg["manage_company_settings"] = ["operator", "manager", "admin", "owner"]
+        settings["role_grants"] = rg
         company.settings = settings
         await session.commit()
         module_dir = tmp_path / "modules"

--- a/tests/test_role_permissions.py
+++ b/tests/test_role_permissions.py
@@ -5,14 +5,24 @@
 Covers:
 - ROLES derived from auth.ROLE_LEVELS with i18n label keys
 - PERMISSIONS catalogue: keys, defaults, floors, fixed rows
-- Resolver: defaults, overrides, stale overrides, fail-closed roles
+- Resolver: default membership, per-role grants, stale grants, fail-closed roles
 - assert_role_permission 403 shape
-- Threshold monotonicity
+- Per-role grant independence (a grant to one role never cascades to another)
 """
 from __future__ import annotations
 
 import pytest
 import pytest_asyncio
+
+
+def _roles_from(role: str) -> list[str]:
+    """The role keys at or above *role* in the hierarchy: the per-role grant set a
+    threshold expands to under the role_grants model. A grant recorded down to
+    *role* holds for that role and every higher one, and no lower one."""
+    from celerp.services.auth import ROLE_LEVELS
+
+    floor = ROLE_LEVELS[role]
+    return [r for r, lvl in ROLE_LEVELS.items() if lvl >= floor]
 
 
 # ── Registry shape ────────────────────────────────────────────────────────────
@@ -95,25 +105,32 @@ def test_fixed_rows_not_grantable():
 
 # ── Resolver ──────────────────────────────────────────────────────────────────
 
-def test_permission_min_level_default():
-    """Empty overrides resolve to the registry default level."""
-    from celerp.services.auth import ROLE_LEVELS
-    from celerp.services.permissions import permission_min_level
+def test_default_resolution_membership():
+    """Empty grants resolve each key to its registry default set: the default role
+    and every role above it hold it, and the role just below does not."""
+    from celerp.services.permissions import role_has_permission
 
-    assert permission_min_level({}, "set_inventory_prices") == ROLE_LEVELS["manager"]
-    assert permission_min_level({}, "set_sales_doc_prices") == ROLE_LEVELS["operator"]
-    assert permission_min_level({}, "view_inventory") == ROLE_LEVELS["viewer"]
+    # set_inventory_prices default manager.
+    assert role_has_permission({}, "manager", "set_inventory_prices") is True
+    assert role_has_permission({}, "operator", "set_inventory_prices") is False
+    # set_sales_doc_prices default operator.
+    assert role_has_permission({}, "operator", "set_sales_doc_prices") is True
+    assert role_has_permission({}, "viewer", "set_sales_doc_prices") is False
+    # view_inventory default viewer: every role holds it.
+    assert role_has_permission({}, "viewer", "view_inventory") is True
 
 
-def test_permission_min_level_override():
-    """An override {perm_key: role_key} changes the resolved level."""
-    from celerp.services.auth import ROLE_LEVELS
-    from celerp.services.permissions import permission_min_level
+def test_grant_resolution_membership():
+    """A role_grants entry sets exactly which roles hold the key, independent of the
+    registry default."""
+    from celerp.services.permissions import role_has_permission
 
-    settings = {"role_permissions": {"set_inventory_prices": "operator"}}
-    assert permission_min_level(settings, "set_inventory_prices") == ROLE_LEVELS["operator"]
-    settings = {"role_permissions": {"set_sales_doc_prices": "manager"}}
-    assert permission_min_level(settings, "set_sales_doc_prices") == ROLE_LEVELS["manager"]
+    settings = {"role_grants": {"set_inventory_prices": _roles_from("operator")}}
+    assert role_has_permission(settings, "operator", "set_inventory_prices") is True
+    assert role_has_permission(settings, "viewer", "set_inventory_prices") is False
+    settings = {"role_grants": {"set_sales_doc_prices": _roles_from("manager")}}
+    assert role_has_permission(settings, "manager", "set_sales_doc_prices") is True
+    assert role_has_permission(settings, "operator", "set_sales_doc_prices") is False
 
 
 def test_manage_company_settings_floor_is_admin():
@@ -125,35 +142,44 @@ def test_manage_company_settings_floor_is_admin():
     assert by_key["manage_company_settings"].floor_role == "admin"
 
 
-def test_permission_min_level_clamps_sub_floor_override():
-    """A grandfathered override below the floor is clamped up to the floor at read
-    time: a stored operator override for manage_company_settings resolves to admin,
+def test_grant_clamped_to_floor_membership():
+    """A stored grant below the floor does not admit the sub-floor role: a grant of
+    manage_company_settings that names operator still resolves to admin-and-up,
     so the raised floor is a real invariant on read and not only on save."""
-    from celerp.services.auth import ROLE_LEVELS
-    from celerp.services.permissions import permission_min_level
+    from celerp.services.permissions import role_has_permission
 
-    settings = {"role_permissions": {"manage_company_settings": "operator"}}
-    assert permission_min_level(settings, "manage_company_settings") == ROLE_LEVELS["admin"]
-
-
-def test_permission_min_level_stale_override_ignored():
-    """Overrides naming unknown roles or permissions fall back to the default."""
-    from celerp.services.auth import ROLE_LEVELS
-    from celerp.services.permissions import permission_min_level
-
-    settings = {"role_permissions": {"set_inventory_prices": "archduke"}}
-    assert permission_min_level(settings, "set_inventory_prices") == ROLE_LEVELS["manager"]
-    settings = {"role_permissions": {"no_such_permission": "operator"}}
-    assert permission_min_level(settings, "set_inventory_prices") == ROLE_LEVELS["manager"]
+    settings = {"role_grants": {"manage_company_settings":
+                                ["operator", "manager", "admin", "owner"]}}
+    assert role_has_permission(settings, "operator", "manage_company_settings") is False
+    assert role_has_permission(settings, "manager", "manage_company_settings") is False
+    assert role_has_permission(settings, "admin", "manage_company_settings") is True
 
 
-def test_permission_min_level_fixed_rows_ignore_overrides():
-    """Fixed rows resolve at owner even when the blob carries an override."""
-    from celerp.services.auth import ROLE_LEVELS
-    from celerp.services.permissions import permission_min_level
+def test_stale_role_in_grant_ignored_membership():
+    """A grant naming a role no longer in ROLE_LEVELS drops that role; the remaining
+    valid roles still resolve, and an all-stale set admits no one (never a crash,
+    never an accidental grant). An unknown key falls back to its default set."""
+    from celerp.services.permissions import role_has_permission
 
-    settings = {"role_permissions": {"manage_permissions": "viewer"}}
-    assert permission_min_level(settings, "manage_permissions") == ROLE_LEVELS["owner"]
+    settings = {"role_grants": {"set_inventory_prices": ["archduke", "manager"]}}
+    assert role_has_permission(settings, "manager", "set_inventory_prices") is True
+    assert role_has_permission(settings, "operator", "set_inventory_prices") is False
+    settings = {"role_grants": {"set_inventory_prices": ["archduke"]}}
+    assert role_has_permission(settings, "manager", "set_inventory_prices") is False
+    settings = {"role_grants": {"no_such_permission": ["operator"]}}
+    assert role_has_permission(settings, "manager", "set_inventory_prices") is True
+    assert role_has_permission(settings, "operator", "set_inventory_prices") is False
+
+
+def test_fixed_permission_ignores_role_grants():
+    """Fixed rows resolve at their owner default even when role_grants names them:
+    the grantable short-circuit prevents both escalation and self-lockout."""
+    from celerp.services.permissions import role_has_permission
+
+    settings = {"role_grants": {"manage_permissions":
+                                ["viewer", "operator", "manager", "admin", "owner"]}}
+    assert role_has_permission(settings, "viewer", "manage_permissions") is False
+    assert role_has_permission(settings, "owner", "manage_permissions") is True
 
 
 def test_role_has_permission_unknown_role_fails_closed():
@@ -182,33 +208,285 @@ def test_assert_role_permission_raises_403():
     assert_role_permission({}, "manager", "set_inventory_prices")
 
 
-def test_threshold_monotonic():
-    """Granting a lower role implies every higher role passes."""
+def test_defaults_are_registry_membership():
+    """With empty grants every registry key resolves to a set: exactly the roles at
+    or above its default_role hold it, every role below does not. This pins the same
+    default thresholds the enforcement sites carried before, expressed as membership
+    of role_has_permission rather than a numeric minimum."""
     from celerp.services.auth import ROLE_LEVELS
-    from celerp.services.permissions import role_has_permission
-
-    settings = {"role_permissions": {"set_inventory_prices": "operator"}}
-    for role, level in ROLE_LEVELS.items():
-        expected = level >= ROLE_LEVELS["operator"]
-        assert role_has_permission(settings, role, "set_inventory_prices") is expected, role
-
-
-def test_defaults_match_current_behavior():
-    """With empty overrides every registry entry resolves to the minimum role
-    its enforcement sites carry today; the old static table's rows are a subset."""
-    from celerp.services.auth import ROLE_LEVELS
-    from celerp.services.permissions import PERMISSIONS, permission_min_level
+    from celerp.services.permissions import PERMISSIONS, role_has_permission
 
     for p in PERMISSIONS:
         expected_role, _, _ = EXPECTED_CATALOGUE[p.key]
-        assert permission_min_level({}, p.key) == ROLE_LEVELS[expected_role], p.key
+        want = ROLE_LEVELS[expected_role]
+        for role, lvl in ROLE_LEVELS.items():
+            assert role_has_permission({}, role, p.key) is (lvl >= want), (p.key, role)
 
 
 # ── Gate 1: inventory cost visibility and price writes ───────────
 
-from test_helpers import grant_permission, perm_setup  # noqa: E402
+from test_helpers import grant_permission, invite_user, perm_setup  # noqa: E402
 
-_GRANTED = {"role_permissions": {"view_inventory_costs": "operator"}}
+_GRANTED = {"role_grants": {"view_inventory_costs": _roles_from("operator")}}
+
+_ROLE_PERM_URL = "/companies/me/role-permissions"
+
+
+async def _company_settings(client, headers: dict) -> dict:
+    """Read the caller's company settings fresh from the API."""
+    r = await client.get("/companies/me", headers=headers)
+    assert r.status_code == 200, r.text
+    return (r.json().get("settings") or {})
+
+
+async def _toggle(client, headers: dict, perm_key: str, role_key: str, granted: bool) -> None:
+    """Toggle one (permission, role) matrix cell through the owner-gated route."""
+    r = await client.patch(
+        _ROLE_PERM_URL,
+        json={"perm_key": perm_key, "role_key": role_key, "granted": granted},
+        headers=headers,
+    )
+    assert r.status_code == 200, r.text
+
+
+# ── Per-role grant independence (grants are a set, not a cascading threshold) ──
+
+
+async def test_grant_is_independent_per_role(client, session):
+    """Granting a perm to viewer alone does not grant it to operator: a grant is
+    per-role, not a threshold that fills in every role above the one granted."""
+    from celerp.services.permissions import role_has_permission
+
+    ctx = await perm_setup(client, session)
+    # set_inventory_prices defaults to manager, so operator sits above viewer but
+    # below the default: the only way operator holds it is if the grant cascaded.
+    await _toggle(client, ctx["admin_h"], "set_inventory_prices", "viewer", True)
+    settings = await _company_settings(client, ctx["admin_h"])
+    assert role_has_permission(settings, "viewer", "set_inventory_prices") is True
+    assert role_has_permission(settings, "operator", "set_inventory_prices") is False
+
+
+async def test_revoke_is_independent_per_role(client, session):
+    """Revoking a perm from one role leaves every other role's grant untouched."""
+    from celerp.services.permissions import role_has_permission
+
+    ctx = await perm_setup(client, session)
+    await _toggle(client, ctx["admin_h"], "set_inventory_prices", "viewer", True)
+    await _toggle(client, ctx["admin_h"], "set_inventory_prices", "operator", True)
+    await _toggle(client, ctx["admin_h"], "set_inventory_prices", "operator", False)
+    settings = await _company_settings(client, ctx["admin_h"])
+    assert role_has_permission(settings, "operator", "set_inventory_prices") is False
+    assert role_has_permission(settings, "viewer", "set_inventory_prices") is True
+
+
+async def test_matrix_toggle_changes_only_that_cell(client, session):
+    """Toggling one matrix cell flips exactly that role's membership and no other."""
+    from celerp.services.auth import ROLE_LEVELS
+    from celerp.services.permissions import role_has_permission
+
+    ctx = await perm_setup(client, session)
+    key = "set_inventory_prices"
+    s_before = await _company_settings(client, ctx["admin_h"])
+    before = {r: role_has_permission(s_before, r, key) for r in ROLE_LEVELS}
+    await _toggle(client, ctx["admin_h"], key, "viewer", True)
+    s_after = await _company_settings(client, ctx["admin_h"])
+    after = {r: role_has_permission(s_after, r, key) for r in ROLE_LEVELS}
+    changed = {r for r in ROLE_LEVELS if before[r] != after[r]}
+    assert changed == {"viewer"}
+
+
+async def test_noncontiguous_grant_independent(client, session):
+    """A grant set need not be contiguous: viewer and admin can hold a perm while
+    operator and manager between them do not."""
+    from celerp.services.permissions import role_has_permission
+
+    ctx = await perm_setup(client, session)
+    key = "set_inventory_prices"  # default manager set: {manager, admin, owner}
+    await _toggle(client, ctx["admin_h"], key, "viewer", True)   # add viewer
+    await _toggle(client, ctx["admin_h"], key, "manager", False)  # drop manager
+    settings = await _company_settings(client, ctx["admin_h"])
+    assert role_has_permission(settings, "viewer", key) is True
+    assert role_has_permission(settings, "operator", key) is False
+    assert role_has_permission(settings, "manager", key) is False
+    assert role_has_permission(settings, "admin", key) is True
+
+
+async def test_admin_cannot_write_role_grants_via_company_settings(client, session):
+    """The permissions matrix is owner-only: an admin cannot bypass it by writing
+    role_grants (or the retired role_permissions key) through PATCH /companies/me.
+    Both blobs are rejected 422 and no effective permission changes."""
+    from celerp.services.permissions import role_has_permission
+
+    ctx = await perm_setup(client, session)
+    admin_h = {"Authorization": f"Bearer {await invite_user(client, session, ctx['admin_h'], 'adm@perm.example', 'admin')}"}
+    for blob in (
+        {"role_grants": {"set_inventory_prices": ["viewer", "operator", "manager", "admin", "owner"]}},
+        {"role_permissions": {"set_inventory_prices": "viewer"}},
+    ):
+        r = await client.patch("/companies/me", json={"settings": blob}, headers=admin_h)
+        assert r.status_code == 422, (blob, r.text)
+    settings = await _company_settings(client, ctx["admin_h"])
+    assert role_has_permission(settings, "operator", "set_inventory_prices") is False
+
+
+# ── Migration: role_permissions threshold -> role_grants set (bug 2) ──────────
+
+import json as _json  # noqa: E402
+import os as _os  # noqa: E402
+import uuid as _uuid  # noqa: E402
+
+from sqlalchemy import create_engine as _create_engine  # noqa: E402
+from sqlalchemy import text as _sa_text  # noqa: E402
+
+def _load_migration_harness():
+    """Load the migration test harness (run_migration_ops, wc_mkcompany) from the
+    migration package's conftest. It is loaded by file path because the tests
+    directory is a namespace package, so tests.test_migrations is not importable
+    as a dotted module from a sibling test file; the migration tests themselves
+    reach it through a relative import that only works from inside that package."""
+    import importlib.util as _ilu
+
+    path = _os.path.join(_os.path.dirname(__file__), "test_migrations", "conftest.py")
+    spec = _ilu.spec_from_file_location("_role_grants_migration_harness", path)
+    mod = _ilu.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod.run_migration_ops, mod.wc_mkcompany
+
+
+run_migration_ops, wc_mkcompany = _load_migration_harness()  # noqa: E402
+
+# The alembic head at merge-base; the role_grants expansion migration descends
+# from it. Before that migration is written, discovery returns None and the
+# T8-T10 tests fail at merge-base for the right reason: it is not present.
+_BASE_HEAD = "f8a9b0c1d2e3"
+
+
+def _role_grants_migration_module():
+    """Module stem of the migration whose down_revision is the pinned base head,
+    or None when no such migration exists yet."""
+    from alembic.script import ScriptDirectory
+
+    from celerp.alembic_config import build_alembic_config
+
+    script = ScriptDirectory.from_config(build_alembic_config())
+    for rev in script.walk_revisions():
+        if rev.down_revision == _BASE_HEAD:
+            return _os.path.splitext(_os.path.basename(rev.path))[0]
+    return None
+
+
+def _read_settings(engine, cid: str) -> dict:
+    with engine.connect() as conn:
+        row = conn.execute(_sa_text("SELECT settings FROM companies WHERE id = :id"),
+                           {"id": cid}).scalar()
+    return row if isinstance(row, dict) else _json.loads(row)
+
+
+@pytest.fixture()
+def role_grants_migration_db():
+    """Isolated Postgres schema with only a companies table, for the settings-only
+    role_permissions->role_grants data migration. Mirrors the repo's other
+    migration harnesses (tests/test_migrations/conftest.py): a sync psycopg2 engine
+    scoped to a throwaway schema, run through a real alembic Operations context."""
+    base_url = _os.environ["DATABASE_URL"].replace("+asyncpg", "+psycopg2")
+    schema = f"rgmig_{_uuid.uuid4().hex[:8]}"
+
+    admin = _create_engine(base_url, isolation_level="AUTOCOMMIT")
+    with admin.connect() as c:
+        c.execute(_sa_text(f'CREATE SCHEMA "{schema}"'))
+    admin.dispose()
+
+    engine = _create_engine(base_url, connect_args={"options": f"-csearch_path={schema}"})
+    with engine.begin() as conn:
+        conn.execute(_sa_text(
+            "CREATE TABLE companies (id UUID PRIMARY KEY, name TEXT, settings JSON NOT NULL)"))
+    yield engine
+    engine.dispose()
+
+    admin = _create_engine(base_url, isolation_level="AUTOCOMMIT")
+    with admin.connect() as c:
+        c.execute(_sa_text(f'DROP SCHEMA "{schema}" CASCADE'))
+    admin.dispose()
+
+
+def test_migration_expands_overrides_preserving_effective_permissions(role_grants_migration_db):
+    """The data migration expands each stored threshold override into an explicit
+    per-role grant set, deltas-only, with the same effective permissions for every
+    role. A sub-floor threshold clamps up to the floor; unoverridden keys stay
+    absent from role_grants; the old role_permissions key is dropped."""
+    from celerp.services.auth import ROLE_LEVELS
+    from celerp.services.permissions import role_has_permission
+
+    module = _role_grants_migration_module()
+    assert module is not None, "role_grants expansion migration not present at merge-base"
+
+    with role_grants_migration_db.begin() as conn:
+        cid = wc_mkcompany(conn, {
+            "role_permissions": {
+                "view_payments": "operator",              # manager default, floor viewer
+                "manage_company_settings": "operator",    # admin default, floor admin (clamps)
+            },
+            "currency": "USD",
+        })
+    run_migration_ops(role_grants_migration_db, module)
+
+    settings = _read_settings(role_grants_migration_db, cid)
+    grants = settings.get("role_grants") or {}
+    # Only the two overridden keys expand; nothing else is materialized.
+    assert set(grants) == {"view_payments", "manage_company_settings"}
+    assert set(grants["view_payments"]) == {"operator", "manager", "admin", "owner"}
+    # operator threshold clamps up to the admin floor for the destructive key.
+    assert set(grants["manage_company_settings"]) == {"admin", "owner"}
+    # The retired key is gone; unrelated settings survive.
+    assert "role_permissions" not in settings
+    assert settings.get("currency") == "USD"
+    # Effective permission is unchanged for every role, overridden and default alike.
+    for r in ROLE_LEVELS:
+        assert role_has_permission(settings, r, "view_payments") is (
+            ROLE_LEVELS[r] >= ROLE_LEVELS["operator"])
+        assert role_has_permission(settings, r, "manage_company_settings") is (
+            ROLE_LEVELS[r] >= ROLE_LEVELS["admin"])
+        assert role_has_permission(settings, r, "set_inventory_prices") is (
+            ROLE_LEVELS[r] >= ROLE_LEVELS["manager"])
+
+
+def test_migration_idempotent(role_grants_migration_db):
+    """Running the migration twice (alembic apply then a reconcile replay) leaves
+    role_grants stable and never re-introduces role_permissions."""
+    module = _role_grants_migration_module()
+    assert module is not None, "role_grants expansion migration not present at merge-base"
+
+    with role_grants_migration_db.begin() as conn:
+        cid = wc_mkcompany(conn, {"role_permissions": {"view_payments": "operator"}})
+    run_migration_ops(role_grants_migration_db, module)
+    first = _read_settings(role_grants_migration_db, cid)
+    run_migration_ops(role_grants_migration_db, module)
+    second = _read_settings(role_grants_migration_db, cid)
+
+    assert second == first
+    assert "role_permissions" not in second
+    assert set(second.get("role_grants", {})) == {"view_payments"}
+
+
+def test_migration_ignores_stale_override_role(role_grants_migration_db):
+    """An override naming a role not in ROLE_LEVELS resolved to the default already,
+    so it becomes no delta: absent from role_grants, no crash. A valid override
+    alongside it still expands."""
+    module = _role_grants_migration_module()
+    assert module is not None, "role_grants expansion migration not present at merge-base"
+
+    with role_grants_migration_db.begin() as conn:
+        cid = wc_mkcompany(conn, {"role_permissions": {
+            "view_payments": "archduke",           # stale role -> dropped
+            "set_inventory_prices": "operator",    # real delta -> expands
+        }})
+    run_migration_ops(role_grants_migration_db, module)
+
+    settings = _read_settings(role_grants_migration_db, cid)
+    grants = settings.get("role_grants") or {}
+    assert "view_payments" not in grants
+    assert set(grants.get("set_inventory_prices", [])) == {"operator", "manager", "admin", "owner"}
+    assert "role_permissions" not in settings
 
 
 async def test_operator_granted_sees_cost_fields(client, session):
@@ -511,10 +789,6 @@ async def test_save_doc_lines_surfaces_permission_error(client, session):
 
 # ── Matrix save API: PATCH /companies/me/role-permissions (J3) ─────────────────
 
-from test_helpers import invite_user  # noqa: E402
-
-_ROLE_PERM_URL = "/companies/me/role-permissions"
-
 
 async def test_patch_role_permissions_owner_only(client, session):
     """Editing permissions is owner-only: an admin is refused, the owner accepts."""
@@ -575,8 +849,8 @@ async def test_patch_role_permissions_persists(client, session):
 
     r2 = await client.get("/companies/me", headers=ctx["admin_h"])
     assert r2.status_code == 200, r2.text
-    overrides = (r2.json()["settings"] or {}).get("role_permissions") or {}
-    assert overrides.get("set_inventory_prices") == "operator"
+    grants = (r2.json()["settings"] or {}).get("role_grants") or {}
+    assert "operator" in (grants.get("set_inventory_prices") or [])
 
 
 async def test_patch_role_permissions_malformed_boolean_422(client, session):
@@ -667,7 +941,8 @@ async def test_matrix_reflects_overrides(ui):
     """A stored override checks the lower role's column that the default leaves clear."""
     assert "checked" not in _cell(await _render_users_tab(ui, "owner", {}),
                                   "set_inventory_prices", "operator")
-    html = await _render_users_tab(ui, "owner", {"role_permissions": {"set_inventory_prices": "operator"}})
+    html = await _render_users_tab(ui, "owner",
+                                   {"role_grants": {"set_inventory_prices": _roles_from("operator")}})
     assert "checked" in _cell(html, "set_inventory_prices", "operator")
 
 
@@ -683,9 +958,9 @@ async def test_matrix_role_columns_from_registry(ui):
         _cell(html, "edit_documents", role.key)
 
 
-async def test_matrix_row_swap_shows_threshold_fill(client, session):
-    """Toggling a cell returns the full re-rendered row with the higher roles that
-    inherit the permission also checked (the unmissable threshold feedback)."""
+async def test_matrix_row_swap_reflects_single_cell(client, session):
+    """Toggling a cell returns the re-rendered row with exactly that role's box now
+    checked; roles above it are not filled in by the toggle (grants are per-role)."""
     from unittest.mock import patch
 
     from httpx import ASGITransport, AsyncClient
@@ -713,9 +988,10 @@ async def test_matrix_row_swap_shows_threshold_fill(client, session):
                 data={"granted": "true"},
             )
     assert r.status_code == 200, r.text
-    # operator now granted, so manager and admin (higher) inherit and show checked too.
-    for role in ("operator", "manager", "admin"):
-        assert "checked" in _cell(r.text, "set_inventory_prices", role), role
+    # operator is now granted; manager holds it by default already, but viewer -
+    # the role below the toggled cell - is not swept in.
+    assert "checked" in _cell(r.text, "set_inventory_prices", "operator")
+    assert "checked" not in _cell(r.text, "set_inventory_prices", "viewer")
 
 
 # ── Dashboard UI follows the permission ───────────────────────────────────────
@@ -796,11 +1072,10 @@ async def test_cost_basis_kpi_follows_permission(ui):
 # ── Default parity, override flips, and write floors (2.8) ─────────────────────
 
 async def test_owner_can_grant_write_to_viewer(client, session):
-    """The owner may lower a write key to viewer: the matrix save returns 200 and
-    the resolver now admits a viewer. Viewers stay read-only by default; the owner
-    is free to grant any grantable key down to viewer."""
-    from celerp.services.auth import ROLE_LEVELS
-    from celerp.services.permissions import permission_min_level
+    """The owner may grant a write key to viewer: the matrix save returns 200 and
+    the resolver then admits a viewer. Viewers stay read-only by default; the owner
+    is free to grant any grantable key to viewer."""
+    from celerp.services.permissions import role_has_permission
 
     ctx = await perm_setup(client, session)
     r = await client.patch(
@@ -810,8 +1085,8 @@ async def test_owner_can_grant_write_to_viewer(client, session):
     )
     assert r.status_code == 200, r.text
 
-    settings = {"role_permissions": {"set_inventory_prices": "viewer"}}
-    assert permission_min_level(settings, "set_inventory_prices") == ROLE_LEVELS["viewer"]
+    settings = await _company_settings(client, ctx["admin_h"])
+    assert role_has_permission(settings, "viewer", "set_inventory_prices") is True
 
 
 async def test_default_parity_matrix(client, session):
@@ -910,13 +1185,13 @@ def test_nav_visibility_follows_permissions():
         # Payments gates on view_payments (manager default): operator cannot see it...
         assert "/payments" not in to_xml(_sidebar("dashboard", role="operator", settings={}))
         # ...until it is granted down to operator.
-        granted = {"role_permissions": {"view_payments": "operator"}}
+        granted = {"role_grants": {"view_payments": _roles_from("operator")}}
         assert "/payments" in to_xml(_sidebar("dashboard", role="operator", settings=granted))
 
         # Sales Documents gate on view_documents (viewer default): a manager sees them,
         # but not once the key is raised to admin.
         assert "/docs?type=invoice" in to_xml(_sidebar("dashboard", role="manager", settings={}))
-        revoked = {"role_permissions": {"view_documents": "admin"}}
+        revoked = {"role_grants": {"view_documents": _roles_from("admin")}}
         assert "/docs?type=invoice" not in to_xml(_sidebar("dashboard", role="manager", settings=revoked))
     finally:
         slots.clear()
@@ -941,7 +1216,7 @@ def test_kpi_specs_follow_permissions():
     op = to_xml(_kpi_grid(cfg, values, role="operator", settings={}))
     assert "Cost Basis" not in op and "Item Count" in op
 
-    granted = {"role_permissions": {"view_inventory_costs": "operator"}}
+    granted = {"role_grants": {"view_inventory_costs": _roles_from("operator")}}
     assert "Cost Basis" in to_xml(_kpi_grid(cfg, values, role="operator", settings=granted))
     assert "Cost Basis" in to_xml(_kpi_grid(cfg, values, role="manager", settings={}))
 
@@ -1075,7 +1350,7 @@ async def test_raised_view_inventory_redirects_viewer(ui):
     from test_helpers import make_test_token
 
     company = {"currency": "THB",
-               "settings": {"role_permissions": {"view_inventory": "operator"}}}
+               "settings": {"role_grants": {"view_inventory": _roles_from("operator")}}}
     patches = [
         patch("ui.api_client.get_company", AsyncMock(return_value=company)),
         patch("ui.api_client.get_item_schema", AsyncMock(return_value={})),
@@ -1102,7 +1377,7 @@ async def _assert_page_redirects_when_revoked(ui, path: str, perm_key: str):
     from test_helpers import make_test_token
 
     company = {"currency": "THB",
-               "settings": {"role_permissions": {perm_key: "operator"}}}
+               "settings": {"role_grants": {perm_key: _roles_from("operator")}}}
     with patch("ui.api_client.get_company", AsyncMock(return_value=company)):
         r = await ui.get(path, cookies={"celerp_token": make_test_token(role="viewer")})
     assert r.status_code == 302, (path, r.status_code)
@@ -1114,7 +1389,7 @@ async def test_dashboard_page_requires_view_dashboards(ui):
     /dashboard, not the KPI grid. The page has nowhere to redirect (it is the
     redirect target), so it degrades in place with a clear message."""
     no_access = b"You do not have access to this page."
-    revoked = {"role_permissions": {"view_dashboards": "operator"}}
+    revoked = {"role_grants": {"view_dashboards": _roles_from("operator")}}
     content = await _render_dashboard(ui, "viewer", revoked, "coins_precious_metals")
     assert no_access in content
 
@@ -1292,25 +1567,33 @@ async def test_adjust_still_allowed_without_amount_permission(client, session):
     """adjust_item is gated by adjust_inventory, not by edit_inventory_amounts: a
     role granted adjust_inventory but lacking the amount key can still adjust."""
     ctx = await perm_setup(client, session)
-    # One settings write (shallow merge would clobber a second call): grant
-    # adjust_inventory down to operator AND raise edit_inventory_amounts above it.
-    r = await client.patch(
-        "/companies/me",
-        json={"settings": {"role_permissions": {
-            "adjust_inventory": "operator", "edit_inventory_amounts": "manager"}}},
-        headers=ctx["admin_h"],
-    )
-    assert r.status_code == 200, r.text
+    # Grant adjust_inventory down to operator AND raise edit_inventory_amounts above
+    # it, so the operator has the adjust gate but not the amount gate.
+    await grant_permission(client, ctx["admin_h"], "adjust_inventory", "operator")
+    await grant_permission(client, ctx["admin_h"], "edit_inventory_amounts", "manager")
     r = await client.post(f"/items/{ctx['item_id']}/adjust", json={"new_qty": 3},
                           headers=ctx["operator_h"])
     assert r.status_code == 200, r.text
 
 
-async def test_sell_by_change_allowed_without_amount_permission(client, session):
-    """Changing sell_by (which server-syncs quantity) is not a hand-edit of an
-    amount and stays allowed for a role lacking edit_inventory_amounts."""
+async def test_sell_by_change_denied_without_amount_permission(client, session):
+    """sell_by is gated under edit_inventory_amounts: a role lacking that key cannot
+    change it, and the 403 names the field so the user knows why the edit failed."""
     ctx = await perm_setup(client, session)
     await grant_permission(client, ctx["admin_h"], "edit_inventory_amounts", "manager")
+    r = await client.patch(
+        f"/items/{ctx['item_id']}",
+        json={"fields_changed": {"sell_by": {"old": "piece", "new": "gram"}}},
+        headers=ctx["operator_h"],
+    )
+    assert r.status_code == 403, r.text
+    assert "sell_by" in r.json()["detail"]
+
+
+async def test_sell_by_change_allowed_with_amount_permission(client, session):
+    """A role holding edit_inventory_amounts can change sell_by."""
+    ctx = await perm_setup(client, session)
+    await grant_permission(client, ctx["admin_h"], "edit_inventory_amounts", "operator")
     r = await client.patch(
         f"/items/{ctx['item_id']}",
         json={"fields_changed": {"sell_by": {"old": "piece", "new": "gram"}}},
@@ -1407,11 +1690,51 @@ async def test_batch_import_nonamount_allowed_without_permission(client, session
     ]}, headers=ctx["operator_h"])
     assert r.status_code == 200 and r.json()["created"] == 1, r.text
 
+
+async def test_bulk_import_sell_by_change_denied_without_permission(client, session):
+    """A batch upsert whose sell_by differs from the stored value is a hand-edit of
+    an amount-gated field: skipped-with-error for a role lacking
+    edit_inventory_amounts, and the stored sell_by is left unchanged. The gate is
+    diff-based, so re-sending the same sell_by is not blocked (covered separately)."""
+    ctx = await perm_setup(client, session)
+    await grant_permission(client, ctx["admin_h"], "edit_inventory_amounts", "manager")
+    eid = "item:bi-sb"
+    r = await client.post("/items/import/batch", json={"records": [
+        _import_record(eid, {"sku": "BI-SB", "name": "BI SB", "sell_by": "piece", "quantity": 5}, "bi-sb")
+    ]}, headers=ctx["operator_h"])
+    assert r.status_code == 200 and r.json()["created"] == 1, r.text
+
+    # Upsert the same key changing sell_by piece -> gram.
     r = await client.post("/items/import/batch", json={"upsert": True, "records": [
-        _import_record(eid, {"sku": "BI-2", "sell_by": "piece", "name": "BI 2 Renamed"}, "bi-name")
+        _import_record(eid, {"sku": "BI-SB", "sell_by": "gram"}, "bi-sb")
     ]}, headers=ctx["operator_h"])
     assert r.status_code == 200, r.text
-    assert r.json()["updated"] == 1
+    result = r.json()
+    assert result["updated"] == 0
+    assert result["errors"]
+    # The blocked sell_by change never landed on the item.
+    item = (await client.get(f"/items/{eid}", headers=ctx["admin_h"])).json()
+    assert item.get("sell_by") == "piece"
+
+
+async def test_bulk_import_non_sellby_change_allowed_without_permission(client, session):
+    """A batch upsert that leaves sell_by unchanged (only name changes) is applied
+    for a role lacking edit_inventory_amounts: the diff carries no gated field."""
+    ctx = await perm_setup(client, session)
+    await grant_permission(client, ctx["admin_h"], "edit_inventory_amounts", "manager")
+    eid = "item:bi-nsb"
+    r = await client.post("/items/import/batch", json={"records": [
+        _import_record(eid, {"sku": "BI-NSB", "name": "BI NSB", "sell_by": "piece", "quantity": 5}, "bi-nsb")
+    ]}, headers=ctx["operator_h"])
+    assert r.status_code == 200 and r.json()["created"] == 1, r.text
+
+    r = await client.post("/items/import/batch", json={"upsert": True, "records": [
+        _import_record(eid, {"sku": "BI-NSB", "name": "BI NSB renamed", "sell_by": "piece"}, "bi-nsb")
+    ]}, headers=ctx["operator_h"])
+    assert r.status_code == 200, r.text
+    result = r.json()
+    assert result["updated"] == 1
+    assert not result["errors"]
 
 
 async def test_batch_import_negative_amount_rejected(client, session):

--- a/tests/test_role_permissions.py
+++ b/tests/test_role_permissions.py
@@ -489,6 +489,42 @@ def test_migration_ignores_stale_override_role(role_grants_migration_db):
     assert "role_permissions" not in settings
 
 
+def test_migration_downgrade_collapses_grants_to_threshold(role_grants_migration_db):
+    """downgrade() is the best-effort inverse of upgrade(): each grant set collapses
+    back to a single role_permissions threshold at its lowest granted role, the
+    retired key is restored, and role_grants is dropped. An upgrade-then-downgrade
+    round trip reconstructs the exact thresholds a contiguous set came from; a
+    hand-authored non-contiguous set collapses to its lowest role (documented
+    lossy)."""
+    module = _role_grants_migration_module()
+    assert module is not None, "role_grants expansion migration not present at merge-base"
+
+    with role_grants_migration_db.begin() as conn:
+        # (a) threshold -> grants -> threshold, expected to round-trip exactly.
+        cid_rt = wc_mkcompany(conn, {
+            "role_permissions": {
+                "view_payments": "operator",             # manager default, floor viewer
+                "manage_company_settings": "operator",   # admin default, floor admin (clamps up)
+            },
+            "currency": "USD",
+        })
+        # (b) a non-contiguous set upgrade never produces; downgrade takes the lowest.
+        cid_nc = wc_mkcompany(conn, {"role_grants": {"view_payments": ["viewer", "admin"]}})
+    run_migration_ops(role_grants_migration_db, module)               # (a) threshold -> grants
+    run_migration_ops(role_grants_migration_db, module, "downgrade")  # grants -> threshold
+
+    rt = _read_settings(role_grants_migration_db, cid_rt)
+    assert "role_grants" not in rt
+    # Lowest granted role restores the original threshold; the admin clamp collapses to admin.
+    assert (rt.get("role_permissions") or {}) == {
+        "view_payments": "operator", "manage_company_settings": "admin"}
+    assert rt.get("currency") == "USD"
+
+    nc = _read_settings(role_grants_migration_db, cid_nc)
+    assert "role_grants" not in nc
+    assert (nc.get("role_permissions") or {}).get("view_payments") == "viewer"
+
+
 async def test_operator_granted_sees_cost_fields(client, session):
     ctx = await perm_setup(client, session)
     await grant_permission(client, ctx["admin_h"], "view_inventory_costs", "operator")

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -568,6 +568,35 @@ class TestClickToEdit:
         assert b"<select" not in r.content
 
     @pytest.mark.asyncio
+    async def test_sell_by_paired_edit_readonly_without_permission(self, ui_client):
+        """GET the paired-edit cell for sell_by, as a role lacking
+        edit_inventory_amounts, returns the read-only paired display: no <input> and
+        no <select>, so the sell unit cannot enter edit state from its paired entry
+        point either (it server-syncs quantity, so it is amount-gated like the
+        single-field cell)."""
+        schema = [{"key": "sell_by", "label": "Sell by", "type": "text", "editable": True}]
+        item = {"entity_id": "gc:123", "sell_by": "piece", "quantity": 5}
+        # Operator holds edit_inventory (default); edit_inventory_amounts is granted
+        # only to manager and up, so the paired sell_by cell must render read-only.
+        company = {"settings": {"role_grants": {"edit_inventory_amounts": ["manager", "admin", "owner"]}}}
+        units = [{"name": "piece", "unit_type": "count"}, {"name": "gram", "unit_type": "weight"}]
+        with (
+            patch("ui.api_client.get_item_schema", new=AsyncMock(return_value=schema)),
+            patch("ui.api_client.get_item", new=AsyncMock(return_value=item)),
+            patch("ui.api_client.get_all_category_schemas", new=AsyncMock(return_value={})),
+            patch("ui.api_client.get_locations", new=AsyncMock(return_value={"items": []})),
+            patch("ui.api_client.get_company", new=AsyncMock(return_value=company)),
+            patch("ui.api_client.get_units", new=AsyncMock(return_value=units)),
+        ):
+            r = await ui_client.get(
+                "/api/items/gc:123/field/sell_by/paired-edit",
+                cookies=_authed(role="operator"),
+            )
+        assert r.status_code == 200
+        assert b"<input" not in r.content
+        assert b"<select" not in r.content
+
+    @pytest.mark.asyncio
     async def test_patch_item_field_returns_display_td(self, ui_client):
         """PATCH /api/items/{id}/field/{field} → saves, returns display <td> with new value."""
         updated = {**_ITEM, "name": "Sapphire"}

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -523,8 +523,8 @@ class TestClickToEdit:
         schema = [{"key": field, "label": field, "type": "number", "editable": True}]
         item = {"entity_id": "gc:123", field: 5}
         # Operator holds edit_inventory (default) but edit_inventory_amounts is
-        # raised to manager, so the amount cell must render read-only.
-        company = {"settings": {"role_permissions": {"edit_inventory_amounts": "manager"}}}
+        # granted only to manager and up, so the amount cell must render read-only.
+        company = {"settings": {"role_grants": {"edit_inventory_amounts": ["manager", "admin", "owner"]}}}
         with (
             patch("ui.api_client.get_item_schema", new=AsyncMock(return_value=schema)),
             patch("ui.api_client.get_item", new=AsyncMock(return_value=item)),
@@ -538,6 +538,34 @@ class TestClickToEdit:
             )
         assert r.status_code == 200
         assert b"<input" not in r.content
+
+    @pytest.mark.asyncio
+    async def test_sell_by_cell_readonly_without_permission(self, ui_client):
+        """GET the single-field edit cell for sell_by, as a role lacking
+        edit_inventory_amounts, returns a non-editable display cell: no <input> and
+        no <select>, so the unit field cannot enter edit state without the amount
+        permission (sell_by server-syncs quantity, so it is amount-gated too)."""
+        schema = [{"key": "sell_by", "label": "Sell by", "type": "text", "editable": True}]
+        item = {"entity_id": "gc:123", "sell_by": "piece"}
+        # Operator holds edit_inventory (default); edit_inventory_amounts is granted
+        # only to manager and up, so the sell_by cell must render read-only.
+        company = {"settings": {"role_grants": {"edit_inventory_amounts": ["manager", "admin", "owner"]}}}
+        units = [{"name": "piece", "unit_type": "count"}, {"name": "gram", "unit_type": "weight"}]
+        with (
+            patch("ui.api_client.get_item_schema", new=AsyncMock(return_value=schema)),
+            patch("ui.api_client.get_item", new=AsyncMock(return_value=item)),
+            patch("ui.api_client.get_all_category_schemas", new=AsyncMock(return_value={})),
+            patch("ui.api_client.get_locations", new=AsyncMock(return_value={"items": []})),
+            patch("ui.api_client.get_company", new=AsyncMock(return_value=company)),
+            patch("ui.api_client.get_units", new=AsyncMock(return_value=units)),
+        ):
+            r = await ui_client.get(
+                "/api/items/gc:123/field/sell_by/edit",
+                cookies=_authed(role="operator"),
+            )
+        assert r.status_code == 200
+        assert b"<input" not in r.content
+        assert b"<select" not in r.content
 
     @pytest.mark.asyncio
     async def test_patch_item_field_returns_display_td(self, ui_client):
@@ -2343,6 +2371,28 @@ class TestCSSConsistency:
         css = pathlib.Path(__file__).parent.parent.joinpath("ui/static/app.css").read_text()
         assert "dashed" in css
         assert "cell--clickable" in css
+
+    @pytest.mark.asyncio
+    async def test_paired_readonly_cell_not_editable_css(self):
+        """A paired cell rendered read-only (a role lacking the amount permission)
+        must not look clickable: both --readonly halves drop the pointer cursor and
+        the dashed underline the editable paired cells carry.
+
+        Red at merge-base: no .paired-primary--readonly / .paired-secondary--readonly
+        styling exists yet.
+        """
+        import pathlib
+        import re
+        css = pathlib.Path(__file__).parent.parent.joinpath("ui/static/app.css").read_text()
+        assert "paired-primary--readonly" in css
+        assert "paired-secondary--readonly" in css
+        # The rule covering the read-only primary half (grouped selector may also
+        # name the secondary half) turns off both click affordances.
+        m = re.search(r"\.paired-primary--readonly[^{]*\{[^}]*\}", css)
+        assert m, "no rule targeting .paired-primary--readonly"
+        block = m.group(0)
+        assert re.search(r"cursor:\s*default", block), block
+        assert re.search(r"border-bottom:\s*none", block), block
 
     @pytest.mark.asyncio
     async def test_column_manager_css_exists(self):

--- a/ui/components/shell.py
+++ b/ui/components/shell.py
@@ -1165,7 +1165,9 @@ _STICKY_HEADER_JS = """
     var thead = t.tHead;
     if(thead){
       thead.style.display = ''; thead.style.tableLayout = ''; thead.style.width = ''; thead.style.left = '';
-      if(thead.rows.length){ var cells = thead.rows[0].cells; for(var i=0;i<cells.length;i++) cells[i].style.width = ''; }
+      // Leave the cell widths in place: they carry the user's applied/resized column sizes, and a
+      // re-pin recaptures from them. Blanking them here dropped custom widths on scroll-up and wiped
+      // an in-progress resize before it could persist.
     }
     t.style.tableLayout = ''; t.style.width = '';
     clearPinArtifacts(t);
@@ -1180,6 +1182,9 @@ _STICKY_HEADER_JS = """
 
   function evaluate(full){
     if(printing || (mqPrint && mqPrint.matches)){ unpinAll(); return; }
+    // A column resize sets th widths pixel by pixel; leave the header alone until the drag ends,
+    // or the per-mutation re-pin recaptures the pre-drag width every move and the drag never sticks.
+    if(document.body && document.body.classList.contains('col-resizing')) return;
     pauseObserver(function(){
       var tables = document.querySelectorAll(SEL);
       for(var i=0;i<tables.length;i++){

--- a/ui/components/table.py
+++ b/ui/components/table.py
@@ -746,6 +746,7 @@ def paired_display_cell(
     secondary_options: list[str] | None = None,
     format_fn=None,
     primary_editable: bool = True,
+    secondary_editable: bool = True,
 ) -> FT:
     """Combined cell showing two separately dbl-click-editable values in one TD.
 
@@ -756,9 +757,10 @@ def paired_display_cell(
     format_fn: optional callable(value) -> str for formatting the primary value.
     When provided, it is used instead of str(). Callers supply unit-aware formatters
     (e.g. format_qty) without coupling this generic component to inventory logic.
-    primary_editable: when False the primary (amount) value renders as a plain,
-    non-clickable span - no dblclick trigger, no edit affordance - while the
-    secondary unit stays editable. Used to honor the edit_inventory_amounts gate.
+    primary_editable / secondary_editable: when False the corresponding value renders
+    as a plain, non-clickable span - no dblclick trigger, no edit affordance. The
+    sell unit gates on the same edit_inventory_amounts permission as the amount it
+    pairs with, because changing the unit rewrites the amount.
     """
     pri_edit = f"/api/items/{entity_id}/field/{primary_field}/paired-edit?peer={secondary_field}"
     sec_edit = f"/api/items/{entity_id}/field/{secondary_field}/paired-edit?peer={primary_field}"
@@ -780,9 +782,7 @@ def paired_display_cell(
         if primary_editable
         else Span(pri_disp, cls="paired-primary paired-primary--readonly")
     )
-    return Td(
-        pri_span,
-        Span(" ", cls="paired-sep"),
+    sec_span = (
         Span(
             sec_disp,
             cls="paired-secondary",
@@ -791,7 +791,14 @@ def paired_display_cell(
             hx_target="closest td",
             hx_swap="outerHTML",
             hx_trigger="dblclick",
-        ),
+        )
+        if secondary_editable
+        else Span(sec_disp, cls="paired-secondary paired-secondary--readonly")
+    )
+    return Td(
+        pri_span,
+        Span(" ", cls="paired-sep"),
+        sec_span,
         cls=f"cell cell--paired",
         data_col=primary_field,
     )

--- a/ui/components/table.py
+++ b/ui/components/table.py
@@ -1464,13 +1464,15 @@ def data_table(
   function saveWidths() {{
     var w = {{}};
     ths.forEach(function(th) {{ if (th.style.width) w[th.dataset.key] = th.style.width; }});
-    localStorage.setItem(WIDTH_KEY, JSON.stringify(w));
+    try {{ localStorage.setItem(WIDTH_KEY, JSON.stringify(w)); }} catch(e) {{}}
   }}
-  // Restore persisted widths on load — defer to rAF so HTMX-swapped DOM has committed layout
-  requestAnimationFrame(function() {{
+  // Restore persisted widths synchronously. A saved width is an explicit px value that needs no
+  // committed layout, and applying it before the sticky controller can pin the header is what keeps
+  // the frozen header's captured geometry in step with the body for a custom column layout.
+  (function() {{
     var saved = loadWidths();
     if (saved) ths.forEach(function(th) {{ if (saved[th.dataset.key]) th.style.width = saved[th.dataset.key]; }});
-  }});
+  }})();
   ths.forEach(function(th) {{
     var handle = document.createElement('div');
     handle.className = 'col-resize-handle';
@@ -1482,6 +1484,9 @@ def data_table(
       startW = th.offsetWidth;
       e.preventDefault();
       e.stopPropagation();
+      // Signal an in-progress resize so the sticky-header controller leaves the header alone while
+      // dragging (its per-mutation re-pin would otherwise recapture the pre-drag width every pixel).
+      document.body.classList.add('col-resizing');
       var scrollWrap = table.closest('.table-scroll-wrap');
       var autoScrollRaf = null;
       function onMove(e2) {{
@@ -1506,6 +1511,10 @@ def data_table(
         document.removeEventListener('mouseup', onUp);
         if (autoScrollRaf) cancelAnimationFrame(autoScrollRaf);
         saveWidths();
+        document.body.classList.remove('col-resizing');
+        // Let the sticky controller recapture the new width once, now the drag is over, so a pinned
+        // header re-aligns its body to the dragged column instead of staying at the old geometry.
+        window.dispatchEvent(new Event('resize'));
       }}
       document.addEventListener('mousemove', onMove);
       document.addEventListener('mouseup', onUp);

--- a/ui/routes/inventory.py
+++ b/ui/routes/inventory.py
@@ -24,7 +24,7 @@ from ui.components.shell import base_shell, page_header, toast_header
 from ui.components.table import data_table, search_bar, pagination, EMPTY, breadcrumbs, status_cards, empty_state_cta, add_new_option, searchable_select, currency_symbol, INACTIVE_ITEM_STATUSES, SERVER_FILTER_JS, filter_th, sortable_th, table_pager, COLUMN_FILTER_JS, ENHANCED_TABLE_JS, date_range_filter
 from ui.config import get_token as _token, get_role as _get_role
 from celerp.services.permissions import role_has_permission
-from celerp.services.field_schema import AMOUNT_ITEM_KEYS
+from celerp.services.field_schema import AMOUNT_EDIT_GATED_KEYS
 from celerp.services.pricing import DEFAULT_PRICE_LIST_NAME, PRICE_LISTS_FALLBACK, is_cost_list_name, is_derived, price_key, resolve_price
 from celerp.events.schemas import _WORKFLOW_TIME_UNITS
 from ui.routes.documents import _ICON_PRINT as _ICON_PRINT_SVG
@@ -2324,10 +2324,10 @@ function celerpPrintLabel(entityId, templateId) {
             _f = next((x for x in schema if x.get("key") == field), {})
             return display_cell(entity_id=entity_id, field=field, value=item.get(field, ""),
                                 cell_type=_f.get("type", "text"), editable=False)
-        if field in AMOUNT_ITEM_KEYS and not role_has_permission(company.get("settings") or {}, _get_role(request), "edit_inventory_amounts"):
-            # Amount fields (quantity/weight/pieces/gross_weight) are gated by
-            # edit_inventory_amounts: this GET is the single edit-entry chokepoint, so no
-            # amount cell can enter edit state without the permission, however it rendered.
+        if field in AMOUNT_EDIT_GATED_KEYS and not role_has_permission(company.get("settings") or {}, _get_role(request), "edit_inventory_amounts"):
+            # Amount fields (quantity/weight/pieces/gross_weight) and sell_by are gated
+            # by edit_inventory_amounts: this GET is the single edit-entry chokepoint, so
+            # no gated cell can enter edit state without the permission, however it rendered.
             from ui.components.table import display_cell
             _f = next((x for x in schema if x.get("key") == field), {})
             return display_cell(entity_id=entity_id, field=field, value=item.get(field, ""),
@@ -3124,6 +3124,7 @@ function celerpPrintLabel(entityId, templateId) {
             primary_options=pri_opts, secondary_options=sec_opts,
             format_fn=fmt_fn,
             primary_editable=(pri_def or {}).get("editable", True),
+            secondary_editable=(sec_def or {}).get("editable", True),
         )
 
     @app.get("/api/items/{entity_id}/field/{field}/paired-edit")
@@ -3142,11 +3143,12 @@ function celerpPrintLabel(entityId, templateId) {
         except APIError as e:
             return P(f"Error: {e.detail}", cls="cell-error")
         locations = locs.get("items", [])
-        if field in AMOUNT_ITEM_KEYS:
+        if field in AMOUNT_EDIT_GATED_KEYS:
             # The paired cell is a second inline-edit entry point for amount fields
-            # (quantity/weight/gross_weight); gate it exactly like field_edit_cell so no
-            # amount can be hand-set without edit_inventory_amounts. Restore the read-only
-            # paired cell rather than an editable input.
+            # (quantity/weight/gross_weight) and the sell unit; gate it exactly like
+            # field_edit_cell so nothing gated can be hand-set without
+            # edit_inventory_amounts. Restore the read-only paired cell rather than an
+            # editable input.
             try:
                 _pe_company = await api.get_company(token)
             except Exception:
@@ -5222,7 +5224,7 @@ def _inventory_cell_renderers(schema: list[dict], unit_names: list[str] | None =
             sec_type = "select" if sec_opts else sec_def.get("type", "text")
             def _make(pri=primary, sec=secondary, pt=pri_def.get("type", "number"),
                       st=sec_type, po=pri_def.get("options"), so=sec_opts, _um=_umap,
-                      ped=pri_def.get("editable", True)):
+                      ped=pri_def.get("editable", True), sed=sec_def.get("editable", True)):
                 def renderer(entity_id: str, row: dict, _umap=_um):
                     # Format primary numeric value using its unit's decimal precision
                     raw_pri = row.get(pri, "")
@@ -5235,6 +5237,7 @@ def _inventory_cell_renderers(schema: list[dict], unit_names: list[str] | None =
                         primary_type=pt, secondary_type=st,
                         primary_options=po, secondary_options=so,
                         primary_editable=ped,
+                        secondary_editable=sed,
                     )
                 return renderer
             renderers[primary] = _make()
@@ -5776,16 +5779,16 @@ def _apply_unit_field_override(
 
 
 def _apply_amount_edit_permission(schema: list[dict], role: str, settings: dict) -> list[dict]:
-    """Return *schema* with amount fields marked read-only when *role* lacks the
-    edit_inventory_amounts permission. One transform at the schema source,
-    mirroring apply_field_visibility for costs (celerp.services.cost_visibility):
+    """Return *schema* with amount fields and the sell unit marked read-only when
+    *role* lacks the edit_inventory_amounts permission. One transform at the schema
+    source, mirroring apply_field_visibility for costs (celerp.services.cost_visibility):
     every cell that reads a field's 'editable' flag - the data_table default cells
-    and the weight/pieces renderers alike - inherits the restriction, so no amount
+    and the weight/pieces renderers alike - inherits the restriction, so no gated
     cell renders as click-to-edit without the permission. The backend edit
     endpoints enforce the same gate regardless of what the UI drew."""
     if role_has_permission(settings, role, "edit_inventory_amounts"):
         return schema
-    return [{**f, "editable": False} if f.get("key") in AMOUNT_ITEM_KEYS else f for f in schema]
+    return [{**f, "editable": False} if f.get("key") in AMOUNT_EDIT_GATED_KEYS else f for f in schema]
 
 
 def _resolve_field_def(

--- a/ui/routes/settings.py
+++ b/ui/routes/settings.py
@@ -3093,8 +3093,8 @@ def _role_matrix_row(perm, settings: dict | None, is_owner: bool) -> FT:
 
     A cell is interactive only for the owner, on a grantable permission, and never
     for the always-granted owner column; every other cell renders disabled. Toggling
-    a cell saves through the per-toggle route and swaps this whole row, so the higher
-    roles that inherit the change light up at once."""
+    a cell saves through the per-toggle route and swaps this whole row, so only the
+    toggled role changes and every other role keeps the grant it already had."""
     from celerp.services.permissions import ROLES, role_has_permission
 
     reason = _FIXED_ROW_REASON.get(perm.key) if not perm.grantable else None
@@ -3141,8 +3141,9 @@ def _role_permissions_matrix(settings: dict | None, is_owner: bool, lang: str = 
             cls="data-table role-ref-table",
         ),
         P(
-            "Roles are hierarchical - each role inherits every permission from the roles below it. "
-            "There must always be at least one Owner.",
+            "Each role's permissions are set independently: granting or removing a "
+            "permission for one role never changes any other role. There must always "
+            "be at least one Owner.",
             cls="role-ref-note",
         ),
         cls="role-ref-details mt-lg",

--- a/ui/static/app.css
+++ b/ui/static/app.css
@@ -379,6 +379,19 @@ a:hover { text-decoration: underline; }
   background: rgba(14,165,122,0.07);
   border-bottom-color: var(--c-accent);
 }
+/* Read-only paired spans (amount or sell unit without edit_inventory_amounts):
+   drop the click-to-edit affordance so they do not read as editable. Placed after
+   the base rules so the equal-specificity override wins by source order. */
+.cell--paired .paired-primary--readonly,
+.cell--paired .paired-secondary--readonly {
+  cursor: default;
+  border-bottom: none;
+}
+.cell--paired .paired-primary--readonly:hover,
+.cell--paired .paired-secondary--readonly:hover {
+  background: none;
+  border-bottom-color: transparent;
+}
 .cell--paired .paired-sep { color: var(--c-text-muted, #888); user-select: none; }
 .cell--paired .paired-tertiary { color: var(--c-text-muted, #888); font-style: italic; cursor: default; user-select: none; }
 


### PR DESCRIPTION
Fixes three issues on the inventory and admin list pages.

Frozen list header with custom columns. Customers who saved a custom column order or custom column widths saw the columns render out of order or at the wrong widths once the header froze on scroll. The frozen header now keeps the saved column arrangement and sizes, so a custom layout looks the same pinned as it does inline. Resetting columns to default continues to work.

Column resizer after a reset. After resetting columns to default, dragging a column border to resize it did not stick and the width reverted. A dragged width now persists and the frozen header re-aligns to the new width once the drag ends. Scrolling back up no longer drops applied widths.

Independent role permissions. In the admin permissions matrix, granting a permission to one role no longer changes another role. Each role's permissions are set independently, with no cross-role cascade.

Sell unit follows the quantity permission. A user whose type is not allowed to change quantity or weight can no longer change the sell unit, which had let quantity be altered indirectly. The sell unit is now gated by the same permission, validated server side with a clear message when the change is not allowed.
