### PR TITLE
Keep the frozen list header inside the table when scrolled sideways

### DIFF
--- a/tests/test_browser/test_sticky_header.py
+++ b/tests/test_browser/test_sticky_header.py
@@ -315,6 +315,39 @@ def test_pinned_header_tracks_horizontal_scroll(page, ui_server, sticky_inventor
     assert lefts is not None and abs(lefts[0] - lefts[1]) <= 2
 
 
+# ── the frozen header stays clipped inside the table, never painting over the sidebar (#274) ──
+def test_pinned_header_never_overlaps_sidebar_when_scrolled_right(page, ui_server, sticky_inventory):
+    _goto(page, ui_server)
+    # widen the first column so the table overflows its wrap and can be scrolled far right.
+    page.evaluate(
+        "() => { var th=document.querySelector('#data-table thead th[data-key]'); if(th) th.style.width='1200px'; }"
+    )
+    _scroll_to_pin(page)
+    assert _pinned(page)
+    # scroll the wrap to its far right so the table's left edge slides in under the sidebar.
+    page.evaluate(
+        "() => { var w=document.querySelector('.table-scroll-wrap');"
+        " w.scrollLeft=w.scrollWidth; w.dispatchEvent(new Event('scroll')); }"
+    )
+    page.wait_for_timeout(200)
+    probe = page.evaluate(
+        """() => {
+          var wrap=document.querySelector('.table-scroll-wrap');
+          var thead=document.querySelector('#data-table thead');
+          var wr=wrap.getBoundingClientRect(), tr=thead.getBoundingClientRect();
+          var x=wr.left-5, y=tr.top+Math.min(tr.height,20)/2;
+          var el=document.elementFromPoint(x, y);
+          return {headerLeft: tr.left, wrapLeft: wr.left,
+                  hitThead: !!(el && el.closest('#data-table thead'))};
+        }"""
+    )
+    # precondition: the header box really does extend left of the probe point (in under the
+    # sidebar), so the probe is a meaningful test of clipping and not a no-op.
+    assert probe["headerLeft"] < probe["wrapLeft"] - 5, "setup: header not scrolled left of the wrap"
+    # the frozen header must be clipped to the wrap; nothing of it may paint over the sidebar band.
+    assert not probe["hitThead"], "frozen header paints over the sidebar when scrolled right"
+
+
 # ── scrolling back to the top restores the inline header (no pin, no spacer, no inline style) ─
 def test_scroll_back_up_restores_inline_header(page, ui_server, sticky_inventory):
     _goto(page, ui_server)

--- a/ui/components/shell.py
+++ b/ui/components/shell.py
@@ -1090,14 +1090,26 @@ _STICKY_HEADER_JS = """
     // rect.left already reflects the wrap's horizontal scroll, so it is the body's content left.
     thead.style.left = rect.left + 'px';
     thead.style.width = rect.width + 'px';
-    // Keep the frozen phantom aligned with the on-screen wrap so its track spans the visible body.
-    // Its scrollLeft stays synced to the wrap by the existing bidirectional listener, unaffected
-    // by fixing position (that sync is scrollLeft-based, not layout-based).
-    var ph = phantomOf(t);
-    if(ph && ph.classList.contains('top-scroll-pinned')){
-      var w = wrapOf(t); var wr = w.getBoundingClientRect();
-      ph.style.left = wr.left + 'px';
-      ph.style.width = w.clientWidth + 'px';
+    // The header is position:fixed, so the wrap's overflow does not clip it: scrolled sideways it
+    // would paint over the sidebar on the left and past the table on the right. Clip it to the
+    // wrap's visible box, the same geometry the phantom scrollbar below already tracks. clip-path
+    // clips painting and hit-testing but leaves getBoundingClientRect intact, so columns stay aligned.
+    var w = wrapOf(t);
+    if(w){
+      var wr = w.getBoundingClientRect();
+      var clipL = Math.max(0, wr.left - rect.left);
+      var clipR = Math.max(0, (rect.left + rect.width) - (wr.left + w.clientWidth));
+      thead.style.clipPath = 'inset(0 ' + clipR + 'px 0 ' + clipL + 'px)';
+      // Keep the frozen phantom aligned with the on-screen wrap so its track spans the visible body.
+      // Its scrollLeft stays synced to the wrap by the existing bidirectional listener, unaffected
+      // by fixing position (that sync is scrollLeft-based, not layout-based).
+      var ph = phantomOf(t);
+      if(ph && ph.classList.contains('top-scroll-pinned')){
+        ph.style.left = wr.left + 'px';
+        ph.style.width = w.clientWidth + 'px';
+      }
+    } else {
+      thead.style.clipPath = '';
     }
   }
 
@@ -1164,7 +1176,7 @@ _STICKY_HEADER_JS = """
     t.classList.remove('hdr-pinned');
     var thead = t.tHead;
     if(thead){
-      thead.style.display = ''; thead.style.tableLayout = ''; thead.style.width = ''; thead.style.left = '';
+      thead.style.display = ''; thead.style.tableLayout = ''; thead.style.width = ''; thead.style.left = ''; thead.style.clipPath = '';
       // Leave the cell widths in place: they carry the user's applied/resized column sizes, and a
       // re-pin recaptures from them. Blanking them here dropped custom widths on scroll-up and wiped
       // an in-progress resize before it could persist.


### PR DESCRIPTION
On the list tables (for example Inventory), the header row freezes at the top once you scroll down so the column titles stay visible while the body scrolls. When the table was also scrolled to the right, the frozen header spilled outside the table: its labels painted over the sidebar navigation on the left and past the table on the right, so it no longer read as sitting over its columns. Scrolling further down kept the misplaced header on screen.

This clips the frozen header to the table's visible area, so it stays over its columns and never covers the sidebar no matter how far the table is scrolled left, right, or down. A table with nothing to scroll sideways is unaffected, and the header returns to normal as soon as you scroll back to the top.

A browser test covers the fix: with the header frozen and the table scrolled fully right, the header no longer paints over the sidebar band.
