### PR TITLE
Fix three inventory role/lot bugs: draft amount-edit lock, reprice wrong lot, split weight-null block

### DIFF
--- a/default_modules/celerp-inventory/celerp_inventory/routes.py
+++ b/default_modules/celerp-inventory/celerp_inventory/routes.py
@@ -1888,7 +1888,16 @@ async def split_item(entity_id: str, payload: SplitBody, company_id=Depends(get_
     parent_attrs_wo_pieces = {k: v for k, v in parent_attrs.items() if k != "pieces"}
 
     parent_weight: float | None = _read_float(parent.state, "weight")
-    parent_weight_unit = parent.state.get("weight_unit") or "gram"
+    parent_is_weight_unit = is_weight_unit(parent_sell_by, unit_map)
+    # No weight was ever recorded (e.g. a CSV import that never synced it from
+    # quantity): fall back to qty, same as split_preview, so the mother-weight
+    # column the preview showed doesn't demand edit_inventory_amounts to confirm
+    # the exact value it already displayed. A genuinely stored weight (which may
+    # legitimately differ from qty) is never overridden.
+    parent_weight_is_derived = parent_weight is None and parent_is_weight_unit
+    if parent_weight_is_derived:
+        parent_weight = parent_qty
+    parent_weight_unit = parent.state.get("weight_unit") or (parent_sell_by if parent_is_weight_unit else "gram")
     weight_unit_cfg = unit_map.get(parent_weight_unit) or {}
     weight_decimals = weight_unit_cfg.get("decimals", 2)
 
@@ -2076,7 +2085,13 @@ async def split_item(entity_id: str, payload: SplitBody, company_id=Depends(get_
             )
 
     # Reduce parent quantity — use explicit mother_qty override when provided (user re-weighed mother).
-    total_child_weight = sum(c.weight for c in payload.children if c.weight is not None)
+    # When the parent weight was derived from qty (no weight was ever recorded), children
+    # never carry their own weight field either (mirrors split_preview) - the weight
+    # consumed is the same qty already summed above, not a sum of (absent) child weights.
+    total_child_weight = (
+        total_child_qty if parent_weight_is_derived
+        else sum(c.weight for c in payload.children if c.weight is not None)
+    )
     derived_parent_qty = round(parent_qty - total_child_qty, 10)
     derived_mother_weight = (
         round(parent_weight - total_child_weight, weight_decimals) if parent_weight is not None else None

--- a/default_modules/celerp-inventory/celerp_inventory/routes.py
+++ b/default_modules/celerp-inventory/celerp_inventory/routes.py
@@ -1961,6 +1961,11 @@ async def split_item(entity_id: str, payload: SplitBody, company_id=Depends(get_
     else:
         _child_cost_totals = [None] * len(children)
 
+    def _child_weight(c) -> float | None:
+        if c.weight is not None:
+            return c.weight
+        return c.quantity if parent_is_weight_unit else None
+
     # Per-child history descriptors with sequential mother deltas (one row per child).
     children_detail: list[dict] = []
     running_qty = parent_qty
@@ -2009,7 +2014,7 @@ async def split_item(entity_id: str, payload: SplitBody, company_id=Depends(get_
 
         # Origin marker on the child: "Split from <mother>" — the child's first history entry.
         ch_pieces = _to_int_pieces(child.attributes.get("pieces", 0)) if parent_pieces is not None else None
-        ch_weight = child.weight if (parent_weight is not None and child.weight is not None) else None
+        ch_weight = _child_weight(child) if parent_weight is not None else None
         origin = await emit_event(
             session,
             company_id=company_id,
@@ -2084,15 +2089,6 @@ async def split_item(entity_id: str, payload: SplitBody, company_id=Depends(get_
                 metadata_={"reason": "from_split"},
             )
 
-    # Reduce parent quantity — use explicit mother_qty override when provided (user re-weighed mother).
-    # For a weight-unit parent, a child's own quantity IS its weight unless it explicitly
-    # names a distinct one (the UI never sends one - qty is the only field it submits for
-    # these children - but a direct API caller may still hand-set a child weight that
-    # diverges from its quantity, same as test_split_mother_weight_computed_server_side).
-    def _child_weight(c) -> float | None:
-        if c.weight is not None:
-            return c.weight
-        return c.quantity if parent_is_weight_unit else None
     total_child_weight = sum(w for c in payload.children if (w := _child_weight(c)) is not None)
     derived_parent_qty = round(parent_qty - total_child_qty, 10)
     derived_mother_weight = (

--- a/default_modules/celerp-inventory/celerp_inventory/routes.py
+++ b/default_modules/celerp-inventory/celerp_inventory/routes.py
@@ -2085,13 +2085,15 @@ async def split_item(entity_id: str, payload: SplitBody, company_id=Depends(get_
             )
 
     # Reduce parent quantity — use explicit mother_qty override when provided (user re-weighed mother).
-    # When the parent weight was derived from qty (no weight was ever recorded), children
-    # never carry their own weight field either (mirrors split_preview) - the weight
-    # consumed is the same qty already summed above, not a sum of (absent) child weights.
-    total_child_weight = (
-        total_child_qty if parent_weight_is_derived
-        else sum(c.weight for c in payload.children if c.weight is not None)
-    )
+    # For a weight-unit parent, a child's own quantity IS its weight unless it explicitly
+    # names a distinct one (the UI never sends one - qty is the only field it submits for
+    # these children - but a direct API caller may still hand-set a child weight that
+    # diverges from its quantity, same as test_split_mother_weight_computed_server_side).
+    def _child_weight(c) -> float | None:
+        if c.weight is not None:
+            return c.weight
+        return c.quantity if parent_is_weight_unit else None
+    total_child_weight = sum(w for c in payload.children if (w := _child_weight(c)) is not None)
     derived_parent_qty = round(parent_qty - total_child_qty, 10)
     derived_mother_weight = (
         round(parent_weight - total_child_weight, weight_decimals) if parent_weight is not None else None

--- a/default_modules/first_party.lock.json
+++ b/default_modules/first_party.lock.json
@@ -7,7 +7,7 @@
   "celerp-contacts": "899cf9febb388356290f6eb8c8ab6d67f1f92a9c9fa8377ebb6d46bf04cedbc3",
   "celerp-dashboard": "00d2e8d6ef46a3afd5d6caf8434217095aabd40c963bfac19d0e988c714443ce",
   "celerp-docs": "8b69661d972454099f94fd0f22d0d3ce614bbc6a257effb776fdb12462a56b7b",
-  "celerp-inventory": "7ad823e6fb63ac1ec7d6347086876640ab02896ed0d330ea2936475d2d0fcd1e",
+  "celerp-inventory": "0d3b85ddb73ce02a2a97a5e00827435e145bddaae79491a7ad6b7ade88f38c06",
   "celerp-labels": "1175c234602fbc80e20a33a4d03bf7abcc9a7a78d6e83729c73106cb0af53832",
   "celerp-manufacturing": "5cc089a345eeff66be25db51432481487e699f28c0a545731650843fce81dc01",
   "celerp-reports": "f100f83b3fc3e4565685d3a0c8e62dcc724bb35d32238f051b05c5f97ae10d13",

--- a/default_modules/first_party.lock.json
+++ b/default_modules/first_party.lock.json
@@ -7,7 +7,7 @@
   "celerp-contacts": "899cf9febb388356290f6eb8c8ab6d67f1f92a9c9fa8377ebb6d46bf04cedbc3",
   "celerp-dashboard": "00d2e8d6ef46a3afd5d6caf8434217095aabd40c963bfac19d0e988c714443ce",
   "celerp-docs": "8b69661d972454099f94fd0f22d0d3ce614bbc6a257effb776fdb12462a56b7b",
-  "celerp-inventory": "722422990ddd1e94d9630ad442a68781e9ccd4d27ee06f59b4a2ba5384173e52",
+  "celerp-inventory": "7ad823e6fb63ac1ec7d6347086876640ab02896ed0d330ea2936475d2d0fcd1e",
   "celerp-labels": "1175c234602fbc80e20a33a4d03bf7abcc9a7a78d6e83729c73106cb0af53832",
   "celerp-manufacturing": "5cc089a345eeff66be25db51432481487e699f28c0a545731650843fce81dc01",
   "celerp-reports": "f100f83b3fc3e4565685d3a0c8e62dcc724bb35d32238f051b05c5f97ae10d13",

--- a/default_modules/first_party.lock.json
+++ b/default_modules/first_party.lock.json
@@ -7,7 +7,7 @@
   "celerp-contacts": "899cf9febb388356290f6eb8c8ab6d67f1f92a9c9fa8377ebb6d46bf04cedbc3",
   "celerp-dashboard": "00d2e8d6ef46a3afd5d6caf8434217095aabd40c963bfac19d0e988c714443ce",
   "celerp-docs": "8b69661d972454099f94fd0f22d0d3ce614bbc6a257effb776fdb12462a56b7b",
-  "celerp-inventory": "3beccf81df7dff80513d8de0b70db17924d2f5bcd8a111068fddcd76475096c4",
+  "celerp-inventory": "722422990ddd1e94d9630ad442a68781e9ccd4d27ee06f59b4a2ba5384173e52",
   "celerp-labels": "1175c234602fbc80e20a33a4d03bf7abcc9a7a78d6e83729c73106cb0af53832",
   "celerp-manufacturing": "5cc089a345eeff66be25db51432481487e699f28c0a545731650843fce81dc01",
   "celerp-reports": "f100f83b3fc3e4565685d3a0c8e62dcc724bb35d32238f051b05c5f97ae10d13",

--- a/tests/test_browser/test_item_draft_status.py
+++ b/tests/test_browser/test_item_draft_status.py
@@ -110,6 +110,106 @@ def test_draft_amounts_editable_for_restricted_role(page, ui_server, api, api_se
                         "granted": True})
 
 
+def test_draft_pieces_editable_on_list_for_restricted_role(page, ui_server, api, api_server,
+                                                            browser_context, seeded_user):
+    """The pieces column has its own dedicated renderer (not a paired cell like
+    quantity/weight/gross_weight), so it needs the same per-row draft carve-out
+    separately: an operator holding edit_inventory but not edit_inventory_amounts
+    should still see a draft row's pieces value as editable on the list page."""
+    tag = uuid.uuid4().hex[:6]
+    draft_sku, avail_sku = f"PCD-{tag}", f"PCA-{tag}"
+    r = api.patch("/companies/me/role-permissions",
+                  json={"perm_key": "edit_inventory_amounts", "role_key": "operator",
+                        "granted": False})
+    assert r.status_code == 200, r.text
+    r = api.post("/companies/me/users",
+                 json={"email": f"opp-{tag}@celerp.test", "name": "Operator",
+                       "role": "operator", "password": "pw12345"})
+    assert r.status_code == 200, r.text
+
+    for sku, make_available in ((draft_sku, False), (avail_sku, True)):
+        r = api.post("/items", json={"sku": sku, "name": "Pieces Widget", "sell_by": "carat",
+                                     "quantity": 2.5, "pieces": 3, "cost_price": 15.0})
+        assert r.status_code == 200, r.text
+        if make_available:
+            r2 = api.post("/items/bulk/make-available", json={"entity_ids": [r.json()["id"]]})
+            assert r2.status_code == 200, r2.text
+
+    _clear_session_registry()
+    lr = httpx.post(f"{api_server}/auth/login",
+                    json={"email": f"opp-{tag}@celerp.test", "password": "pw12345"}, timeout=10)
+    assert lr.status_code == 200, lr.text
+    try:
+        _set_cookie(browser_context, lr.json()["access_token"])
+
+        page.goto(f"{ui_server}/inventory?q={draft_sku}", wait_until="domcontentloaded")
+        page.wait_for_selector(".badge--draft", timeout=8000)
+        pcs = page.locator(f'tr:has-text("{draft_sku}") td[data-col="pieces"]').first
+        pcs.wait_for(timeout=8000)
+        assert pcs.get_attribute("title") == "Double-click to edit"
+        assert "cell--clickable" in (pcs.get_attribute("class") or "")
+
+        page.goto(f"{ui_server}/inventory?q={avail_sku}", wait_until="domcontentloaded")
+        page.wait_for_selector(".badge--available", timeout=8000)
+        pcs2 = page.locator(f'tr:has-text("{avail_sku}") td[data-col="pieces"]').first
+        pcs2.wait_for(timeout=8000)
+        assert pcs2.get_attribute("title") is None
+        assert "cell--clickable" not in (pcs2.get_attribute("class") or "")
+    finally:
+        _set_cookie(browser_context, seeded_user["access_token"])
+        api.patch("/companies/me/role-permissions",
+                  json={"perm_key": "edit_inventory_amounts", "role_key": "operator",
+                        "granted": True})
+
+
+def test_draft_amounts_editable_on_detail_page_for_restricted_role(page, ui_server, api, api_server,
+                                                                    browser_context, seeded_user):
+    tag = uuid.uuid4().hex[:6]
+    draft_sku, avail_sku = f"DPD-{tag}", f"DPA-{tag}"
+    r = api.patch("/companies/me/role-permissions",
+                  json={"perm_key": "edit_inventory_amounts", "role_key": "operator",
+                        "granted": False})
+    assert r.status_code == 200, r.text
+    r = api.post("/companies/me/users",
+                 json={"email": f"opd-{tag}@celerp.test", "name": "Operator",
+                       "role": "operator", "password": "pw12345"})
+    assert r.status_code == 200, r.text
+
+    item_ids = {}
+    for sku, make_available in ((draft_sku, False), (avail_sku, True)):
+        r = api.post("/items", json={"sku": sku, "name": "Detail Widget", "sell_by": "piece",
+                                     "quantity": 4, "cost_price": 15.0})
+        assert r.status_code == 200, r.text
+        item_ids[sku] = r.json()["id"]
+        if make_available:
+            r2 = api.post("/items/bulk/make-available", json={"entity_ids": [item_ids[sku]]})
+            assert r2.status_code == 200, r2.text
+
+    _clear_session_registry()
+    lr = httpx.post(f"{api_server}/auth/login",
+                    json={"email": f"opd-{tag}@celerp.test", "password": "pw12345"}, timeout=10)
+    assert lr.status_code == 200, lr.text
+    try:
+        _set_cookie(browser_context, lr.json()["access_token"])
+
+        page.goto(f"{ui_server}/inventory/{item_ids[draft_sku]}", wait_until="domcontentloaded")
+        qty = page.locator('tr:has-text("Qty") .paired-primary').first
+        qty.wait_for(timeout=8000)
+        assert qty.get_attribute("title") == "Double-click to edit"
+        assert "paired-primary--readonly" not in (qty.get_attribute("class") or "")
+
+        page.goto(f"{ui_server}/inventory/{item_ids[avail_sku]}", wait_until="domcontentloaded")
+        qty2 = page.locator('tr:has-text("Qty") .paired-primary').first
+        qty2.wait_for(timeout=8000)
+        assert "paired-primary--readonly" in (qty2.get_attribute("class") or "")
+        assert qty2.get_attribute("title") is None
+    finally:
+        _set_cookie(browser_context, seeded_user["access_token"])
+        api.patch("/companies/me/role-permissions",
+                  json={"perm_key": "edit_inventory_amounts", "role_key": "operator",
+                        "granted": True})
+
+
 def test_draft_cost_edit_on_pricing_tab_persists(page, ui_server, api, api_server,
                                                   browser_context, seeded_user):
     """An operator (edit_inventory only) sees an editable cost input on a draft's

--- a/tests/test_browser/test_reprice_wrong_lot.py
+++ b/tests/test_browser/test_reprice_wrong_lot.py
@@ -1,0 +1,102 @@
+# Copyright (c) 2026 Noah Severs. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-Proprietary
+"""Regression: repricing a memo must reprice each line against the exact inventory
+lot it was added from, not the first item found by a SKU lookup.
+
+Bug: both reprice paths (the price_list field-edit and the /reprice endpoint) looked
+up the current price by `list_items(token, {"sku": sku, "limit": 1})` and used
+`items[0]`, ignoring the `item_id` already stored on the line. When two lots share
+a SKU with different prices, reprice can silently swap in a sibling lot's price.
+"""
+from __future__ import annotations
+
+import uuid
+
+import httpx
+import pytest
+
+pytestmark = pytest.mark.browser
+
+
+@pytest.fixture()
+def duplicate_sku_memo(fresh_company):
+    """Two items sharing one SKU with different prices, and a memo whose single
+    line references the SECOND item (the one list_items would NOT return first)."""
+    api = fresh_company
+    r = api.patch("/companies/me/price-lists", json={
+        "price_lists": [{"name": "Retail"}, {"name": "Wholesale"}],
+        "base_price_list": "Retail",
+    })
+    assert r.status_code in {200, 201}, r.text
+
+    sku = f"DUP-{uuid.uuid4().hex[:6]}"
+    r_a = api.post("/items", json={"sku": sku, "name": "Lot A", "sell_by": "piece",
+                                   "quantity": 1, "retail_price": 100.0, "wholesale_price": 50.0})
+    assert r_a.status_code == 200, r_a.text
+    r_b = api.post("/items", json={"sku": sku, "name": "Lot B", "sell_by": "piece",
+                                   "quantity": 1, "retail_price": 200.0, "wholesale_price": 150.0})
+    assert r_b.status_code == 200, r_b.text
+    item_b_id = r_b.json()["id"]
+
+    item_a_id = r_a.json()["id"]
+    r = api.post("/items/bulk/make-available", json={"entity_ids": [item_a_id, item_b_id]})
+    assert r.status_code == 200, r.text
+
+    # list_items (unsorted) defaults to most-recently-updated-first: touch Lot A last so
+    # it sorts ahead of Lot B, reproducing the exact bug - a plain sku lookup's items[0]
+    # lands on the WRONG lot (A) even though this memo's line points at Lot B.
+    r = api.patch(f"/items/{item_a_id}", json={"location_name": "Main"})
+    assert r.status_code == 200, r.text
+
+    r = api.post("/docs", json={
+        "doc_type": "memo",
+        "status": "draft",
+        "price_list": "Retail",
+        "line_items": [
+            {"sku": sku, "item_id": item_b_id, "name": "Lot B", "quantity": 1,
+             "unit_price": 200.0, "line_total": 200.0},
+        ],
+        "total": 200.0,
+    })
+    assert r.status_code in {200, 201}, r.text
+    return api, r.json()["id"], item_b_id
+
+
+def _line_items(api, doc_id):
+    r = api.get(f"/docs/{doc_id}")
+    assert r.status_code == 200, r.text
+    return r.json()
+
+
+def test_reprice_via_price_list_field_uses_lines_own_lot(ui_server, duplicate_sku_memo):
+    api, doc_id, item_b_id = duplicate_sku_memo
+    token = api.headers["Authorization"].removeprefix("Bearer ")
+
+    with httpx.Client(base_url=ui_server, cookies={"celerp_token": token}, timeout=10) as ui:
+        r = ui.patch(f"/docs/{doc_id}/field/price_list", data={"value": "Wholesale"})
+        assert r.status_code in (200, 204), r.text
+
+    doc = _line_items(api, doc_id)
+    line = doc["line_items"][0]
+    assert line["item_id"] == item_b_id
+    assert line["unit_price"] == 150.0, (
+        f"reprice picked the wrong lot's price: got {line['unit_price']}, "
+        f"expected Lot B's wholesale_price (150.0), not Lot A's (50.0)"
+    )
+
+
+def test_reprice_endpoint_uses_lines_own_lot(ui_server, duplicate_sku_memo):
+    api, doc_id, item_b_id = duplicate_sku_memo
+    token = api.headers["Authorization"].removeprefix("Bearer ")
+
+    with httpx.Client(base_url=ui_server, cookies={"celerp_token": token}, timeout=10) as ui:
+        r = ui.post(f"/docs/{doc_id}/reprice", json={"price_list": "Wholesale"})
+        assert r.status_code == 200, r.text
+
+    doc = _line_items(api, doc_id)
+    line = doc["line_items"][0]
+    assert line["item_id"] == item_b_id
+    assert line["unit_price"] == 150.0, (
+        f"reprice picked the wrong lot's price: got {line['unit_price']}, "
+        f"expected Lot B's wholesale_price (150.0), not Lot A's (50.0)"
+    )

--- a/tests/test_item_history.py
+++ b/tests/test_item_history.py
@@ -206,6 +206,50 @@ async def test_split_weight_parcel_with_child_pieces_conserves(client):
 
 
 @pytest.mark.asyncio
+async def test_split_derived_weight_history_matches_mother_state(client):
+    h = {"Authorization": f"Bearer {await _token(client)}"}
+    parent_id = await _seed(client, h, quantity=10.0, sell_by="carat", attributes={"pieces": 8})
+    r = await client.post(f"/items/{parent_id}/split",
+                          json={"children": [{"sku": "MUM.1", "quantity": 3.0, "pieces": 3}]}, headers=h)
+    assert r.status_code == 200, r.text
+    child_id = r.json()["children"][0]["id"]
+
+    mother = await _item(client, h, parent_id)
+    assert mother["quantity"] == pytest.approx(7.0)
+    assert mother["weight"] == pytest.approx(7.0)
+
+    split = [e for e in await _events(client, h, parent_id) if e["event_type"] == "item.split"][0]
+    c0 = split["data"]["children_detail"][0]
+    assert (c0["qty_before"], c0["qty_after"]) == (pytest.approx(10.0), pytest.approx(7.0))
+    assert (c0["weight_before"], c0["weight_after"]) == (pytest.approx(10.0), pytest.approx(7.0))
+
+    origin = [e for e in await _events(client, h, child_id) if e["event_type"] == "item.split_from"][0]
+    assert origin["data"]["qty"] == pytest.approx(3.0)
+    assert origin["data"]["weight"] == pytest.approx(3.0)
+
+
+@pytest.mark.asyncio
+async def test_split_derived_weight_history_sequential_two_children(client):
+    h = {"Authorization": f"Bearer {await _token(client)}"}
+    parent_id = await _seed(client, h, quantity=10.0, sell_by="carat", attributes={"pieces": 8})
+    r = await client.post(
+        f"/items/{parent_id}/split",
+        json={"children": [{"sku": "MUM.1", "quantity": 3.0, "pieces": 3},
+                           {"sku": "MUM.2", "quantity": 2.0, "pieces": 2}]},
+        headers=h,
+    )
+    assert r.status_code == 200, r.text
+
+    split = [e for e in await _events(client, h, parent_id) if e["event_type"] == "item.split"][0]
+    cd = split["data"]["children_detail"]
+    assert (cd[0]["weight_before"], cd[0]["weight_after"]) == (pytest.approx(10.0), pytest.approx(7.0))
+    assert (cd[1]["weight_before"], cd[1]["weight_after"]) == (pytest.approx(7.0), pytest.approx(5.0))
+
+    mother = await _item(client, h, parent_id)
+    assert mother["weight"] == pytest.approx(5.0)
+
+
+@pytest.mark.asyncio
 async def test_split_piece_unit_pieces_track_quantity(client):
     """For a piece-unit item, pieces track quantity: children get their own
     quantity, the mother keeps what remains - never the full inherited count."""

--- a/tests/test_role_permissions.py
+++ b/tests/test_role_permissions.py
@@ -1713,6 +1713,34 @@ async def test_split_allowed_without_amount_permission_when_weight_missing_but_p
     assert r.status_code == 200, r.text
 
 
+async def test_split_allowed_without_amount_permission_when_parent_has_real_weight(client, session):
+    """A weight-sell-by item that DOES carry a real, stored weight (equal to qty, as
+    normal for these items): a child submits only quantity + a pieces complement, no
+    explicit weight, exactly what the UI sends for weight-unit sell_by children. The
+    mother's derived remainder must still fall back to qty for that child - not treat
+    the child as contributing zero weight - so the permission check doesn't fire for
+    a value nobody hand-set."""
+    ctx = await perm_setup(client, session)
+    await grant_permission(client, ctx["admin_h"], "edit_inventory_amounts", "manager")
+    r = await client.post(
+        "/items",
+        json={"status": "available", "sku": "SPLW-2", "name": "SPLW-2", "quantity": 147.0,
+              "weight": 147.0, "location_id": ctx["location_id"], "sell_by": "gram",
+              "allow_splitting": True, "attributes": {"pieces": 5}},
+        headers=ctx["admin_h"],
+    )
+    assert r.status_code == 200, r.text
+    item_id = r.json()["id"]
+    # derived remainder = 147 - 22.99 = 124.01 (child weight falls back to its own qty)
+    r = await client.post(
+        f"/items/{item_id}/split",
+        json={"children": [{"sku": "SPLW-2.1", "quantity": 22.99, "pieces": 1}],
+              "mother_weight": 124.01},
+        headers=ctx["operator_h"],
+    )
+    assert r.status_code == 200, r.text
+
+
 def _import_record(entity_id: str, data: dict, key: str, event_type: str = "item.created") -> dict:
     return {"entity_id": entity_id, "event_type": event_type, "data": data,
             "source": "csv", "idempotency_key": key}

--- a/tests/test_role_permissions.py
+++ b/tests/test_role_permissions.py
@@ -1685,6 +1685,34 @@ async def test_split_negative_reweigh_rejected(client, session):
     assert r.status_code == 422, r.text
 
 
+async def test_split_allowed_without_amount_permission_when_weight_missing_but_pieces_tracked(client, session):
+    """A weight-sell-by item whose weight was never recorded (e.g. a CSV import that
+    never synced weight from quantity) but which tracks pieces makes the item-detail
+    split card show a weight column, whose hidden mother_weight field is always
+    submitted at the preview's fallback-derived value (== remaining qty, since raw
+    weight is null). That echoed-back fallback value is not a hand re-weigh and must
+    not require edit_inventory_amounts."""
+    ctx = await perm_setup(client, session)
+    await grant_permission(client, ctx["admin_h"], "edit_inventory_amounts", "manager")
+    r = await client.post(
+        "/items",
+        json={"status": "available", "sku": "SPLW-1", "name": "SPLW-1", "quantity": 10,
+              "location_id": ctx["location_id"], "sell_by": "carat", "allow_splitting": True,
+              "attributes": {"pieces": 8}},
+        headers=ctx["admin_h"],
+    )
+    assert r.status_code == 200, r.text
+    item_id = r.json()["id"]
+    # derived remainder = 10 - 3 = 7 (weight falls back to qty since raw weight is unset)
+    r = await client.post(
+        f"/items/{item_id}/split",
+        json={"children": [{"sku": "SPLW-1.1", "quantity": 3, "pieces": 3}],
+              "mother_weight": 7.0},
+        headers=ctx["operator_h"],
+    )
+    assert r.status_code == 200, r.text
+
+
 def _import_record(entity_id: str, data: dict, key: str, event_type: str = "item.created") -> dict:
     return {"entity_id": entity_id, "event_type": event_type, "data": data,
             "source": "csv", "idempotency_key": key}

--- a/ui/routes/documents.py
+++ b/ui/routes/documents.py
@@ -2540,12 +2540,16 @@ celerpUpdateBulkAlloc();
                         repriced = 0
                         for line in lines:
                             sku = (line.get("sku") or "").strip()
-                            if sku:
+                            eid = (line.get("item_id") or line.get("entity_id") or "").strip()
+                            if sku or eid:
                                 try:
-                                    resp = await api.list_items(token, {"sku": sku, "limit": 1})
-                                    items = resp.get("items", []) if isinstance(resp, dict) else resp
-                                    if items:
-                                        new_price = resolve_price(items[0], new_pl)
+                                    item = await api.get_item(token, eid) if eid else None
+                                    if item is None and sku:
+                                        resp = await api.list_items(token, {"sku": sku, "limit": 1})
+                                        items = resp.get("items", []) if isinstance(resp, dict) else resp
+                                        item = items[0] if items else None
+                                    if item is not None:
+                                        new_price = resolve_price(item, new_pl)
                                         line = {**line, "unit_price": new_price, "price_list": new_pl}
                                         repriced += 1
                                 except Exception:
@@ -2900,13 +2904,16 @@ celerpUpdateBulkAlloc();
         updated_lines = []
         for line in existing_lines:
             sku = (line.get("sku") or "").strip()
-            if sku:
-                # Look up current item price via catalog endpoint (SKU lookup)
+            eid = (line.get("item_id") or line.get("entity_id") or "").strip()
+            if sku or eid:
                 try:
-                    resp = await api.list_items(token, {"sku": sku, "limit": 1})
-                    items = resp.get("items", []) if isinstance(resp, dict) else resp
-                    if items:
-                        new_price = resolve_price(items[0], price_list)
+                    item = await api.get_item(token, eid) if eid else None
+                    if item is None and sku:
+                        resp = await api.list_items(token, {"sku": sku, "limit": 1})
+                        items = resp.get("items", []) if isinstance(resp, dict) else resp
+                        item = items[0] if items else None
+                    if item is not None:
+                        new_price = resolve_price(item, price_list)
                         line = {**line, "unit_price": new_price, "price_list": price_list}
                         repriced += 1
                 except APIError:

--- a/ui/routes/inventory.py
+++ b/ui/routes/inventory.py
@@ -1855,6 +1855,9 @@ def setup_routes(app):
             for f in schema
         ]
         schema = _apply_amount_edit_permission(schema, _get_role(request), company.get("settings") or {})
+        if (str(item.get("status") or "").lower() == "draft"
+                and role_has_permission(company.get("settings") or {}, _get_role(request), "edit_inventory")):
+            schema = [{**f, "editable": True} if f.get("key") in AMOUNT_EDIT_GATED_KEYS else f for f in schema]
         # Merge category-specific fields for this item's category
         item_cat = item.get("category", "")
         if item_cat and item_cat in cat_schemas:
@@ -5438,7 +5441,8 @@ def _inventory_cell_renderers(schema: list[dict], unit_names: list[str] | None =
                     data_col="pieces",
                     data_decimals=str(decimals),
                 )
-            return display_cell(entity_id=entity_id, field="pieces", value=row.get("pieces", ""), cell_type="number", editable=_ed)
+            _rek = set(row.get("_row_editable_keys") or ())
+            return display_cell(entity_id=entity_id, field="pieces", value=row.get("pieces", ""), cell_type="number", editable=_ed or "pieces" in _rek)
         renderers["pieces"] = _pieces_renderer
 
     # Status renderer: a doc-driven status (sold, memo_out, consigned-in stock) carries


### PR DESCRIPTION
## What this changes

### Summary
- Draft items still showed quantity/weight/pieces as read-only on the item
  detail page and the pieces column on the list page, for a role holding
  edit_inventory but not edit_inventory_amounts — even though the same
  fields were already correctly editable elsewhere in the draft flow.
- Repricing a document (via the price_list field edit and the /reprice
  endpoint) looked up the new price by SKU and took the first match,
  silently pricing against the wrong lot whenever two items share a SKU.
- Splitting a weight-sell-by item whose weight was never recorded (e.g. a
  CSV import that never synced weight from quantity) incorrectly demanded
  edit_inventory_amounts, because split_item's derivation didn't match
  split_preview's existing qty-fallback — blocking operators from splitting
  some stones but not others for no visible reason.

### Test plan
- [x] New/updated regression tests for each fix, confirmed to fail before
      the fix and pass after
- [x] Full non-browser suite (11658 passed; only pre-existing/environment
      failures unrelated to this branch)
- [x] Full browser suite (419 passed)
- [x] first_party.lock.json regenerated for the celerp-inventory change

## Checklist

- [X] Tests added or updated, and the relevant suites pass locally
- [X] License headers are correct for the paths touched (see `LICENSING.md`; enforced by `scripts/licenses.py`)
