### PR TITLE
Fix reconciliation form, invoice PDF, and setup wizard bugs

### DIFF
--- a/celerp/output/pdf.py
+++ b/celerp/output/pdf.py
@@ -349,7 +349,7 @@ def generate_document_pdf(doc: dict[str, Any], company: dict[str, Any] | None = 
         if li_taxes:
             tax_str = " + ".join(
                 f"{t.get('label') or t.get('code') or 'Tax'} {float(t.get('rate', 0)):.1f}%"
-                for item in li_taxes
+                for t in li_taxes
             )
         else:
             tax_str = f"{float(li.get('tax_rate') or 0):.1f}%"

--- a/conftest.py
+++ b/conftest.py
@@ -5,29 +5,26 @@ from __future__ import annotations
 
 import os
 
+from conftest_support import is_own_test_config, resolve_worker_config
+
 # Must be set before celerp.config is imported (JWT guard fires at module load).
 os.environ.setdefault("ALLOW_INSECURE_JWT", "true")
 
-# Point config.toml at a per-worker temp file. Otherwise every xdist worker
-# shares ~/.config/celerp/config.toml, which ensure_instance_id() reads+writes
-# on the cloud-relay endpoints — concurrent access across workers (and leakage
-# of one test's instance_id/token into the next) made those tests flaky.
-import tempfile as _tempfile
+# Point config.toml at a per-worker temp file. Otherwise every xdist worker shares
+# ~/.config/celerp/config.toml, which ensure_instance_id() reads+writes on the
+# cloud-relay endpoints: concurrent access across workers corrupts the file
+# mid-write (a torn read raises tomllib.TOMLDecodeError) and leaks one test's
+# instance_id/token into the next. resolve_worker_config is the shared rule (see
+# its docstring for why a plain setdefault does not achieve this under xdist).
 _worker = os.environ.get("PYTEST_XDIST_WORKER", "main")
-os.environ.setdefault(
-    "CELERP_CONFIG",
-    os.path.join(_tempfile.gettempdir(), f"celerp-test-config-{_worker}.toml"),
-)
+os.environ["CELERP_CONFIG"] = resolve_worker_config(os.environ.get("CELERP_CONFIG"), _worker)
+
 # Start from a clean config: a temp file left by a previous local run (e.g. a
 # persisted [cloud] disconnected = true from the disconnect endpoint) must not
 # leak into this session. Scoped to our own temp path so a real CELERP_CONFIG
 # passed in by CI is never touched.
 _cfg_start = os.environ["CELERP_CONFIG"]
-if (
-    os.path.dirname(_cfg_start) == _tempfile.gettempdir()
-    and os.path.basename(_cfg_start).startswith("celerp-test-config-")
-    and os.path.exists(_cfg_start)
-):
+if is_own_test_config(_cfg_start) and os.path.exists(_cfg_start):
     os.remove(_cfg_start)
 
 # ── Postgres for the whole test suite ──────────────────────────────────────────

--- a/conftest_support.py
+++ b/conftest_support.py
@@ -1,0 +1,44 @@
+# Copyright (c) 2026 Noah Severs
+# SPDX-License-Identifier: LicenseRef-Proprietary
+"""Side-effect-free helpers for the root conftest.
+
+Kept in a separate module (never collected as a test, never provisions a
+database on import) so the per-worker config-isolation rule can be unit tested
+without importing the root conftest, which spins up Postgres at import time.
+"""
+from __future__ import annotations
+
+import os
+import tempfile
+
+_CONFIG_PREFIX = "celerp-test-config-"
+
+
+def is_own_test_config(path: str | None, tmpdir: str | None = None) -> bool:
+    """True for a config path this harness itself created (our per-worker temp).
+
+    Used to tell an inherited value we set from a genuine external CELERP_CONFIG:
+    only the former may be recomputed per worker, the latter is always honored.
+    """
+    if path is None:
+        return False
+    tmpdir = tmpdir or tempfile.gettempdir()
+    return os.path.dirname(path) == tmpdir and os.path.basename(path).startswith(_CONFIG_PREFIX)
+
+
+def resolve_worker_config(existing: str | None, worker: str, tmpdir: str | None = None) -> str:
+    """Return the config.toml path this worker must use.
+
+    An xdist worker inherits the controller process's environment, where the root
+    conftest already ran and set CELERP_CONFIG to the controller's ("main") path.
+    A plain setdefault would then leave every worker pointing at that one shared
+    file, so concurrent read/write across workers corrupts it mid-write (a torn
+    file fails tomllib.load and 500s unrelated requests). So whenever the inherited
+    value is one of our own temp paths (or unset), recompute it for THIS worker; a
+    genuine external CELERP_CONFIG is always left untouched.
+    """
+    tmpdir = tmpdir or tempfile.gettempdir()
+    own = os.path.join(tmpdir, f"{_CONFIG_PREFIX}{worker}.toml")
+    if existing is None or is_own_test_config(existing, tmpdir):
+        return own
+    return existing

--- a/scripts/check_undefined_names.py
+++ b/scripts/check_undefined_names.py
@@ -54,6 +54,8 @@ class Scope:
         self.parent = parent      # lexical parent Scope or None
         self.kind = kind          # 'module' | 'function' | 'class' | 'comp'
         self.names: set[str] = set()
+        self.global_names: set[str] = set()    # `global x` declared here
+        self.nonlocal_names: set[str] = set()  # `nonlocal x` declared here
         self.star = False         # saw an `import *` whose source could not resolve
 
 
@@ -85,12 +87,14 @@ class ScopeBuilder(ast.NodeVisitor):
             self.scope.names.add(node.id)
 
     def visit_Global(self, node):
+        # A global name is NOT a local binding: it resolves against module
+        # scope, so record it separately rather than as a local name.
         for n in node.names:
-            self.scope.names.add(n)
+            self.scope.global_names.add(n)
 
     def visit_Nonlocal(self, node):
         for n in node.names:
-            self.scope.names.add(n)
+            self.scope.nonlocal_names.add(n)
 
     def visit_Import(self, node):
         for a in node.names:
@@ -139,19 +143,48 @@ class Checker:
         self.path = path
         self.errors: list[tuple[int, str]] = []
 
+    @staticmethod
+    def _module(scope: Scope) -> Scope:
+        s = scope
+        while s.parent is not None:
+            s = s.parent
+        return s
+
     def resolve(self, name: str, scope: Scope) -> bool:
+        # A `global` declaration in this scope forces module-level resolution,
+        # ignoring any enclosing function or class binding.
+        if name in scope.global_names:
+            mod = self._module(scope)
+            return name in mod.names or mod.star or name in BUILTINS
+        # A `nonlocal` declaration binds to an enclosing FUNCTION scope only.
+        if name in scope.nonlocal_names:
+            s = scope.parent
+            while s is not None:
+                if s.kind == "function" and name in s.names:
+                    return True
+                s = s.parent
+            return False
+        # Ordinary lexical lookup. A class scope is visible only to code
+        # directly in the class body, never to a nested function/comprehension
+        # scope, so skip any class scope that is not the starting scope.
         s = scope
         saw_star = False
         while s is not None:
             if s.star:
                 saw_star = True
-            if name in s.names:
+            if name in s.names and not (s.kind == "class" and s is not scope):
                 return True
             s = s.parent
         return name in BUILTINS or saw_star
 
     def check_body(self, body, scope: Scope):
         build_scope_names(body, scope)
+        # A name declared `global` AND assigned in this scope binds a module
+        # global at runtime; surface it at module scope so later loads resolve.
+        if scope.global_names:
+            mod = self._module(scope)
+            for g in scope.global_names & scope.names:
+                mod.names.add(g)
         for stmt in body:
             self.visit(stmt, scope)
 
@@ -239,6 +272,17 @@ class Checker:
             self.visit(node.elt, cscope)
 
 
+def check_source(src: str, filename: str = "<string>") -> list[tuple[int, str]]:
+    """Return (lineno, name) for every undefined load in a source string."""
+    tree = ast.parse(src, filename=filename)
+    mscope = Scope(None, "module")
+    mscope.names |= {"__file__", "__name__", "__doc__", "__package__",
+                     "__spec__", "__loader__", "__builtins__"}
+    c = Checker(Path(filename))
+    c.check_body(tree.body, mscope)
+    return list(c.errors)
+
+
 def find_undefined(roots) -> list[tuple[Path, int, str]]:
     """Return (path, lineno, name) for every undefined load under the given roots."""
     findings: list[tuple[Path, int, str]] = []
@@ -247,17 +291,10 @@ def find_undefined(roots) -> list[tuple[Path, int, str]]:
         for path in sorted(root.rglob("*.py")):
             src = path.read_text(encoding="utf-8")
             try:
-                tree = ast.parse(src, filename=str(path))
+                for lineno, name in check_source(src, str(path)):
+                    findings.append((path, lineno, name))
             except SyntaxError as e:
                 findings.append((path, getattr(e, "lineno", 0) or 0, f"SYNTAX ERROR {e}"))
-                continue
-            mscope = Scope(None, "module")
-            mscope.names |= {"__file__", "__name__", "__doc__", "__package__",
-                             "__spec__", "__loader__", "__builtins__"}
-            c = Checker(path)
-            c.check_body(tree.body, mscope)
-            for lineno, name in c.errors:
-                findings.append((path, lineno, name))
     return findings
 
 

--- a/scripts/check_undefined_names.py
+++ b/scripts/check_undefined_names.py
@@ -1,0 +1,274 @@
+# Copyright (c) 2026 Noah Severs
+# SPDX-License-Identifier: LicenseRef-Proprietary
+
+"""Static checker for undefined names (NameError at runtime).
+
+pyflakes and ruff stop reporting undefined names (F821) in any module that does
+`from x import *`, because the star import could in principle bind the name.
+Every UI route and component does `from fasthtml.common import *`, so that whole
+layer has no undefined-name coverage from the normal linters. Issue 284 shipped
+exactly there: a route referenced a constant that did not exist and 500'd the
+moment the form opened.
+
+This checker closes that gap. It resolves star exports by importing the named
+module and reading `__all__` (or its public names), does proper per-scope binding
+collection with a forward pass so global references defined later still resolve,
+skips annotation subtrees (the repo uses `from __future__ import annotations`, so
+annotations are strings and never raise), and reports every load of a name that
+cannot resolve at runtime. It fails safe: if a star-import source cannot be
+imported, that module's reports are suppressed rather than guessed at.
+
+Usage: python scripts/check_undefined_names.py [<pkg_dir> ...]   (default: ui celerp scripts)
+Exit 1 if any undefined load is found.
+"""
+
+from __future__ import annotations
+
+import ast
+import builtins
+import importlib
+import sys
+from pathlib import Path
+
+BUILTINS = set(dir(builtins)) | {
+    "__file__", "__name__", "__doc__", "__package__", "__spec__",
+    "__loader__", "__builtins__", "__annotations__", "__dict__", "__class__",
+}
+
+DEFAULT_ROOTS = ["ui", "celerp", "scripts"]
+
+
+def star_exports(module_name: str) -> set[str]:
+    """Names `from module import *` would bind. Best-effort: import the module."""
+    try:
+        mod = importlib.import_module(module_name)
+    except Exception:
+        return set()
+    if hasattr(mod, "__all__"):
+        return set(mod.__all__)
+    return {n for n in dir(mod) if not n.startswith("_")}
+
+
+class Scope:
+    def __init__(self, parent, kind):
+        self.parent = parent      # lexical parent Scope or None
+        self.kind = kind          # 'module' | 'function' | 'class' | 'comp'
+        self.names: set[str] = set()
+        self.star = False         # saw an `import *` whose source could not resolve
+
+
+class ScopeBuilder(ast.NodeVisitor):
+    """Pass 1: collect the names bound in a scope, without descending into child
+    function/class/comprehension scopes (each gets its own build)."""
+
+    def __init__(self, scope: Scope):
+        self.scope = scope
+
+    def visit_FunctionDef(self, node):
+        self.scope.names.add(node.name)
+
+    visit_AsyncFunctionDef = visit_FunctionDef
+
+    def visit_ClassDef(self, node):
+        self.scope.names.add(node.name)
+
+    def visit_Lambda(self, node):
+        pass
+
+    def visit_ListComp(self, node): pass
+    def visit_SetComp(self, node): pass
+    def visit_DictComp(self, node): pass
+    def visit_GeneratorExp(self, node): pass
+
+    def visit_Name(self, node):
+        if isinstance(node.ctx, ast.Store):
+            self.scope.names.add(node.id)
+
+    def visit_Global(self, node):
+        for n in node.names:
+            self.scope.names.add(n)
+
+    def visit_Nonlocal(self, node):
+        for n in node.names:
+            self.scope.names.add(n)
+
+    def visit_Import(self, node):
+        for a in node.names:
+            self.scope.names.add((a.asname or a.name).split(".")[0])
+
+    def visit_ImportFrom(self, node):
+        for a in node.names:
+            if a.name == "*":
+                exports = star_exports(node.module or "")
+                if exports:
+                    self.scope.names |= exports
+                else:
+                    self.scope.star = True
+            else:
+                self.scope.names.add(a.asname or a.name)
+
+    def visit_ExceptHandler(self, node):
+        if node.name:
+            self.scope.names.add(node.name)
+        self.generic_visit(node)
+
+    def visit_MatchAs(self, node):
+        if node.name:
+            self.scope.names.add(node.name)
+        self.generic_visit(node)
+
+    def visit_MatchStar(self, node):
+        if node.name:
+            self.scope.names.add(node.name)
+        self.generic_visit(node)
+
+    def visit_MatchMapping(self, node):
+        if node.rest:
+            self.scope.names.add(node.rest)
+        self.generic_visit(node)
+
+
+def build_scope_names(body_nodes, scope: Scope):
+    b = ScopeBuilder(scope)
+    for n in body_nodes:
+        b.visit(n)
+
+
+class Checker:
+    def __init__(self, path: Path):
+        self.path = path
+        self.errors: list[tuple[int, str]] = []
+
+    def resolve(self, name: str, scope: Scope) -> bool:
+        s = scope
+        saw_star = False
+        while s is not None:
+            if s.star:
+                saw_star = True
+            if name in s.names:
+                return True
+            s = s.parent
+        return name in BUILTINS or saw_star
+
+    def check_body(self, body, scope: Scope):
+        build_scope_names(body, scope)
+        for stmt in body:
+            self.visit(stmt, scope)
+
+    def visit(self, node, scope: Scope):
+        # Annotation subtrees are strings under `from __future__ import
+        # annotations` and never raise NameError, so skip them.
+        if isinstance(node, ast.AnnAssign):
+            if node.value is not None:
+                self.visit(node.value, scope)
+            self.visit(node.target, scope)
+            return
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            self._visit_function(node, scope)
+            return
+        if isinstance(node, ast.ClassDef):
+            self._visit_class(node, scope)
+            return
+        if isinstance(node, ast.Lambda):
+            self._visit_lambda(node, scope)
+            return
+        if isinstance(node, (ast.ListComp, ast.SetComp, ast.GeneratorExp, ast.DictComp)):
+            self._visit_comp(node, scope)
+            return
+        if isinstance(node, ast.Name):
+            if isinstance(node.ctx, ast.Load) and not self.resolve(node.id, scope):
+                self.errors.append((node.lineno, node.id))
+            return
+        for child in ast.iter_child_nodes(node):
+            self.visit(child, scope)
+
+    def _visit_function(self, node, scope):
+        # Defaults and decorators evaluate in the enclosing scope.
+        for d in node.decorator_list:
+            self.visit(d, scope)
+        for d in (node.args.defaults + [x for x in node.args.kw_defaults if x]):
+            self.visit(d, scope)
+        fscope = Scope(scope, "function")
+        a = node.args
+        for arg in (a.posonlyargs + a.args + a.kwonlyargs):
+            fscope.names.add(arg.arg)
+        if a.vararg:
+            fscope.names.add(a.vararg.arg)
+        if a.kwarg:
+            fscope.names.add(a.kwarg.arg)
+        self.check_body(node.body, fscope)
+
+    def _visit_lambda(self, node, scope):
+        for d in (node.args.defaults + [x for x in node.args.kw_defaults if x]):
+            self.visit(d, scope)
+        lscope = Scope(scope, "function")
+        a = node.args
+        for arg in (a.posonlyargs + a.args + a.kwonlyargs):
+            lscope.names.add(arg.arg)
+        if a.vararg:
+            lscope.names.add(a.vararg.arg)
+        if a.kwarg:
+            lscope.names.add(a.kwarg.arg)
+        self.visit(node.body, lscope)
+
+    def _visit_class(self, node, scope):
+        for d in node.decorator_list:
+            self.visit(d, scope)
+        for b in node.bases:
+            self.visit(b, scope)
+        for k in node.keywords:
+            self.visit(k.value, scope)
+        cscope = Scope(scope, "class")
+        self.check_body(node.body, cscope)
+
+    def _visit_comp(self, node, scope):
+        cscope = Scope(scope, "comp")
+        for gen in node.generators:
+            for n in ast.walk(gen.target):
+                if isinstance(n, ast.Name) and isinstance(n.ctx, ast.Store):
+                    cscope.names.add(n.id)
+        for i, gen in enumerate(node.generators):
+            # The first iterable evaluates in the enclosing scope.
+            self.visit(gen.iter, scope if i == 0 else cscope)
+            for cond in gen.ifs:
+                self.visit(cond, cscope)
+        if isinstance(node, ast.DictComp):
+            self.visit(node.key, cscope)
+            self.visit(node.value, cscope)
+        else:
+            self.visit(node.elt, cscope)
+
+
+def find_undefined(roots) -> list[tuple[Path, int, str]]:
+    """Return (path, lineno, name) for every undefined load under the given roots."""
+    findings: list[tuple[Path, int, str]] = []
+    for d in roots:
+        root = Path(d).resolve()
+        for path in sorted(root.rglob("*.py")):
+            src = path.read_text(encoding="utf-8")
+            try:
+                tree = ast.parse(src, filename=str(path))
+            except SyntaxError as e:
+                findings.append((path, getattr(e, "lineno", 0) or 0, f"SYNTAX ERROR {e}"))
+                continue
+            mscope = Scope(None, "module")
+            mscope.names |= {"__file__", "__name__", "__doc__", "__package__",
+                             "__spec__", "__loader__", "__builtins__"}
+            c = Checker(path)
+            c.check_body(tree.body, mscope)
+            for lineno, name in c.errors:
+                findings.append((path, lineno, name))
+    return findings
+
+
+def main(argv) -> int:
+    roots = argv or DEFAULT_ROOTS
+    findings = find_undefined(roots)
+    for path, lineno, name in findings:
+        print(f"{path}:{lineno}: undefined name '{name}'")
+    print(f"\n== {len(findings)} undefined-name load(s) found ==")
+    return 1 if findings else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/tests/test_check_undefined_names.py
+++ b/tests/test_check_undefined_names.py
@@ -1,0 +1,129 @@
+# Copyright (c) 2026 Noah Severs
+# SPDX-License-Identifier: LicenseRef-Proprietary
+
+"""Unit tests for the undefined-name checker's scope model.
+
+These pin the semantics directly, so the guard cannot silently regress into
+missing real NameErrors (a false negative here would let another
+undefined-reference bug merge while the repo-wide guard reports clean).
+"""
+
+import importlib.util
+from pathlib import Path
+
+_CHECKER_PATH = Path(__file__).resolve().parent.parent / "scripts" / "check_undefined_names.py"
+_spec = importlib.util.spec_from_file_location("check_undefined_names", _CHECKER_PATH)
+_checker = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_checker)
+
+
+def _names(src: str) -> set[str]:
+    return {name for _lineno, name in _checker.check_source(src)}
+
+
+# --- must REPORT (real NameErrors) ---
+
+def test_class_attr_not_visible_in_method() -> None:
+    src = (
+        "class C:\n"
+        "    x = 1\n"
+        "    def f(self):\n"
+        "        return x\n"
+    )
+    assert "x" in _names(src)
+
+
+def test_unassigned_global_is_reported() -> None:
+    src = (
+        "def f():\n"
+        "    global missing\n"
+        "    return missing\n"
+    )
+    assert "missing" in _names(src)
+
+
+def test_global_shadowed_by_enclosing_function_still_reported() -> None:
+    src = (
+        "def outer():\n"
+        "    X = 1\n"
+        "    def inner():\n"
+        "        global X\n"
+        "        return X\n"
+    )
+    assert "X" in _names(src)
+
+
+def test_bare_undefined_name_is_reported() -> None:
+    assert "nope" in _names("def f():\n    return nope\n")
+
+
+# --- must NOT report (valid Python) ---
+
+def test_class_attr_via_self_is_fine() -> None:
+    src = (
+        "class C:\n"
+        "    x = 1\n"
+        "    def f(self):\n"
+        "        return self.x\n"
+    )
+    assert not _names(src)
+
+
+def test_class_body_sees_its_own_names() -> None:
+    src = (
+        "class C:\n"
+        "    x = 1\n"
+        "    y = x + 1\n"
+    )
+    assert not _names(src)
+
+
+def test_assigned_global_resolves() -> None:
+    src = (
+        "def setter():\n"
+        "    global CONF\n"
+        "    CONF = 1\n"
+        "def getter():\n"
+        "    global CONF\n"
+        "    return CONF\n"
+    )
+    assert not _names(src)
+
+
+def test_module_global_visible_via_global_decl() -> None:
+    src = (
+        "TOP = 1\n"
+        "def f():\n"
+        "    global TOP\n"
+        "    return TOP\n"
+    )
+    assert not _names(src)
+
+
+def test_nonlocal_binding_resolves() -> None:
+    src = (
+        "def outer():\n"
+        "    v = 1\n"
+        "    def inner():\n"
+        "        nonlocal v\n"
+        "        return v\n"
+    )
+    assert not _names(src)
+
+
+def test_closure_over_enclosing_function_var() -> None:
+    src = (
+        "def outer():\n"
+        "    v = 1\n"
+        "    def inner():\n"
+        "        return v\n"
+    )
+    assert not _names(src)
+
+
+def test_comprehension_target_resolves() -> None:
+    assert not _names("def f(xs):\n    return [i for i in xs]\n")
+
+
+def test_builtins_resolve() -> None:
+    assert not _names("def f(xs):\n    return len(list(xs))\n")

--- a/tests/test_no_undefined_names.py
+++ b/tests/test_no_undefined_names.py
@@ -1,0 +1,31 @@
+# Copyright (c) 2026 Noah Severs
+# SPDX-License-Identifier: LicenseRef-Proprietary
+
+"""Guard against undefined names (NameError at runtime) that the linters miss.
+
+Every UI route and component does `from fasthtml.common import *`, which disables
+pyflakes/ruff F821 undefined-name reporting for that whole layer. Issue 284 (a
+route referencing a constant that did not exist) shipped through that blind spot.
+This test runs the star-import-aware checker over ui/, celerp/, and scripts/ and
+fails on any undefined load, so the class cannot regress.
+"""
+
+import importlib.util
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_CHECKER_PATH = _REPO_ROOT / "scripts" / "check_undefined_names.py"
+
+_spec = importlib.util.spec_from_file_location("check_undefined_names", _CHECKER_PATH)
+_checker = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_checker)
+
+
+def test_no_undefined_names_in_repo() -> None:
+    roots = [str(_REPO_ROOT / pkg) for pkg in ("ui", "celerp", "scripts")]
+    findings = _checker.find_undefined(roots)
+    detail = "\n".join(
+        f"{path.relative_to(_REPO_ROOT)}:{lineno}: undefined name '{name}'"
+        for path, lineno, name in findings
+    )
+    assert not findings, f"undefined names found:\n{detail}"

--- a/tests/test_reconciliation_forms.py
+++ b/tests/test_reconciliation_forms.py
@@ -1,0 +1,37 @@
+# Copyright (c) 2026 Noah Severs
+# SPDX-License-Identifier: LicenseRef-Proprietary
+
+"""Reconciliation inline create/split forms render without error.
+
+Regression guard for the reconcile create/split partials raising a NameError
+on an undefined party-search-URL constant (GitHub issue 284): the forms 500'd
+the moment a user opened Create or Split on an imported statement line.
+"""
+
+from html import escape
+
+from fasthtml.common import to_xml
+
+from ui.components.table import PARTY_SEARCH_URL
+from ui.routes.reconciliation import _create_form, _split_form
+
+_LINE = {"id": "line-1", "amount": -42.5, "description": "Office supplies"}
+_CHART = [
+    {"code": "5000", "name": "Expenses", "account_type": "expense"},
+    {"code": "1000", "name": "Cash", "account_type": "asset"},
+]
+_CONTACTS = [{"id": "c1", "name": "Acme Ltd"}]
+
+
+def _render(builder):
+    return to_xml(builder("sess-1", "line-1", _LINE, _CHART, "USD", _CONTACTS))
+
+
+def test_create_form_renders_with_party_search_url():
+    html = _render(_create_form)
+    assert escape(PARTY_SEARCH_URL) in html
+
+
+def test_split_form_renders_with_party_search_url():
+    html = _render(_split_form)
+    assert escape(PARTY_SEARCH_URL) in html

--- a/tests/test_worker_config_isolation.py
+++ b/tests/test_worker_config_isolation.py
@@ -1,0 +1,62 @@
+# Copyright (c) 2026 Noah Severs
+# SPDX-License-Identifier: LicenseRef-Proprietary
+"""Regression tests for per-xdist-worker config isolation (conftest_support).
+
+The bug: xdist workers inherit the controller process's environment, where the
+root conftest already set CELERP_CONFIG to the controller's ("main") temp path.
+The old conftest used os.environ.setdefault, so that inherited value stuck and
+EVERY worker read/wrote the SAME config.toml. Under -n auto two workers then
+corrupted the file mid-write, and a torn read raised tomllib.TOMLDecodeError,
+500ing unrelated requests (observed as flaky apply-preset failures on CI shard 6).
+
+resolve_worker_config recomputes the path per worker whenever the inherited value
+is one of our own temp paths, so two workers can never collide.
+"""
+from __future__ import annotations
+
+from conftest_support import is_own_test_config, resolve_worker_config
+
+_TMP = "/tmp"
+
+
+def _own(worker: str) -> str:
+    return f"{_TMP}/celerp-test-config-{worker}.toml"
+
+
+class TestResolveWorkerConfig:
+    def test_inherited_main_path_is_recomputed_for_the_worker(self):
+        # The exact bug scenario: the worker inherits the controller's "main" path.
+        # It must NOT keep it (that is what shared the file); it takes its own.
+        assert resolve_worker_config(_own("main"), "gw1", _TMP) == _own("gw1")
+
+    def test_two_workers_never_share_a_file(self):
+        inherited = _own("main")
+        p0 = resolve_worker_config(inherited, "gw0", _TMP)
+        p1 = resolve_worker_config(inherited, "gw1", _TMP)
+        assert p0 != p1
+        assert p0 == _own("gw0")
+        assert p1 == _own("gw1")
+
+    def test_unset_env_gets_per_worker_path(self):
+        assert resolve_worker_config(None, "gw3", _TMP) == _own("gw3")
+
+    def test_external_config_is_left_untouched(self):
+        external = "/etc/celerp/config.toml"
+        assert resolve_worker_config(external, "gw0", _TMP) == external
+
+    def test_main_controller_resolves_to_its_own_path(self):
+        assert resolve_worker_config(None, "main", _TMP) == _own("main")
+
+
+class TestIsOwnTestConfig:
+    def test_none_is_not_ours(self):
+        assert is_own_test_config(None, _TMP) is False
+
+    def test_our_temp_path_is_ours(self):
+        assert is_own_test_config(_own("gw0"), _TMP) is True
+
+    def test_external_path_is_not_ours(self):
+        assert is_own_test_config("/etc/celerp/config.toml", _TMP) is False
+
+    def test_wrong_prefix_in_tmp_is_not_ours(self):
+        assert is_own_test_config(f"{_TMP}/some-other-file.toml", _TMP) is False

--- a/ui/routes/reconciliation.py
+++ b/ui/routes/reconciliation.py
@@ -204,7 +204,7 @@ def _create_form(session_id: str, line_id: str, line: dict, chart: list[dict], c
             Div(
                 Label(t("acct.je_line_party"), cls="form-label"),
                 searchable_select("contact", contact_opts, placeholder=t("acct.je_line_party"),
-                                  cls_extra="form-input", search_url=_PARTY_SEARCH_URL),
+                                  cls_extra="form-input", search_url=PARTY_SEARCH_URL),
                 cls="form-field",
             ),
             Div(
@@ -260,7 +260,7 @@ def _split_form(session_id: str, line_id: str, line: dict, chart: list[dict], cu
                               step="0.01", cls="form-input max-w-sm"),
                         searchable_select("contact_0", contact_opts,
                                           placeholder=t("acct.je_line_party"),
-                                          cls_extra="form-input", search_url=_PARTY_SEARCH_URL),
+                                          cls_extra="form-input", search_url=PARTY_SEARCH_URL),
                         Input(type="text", name="memo_0", placeholder="Memo", cls="form-input"),
                         cls="split-entry-row flex-row gap-sm mb-sm",
                     )

--- a/ui/routes/setup.py
+++ b/ui/routes/setup.py
@@ -208,8 +208,8 @@ def setup_routes(app):
                     settings = dict(raw.get("settings") or {})
                     settings["vertical"] = vertical
                     api._raise(await c.patch("/companies/me", json={"name": raw.get("name", ""), "settings": settings}))
-            except Exception:
-                pass
+            except Exception as exc:
+                logger.warning("storing vertical failed during setup wizard: %s", exc)
             # Re-seed demo items with vertical-aware examples now that vertical is set
             try:
                 async with api._client(token) as c:

--- a/ui/routes/setup.py
+++ b/ui/routes/setup.py
@@ -207,7 +207,7 @@ def setup_routes(app):
                     raw = api._raise(await c.get("/companies/me")).json()
                     settings = dict(raw.get("settings") or {})
                     settings["vertical"] = vertical
-                    await c.patch("/companies/me", json={"name": raw.get("name", ""), "settings": settings})
+                    api._raise(await c.patch("/companies/me", json={"name": raw.get("name", ""), "settings": settings}))
             except Exception:
                 pass
             # Re-seed demo items with vertical-aware examples now that vertical is set

--- a/ui/routes/setup.py
+++ b/ui/routes/setup.py
@@ -204,7 +204,7 @@ def setup_routes(app):
             # Store the vertical name in company settings so the dashboard can use it
             try:
                 async with api._client(token) as c:
-                    raw = _raise(await c.get("/companies/me")).json()
+                    raw = api._raise(await c.get("/companies/me")).json()
                     settings = dict(raw.get("settings") or {})
                     settings["vertical"] = vertical
                     await c.patch("/companies/me", json={"name": raw.get("name", ""), "settings": settings})


### PR DESCRIPTION
Fixes three errors caused by references to names that did not exist:

- Opening the Create match or Split form on a reconciliation statement line no longer errors and the form now loads. Closes #284.
- Invoices and quotes that carry more than one tax on a line now export to PDF instead of failing.
- The setup wizard now saves the industry you pick, so the dashboard reflects it.

A static check over the UI, backend, and scripts packages now runs in the test suite and fails on any undefined name, which the standard linters miss for modules using wildcard imports.