### PR TITLE
Scanning into a building list updates lines in place and keeps scan bar focus

### DIFF
--- a/tests/test_browser/test_list_scan_in_place.py
+++ b/tests/test_browser/test_list_scan_in_place.py
@@ -1,0 +1,37 @@
+# Copyright (c) 2026 Noah Severs
+# SPDX-License-Identifier: LicenseRef-Proprietary
+"""Scanning into a building list is in place, like invoices and memos: the new line appears
+without a page reload and the scan bar keeps focus so the next scan can be entered immediately.
+"""
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+pytestmark = pytest.mark.browser
+
+
+def test_building_list_scan_appends_without_reload(page, ui_server, api):
+    tag = uuid.uuid4().hex[:6]
+    barcode = str(uuid.uuid4().int)[:12]
+    api.post("/items", json={"sku": f"SCN-{tag}", "name": "Scan Widget", "sell_by": "piece",
+             "quantity": 10, "barcode": barcode})
+    list_id = api.post("/lists", json={"list_type": "quotation"}).json()["id"]
+
+    page.goto(f"{ui_server}/lists/{list_id}", wait_until="domcontentloaded")
+    page.wait_for_selector("#scan-bar-input", timeout=8000)
+
+    # A reload would wipe this flag; it surviving the scan proves the update was in place.
+    page.evaluate("window.__scanProbe = 1")
+
+    page.locator("#scan-bar-input").click()
+    page.locator("#scan-bar-input").fill(barcode)
+    page.locator("#scan-bar-input").press("Enter")
+
+    # The scanned line lands in the tbody without a navigation.
+    page.wait_for_selector(f'#line-body [data-name="sku"][value="SCN-{tag}"]', timeout=8000)
+    assert page.evaluate("window.__scanProbe") == 1, "page reloaded on scan"
+    # Focus stays on the scan bar, cleared and ready for the next scan.
+    assert page.evaluate("document.activeElement && document.activeElement.id") == "scan-bar-input"
+    assert page.locator("#scan-bar-input").input_value() == ""

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -10328,6 +10328,39 @@ class TestAuditHighlightScoping:
         assert "data-row--audited" not in r.text
 
 
+class TestListScanInPlace:
+    """Scanning into a building list must never reload the page: the endpoint answers a plain 204
+    (no HX-Refresh) and the page script pulls the fresh tbody out of a background page fetch, so the
+    scan bar keeps focus between scans exactly like it does on invoices and memos."""
+
+    _DRAFT = {
+        "entity_id": "list:1", "list_type": "quotation", "status": "draft",
+        "receiver_type": "location", "receiver": "Main", "currency": "USD",
+        "discount": 0, "tax": 0, "subtotal": 0, "total": 0,
+        "line_items": [{
+            "entity_id": "li:1", "item_id": "item:1", "sku": "A1", "name": "Widget",
+            "description": "Widget", "quantity": 5,
+        }],
+    }
+
+    @pytest.mark.asyncio
+    async def test_building_list_scan_answers_204_without_refresh(self, ui_client):
+        with patch("ui.api_client.scan_list", new=AsyncMock(return_value={"state": "added"})), \
+             patch("ui.api_client.get_list", new=AsyncMock(return_value=self._DRAFT)):
+            r = await ui_client.post("/lists/list:1/scan", data={"barcode": "A1"}, cookies=_authed())
+        assert r.status_code == 204
+        assert "HX-Refresh" not in r.headers
+
+    @pytest.mark.asyncio
+    async def test_list_page_scan_script_swaps_tbody_in_place(self, ui_client):
+        # The list scan branch refetches this page and swaps #line-body instead of reloading.
+        with patch("ui.api_client.get_list", new=AsyncMock(return_value=self._DRAFT)):
+            r = await ui_client.get("/lists/list:1", cookies=_authed())
+        assert r.status_code == 200
+        assert "DOMParser" in r.text
+        assert "fetch(location.href)" in r.text
+
+
 class TestAuditColumnAlignment:
     """A draft audit is editable, but audits have no Unit column. Editable invoice rows otherwise emit
     a col-unit cell with no matching header, which on an audit would leak the unit label and shove

--- a/ui/routes/documents.py
+++ b/ui/routes/documents.py
@@ -4589,9 +4589,10 @@ celerpUpdateBulkAlloc();
         dispatches on (list_type, status); here we only choose the response shape:
 
         - a finalized audit (the rapid check-off case): swap the re-rendered #line-body tbody for speed;
-        - everything else, including a DRAFT audit building its manifest: reload via HX-Refresh so the
-          correct (editable) column layout renders through the same detail renderer (no duplicated row
-          builder).
+        - everything else, including a DRAFT audit building its manifest: plain 204 - the client pulls
+          the fresh tbody out of a background page fetch, so the correct (editable) column layout still
+          renders through the same detail renderer (no duplicated row builder) without a page reload,
+          and the scan bar keeps focus between scans exactly like it does on invoices and memos.
         """
         from starlette.responses import Response as _R
         from fasthtml.common import to_xml
@@ -4614,7 +4615,7 @@ celerpUpdateBulkAlloc();
         # audit is editable, so it reloads like every other building list to keep its inputs.
         if (lst.get("list_type") or "") == "audit" and lst.get("status") in (_LF, _LC):
             return HTMLResponse(to_xml(await _audit_line_tbody(token, entity_id)))
-        return _R("", status_code=204, headers={"HX-Refresh": "true"})
+        return _R("", status_code=204)
 
     @app.post("/lists/{entity_id}/set-scanned")
     async def list_set_scanned(request: Request, entity_id: str):
@@ -6845,23 +6846,37 @@ function _celerpDocTypeParam() {{
         scanStatus.className = 'scan-bar-status';
         if (_CELERP_IS_LIST === 'true') {{
             // Every list type scans through ONE server endpoint that dispatches on (type, status).
-            // The response is either a re-rendered tbody (audit fast-path) or an HX-Refresh (reload
-            // so the correct columns render via the same detail renderer). No client fork.
+            // The response is either a re-rendered tbody (audit fast-path) or a plain 204; on 204
+            // the fresh tbody comes from a background fetch of this page, so the editable columns
+            // still render via the same detail renderer. Either way the swap is in place - never a
+            // reload - so the scan bar keeps focus and a run of scans flows like it does on
+            // invoices and memos. No client fork.
             try {{
                 const fd = new URLSearchParams({{barcode: code}});
                 const plSelect = document.getElementById('doc-price-list');
                 if (plSelect) fd.append('price_list', plSelect.value);
                 const resp = await fetch('/lists/' + _CELERP_EID + '/scan', {{method: 'POST', body: fd}});
-                if (resp.headers.get('HX-Refresh')) {{ location.reload(); return; }}
                 if (!resp.ok) {{
                     const txt = await resp.text();
                     scanStatus.textContent = '✗ ' + (txt || 'Scan error');
                     scanStatus.className = 'scan-bar-status scan-bar-status--err';
                 }} else {{
-                    const html = await resp.text();
+                    let html = await resp.text();
+                    if (!html) {{
+                        const page = await fetch(location.href);
+                        const doc = new DOMParser().parseFromString(await page.text(), 'text/html');
+                        const fresh = doc.getElementById('{line_body_id}');
+                        html = fresh ? fresh.outerHTML : '';
+                    }}
                     const tbody = document.getElementById('{line_body_id}');
-                    if (tbody && html) tbody.outerHTML = html;
-                    htmx.process(document.getElementById('{line_body_id}'));
+                    if (tbody && html) {{
+                        tbody.outerHTML = html;
+                        const swapped = document.getElementById('{line_body_id}');
+                        htmx.process(swapped);
+                        swapped.querySelectorAll('.combobox-wrap').forEach(initCombobox);
+                        celerpUpdateTotals();
+                        _celerpHadLines = true;
+                    }}
                     scanStatus.textContent = '✓ Scanned: ' + code;
                     scanStatus.className = 'scan-bar-status scan-bar-status--ok';
                 }}


### PR DESCRIPTION
Scanning a barcode into a list that is still being built (and into any non-audit list) used to reload the whole page on every scan, dropping focus off the scan bar so each scan required clicking back into the field. Invoices and memos never did this.

Now every list scan updates the line items in place: the finalized audit fast path is unchanged, and all other list scans refresh the line table from a background page fetch instead of reloading. The scan bar keeps focus and clears after each scan, so a run of scans flows uninterrupted, the same way it already does on invoices and memos.

Fixes #278.