### PR TITLE
Show sold prices in sold inventory, catalog links on finalized lines, and fix frozen header alignment

### DIFF
--- a/celerp/services/holdings.py
+++ b/celerp/services/holdings.py
@@ -117,3 +117,56 @@ def consignment_holdings(
             cost = (unit * (_num(state.get("quantity")) or 0.0)) if unit is not None else 0.0
         out[item_id] = round(cost, 2)
     return out
+
+
+def sold_prices(
+    items: Iterable[tuple[str, dict]],
+    sold_docs: Iterable[tuple[str, dict]],
+) -> dict[str, float | None]:
+    """Map item_id -> realized per-unit sale price for sold items.
+
+    ``items``: (entity_id, state) for the sold items to price.
+    ``sold_docs``: (entity_id, state) for the documents that sold them.
+
+    The price is read from the line of the document that sold the item
+    (its ``status_doc_id``). The line is matched by its item reference where the doc
+    carries one (imported docs, per-line fulfillment), else by SKU (engine-fulfilled
+    invoices created from a SKU carry no item reference on the line, only the sku the
+    item still holds). The value is the line's ``unit_price`` (per sell-unit,
+    post-discount); when only a ``line_total`` is stored it is divided by the line
+    quantity to a per-unit figure. Returns None for an item whose selling line or
+    price cannot be resolved, so the view shows an honest ``--`` rather than a
+    fabricated 0.
+    """
+    line_by_ref: dict[tuple[str, str], dict] = {}
+    line_by_sku: dict[tuple[str, str], dict] = {}
+    for doc_id, state in sold_docs:
+        for line in (state or {}).get("line_items", []) or []:
+            key = str(doc_id)
+            eid = line.get("entity_id") or line.get("item_id")
+            if eid:
+                line_by_ref[(key, eid)] = line
+            sku = str(line.get("sku") or "").strip()
+            if sku:
+                line_by_sku.setdefault((key, sku), line)  # first priced line for the sku
+
+    out: dict[str, float | None] = {}
+    for item_id, state in items:
+        state = state or {}
+        doc_id = state.get("status_doc_id")
+        if not doc_id:
+            out[item_id] = None
+            continue
+        line = line_by_ref.get((str(doc_id), item_id))
+        if line is None:
+            sku = str(state.get("sku") or "").strip()
+            line = line_by_sku.get((str(doc_id), sku)) if sku else None
+        if line is None:
+            out[item_id] = None
+            continue
+        unit = _num(line.get("unit_price"))
+        if unit is None:
+            total, qty = _num(line.get("line_total")), _num(line.get("quantity"))
+            unit = (total / qty) if (total is not None and qty) else None
+        out[item_id] = round(unit, 2) if unit is not None else None
+    return out

--- a/celerp/services/holdings.py
+++ b/celerp/services/holdings.py
@@ -1,8 +1,8 @@
 # Copyright (c) 2026 Noah Severs
 # SPDX-License-Identifier: BUSL-1.1
-"""Contact-scoped consignment / memo holdings.
+"""Contact-scoped consignment / memo holdings and realized sale prices.
 
-Two mirror-image questions, answered as pure reads over existing projection state
+Three mirror-image questions, answered as pure reads over existing projection state
 (no new columns, no migration):
 
 - What is currently out on memo TO a customer? Items with status ``memo_out`` whose
@@ -12,8 +12,10 @@ Two mirror-image questions, answered as pure reads over existing projection stat
 - What do we currently hold on consignment FROM a supplier? Items with
   ``consignment_flag == "in"`` created by one of that supplier's ``consignment_in``
   docs (tracked on the doc as ``received_item_ids``). Valued at cost.
+- What did a sold item actually sell for? The per-unit price on its selling
+  document's line, matched by item reference or SKU (``sold_prices``).
 
-Both functions are pure over already-loaded rows so the inventory endpoint can share
+Every function is pure over already-loaded rows so the inventory endpoint can share
 one item scan, and so the membership predicate is unit-testable in isolation. The
 value each returns is exactly what the list endpoint should display and total for the
 scoped view, so the card total and the list reconcile by construction.
@@ -21,7 +23,24 @@ scoped view, so the card total and the list reconcile by construction.
 
 from __future__ import annotations
 
-from collections.abc import Iterable
+from collections.abc import Iterable, Iterator
+
+
+def _doc_lines(docs: Iterable[tuple[str, dict]]) -> Iterator[tuple[str, dict]]:
+    """Yield (doc_id, line) for every line item across the given docs' states."""
+    for doc_id, state in docs:
+        for line in (state or {}).get("line_items", []) or []:
+            yield str(doc_id), line
+
+
+def _lines_by_ref(docs: Iterable[tuple[str, dict]]) -> dict[tuple[str, str], dict]:
+    """(doc_id, item-ref) -> line, for every doc line carrying an item reference."""
+    out: dict[tuple[str, str], dict] = {}
+    for doc_id, line in _doc_lines(docs):
+        eid = line.get("entity_id") or line.get("item_id")
+        if eid:
+            out[(doc_id, eid)] = line
+    return out
 
 
 def _num(value: object) -> float | None:
@@ -55,12 +74,7 @@ def memo_holdings(
     doc_ids = {doc_id for doc_id, _ in memo_docs}
     # (doc_id, item_id) -> line, so an item that was on memo to A, returned, then
     # re-sent to B resolves against the doc that is actually in fulfilled_for_docs.
-    line_by: dict[tuple[str, str], dict] = {}
-    for doc_id, state in memo_docs:
-        for line in (state or {}).get("line_items", []) or []:
-            eid = line.get("entity_id") or line.get("item_id")
-            if eid:
-                line_by[(doc_id, eid)] = line
+    line_by = _lines_by_ref(memo_docs)
 
     out: dict[str, float] = {}
     for item_id, state in items:
@@ -138,17 +152,13 @@ def sold_prices(
     price cannot be resolved, so the view shows an honest ``--`` rather than a
     fabricated 0.
     """
-    line_by_ref: dict[tuple[str, str], dict] = {}
+    sold_docs = list(sold_docs)
+    line_by_ref = _lines_by_ref(sold_docs)
     line_by_sku: dict[tuple[str, str], dict] = {}
-    for doc_id, state in sold_docs:
-        for line in (state or {}).get("line_items", []) or []:
-            key = str(doc_id)
-            eid = line.get("entity_id") or line.get("item_id")
-            if eid:
-                line_by_ref[(key, eid)] = line
-            sku = str(line.get("sku") or "").strip()
-            if sku:
-                line_by_sku.setdefault((key, sku), line)  # first priced line for the sku
+    for doc_id, line in _doc_lines(sold_docs):
+        sku = str(line.get("sku") or "").strip()
+        if sku:
+            line_by_sku.setdefault((doc_id, sku), line)  # first line for the sku wins
 
     out: dict[str, float | None] = {}
     for item_id, state in items:

--- a/default_modules/celerp-inventory/celerp_inventory/routes.py
+++ b/default_modules/celerp-inventory/celerp_inventory/routes.py
@@ -647,6 +647,34 @@ async def list_items(
         )
         result = [r for r in result if r.get("id") in scope_value]
 
+    # Sold price: when the sold view is active, price each sold item from the line of
+    # the document that sold it (status_doc_id). A realized sale price is not a cost, so
+    # (like the memo value below) it is not gated by view_inventory_costs. Computed here
+    # over the loaded rows; attached to the result dicts after visibility rebuild.
+    sold_scoped = "sold" in (status_set or {str(status).lower()} if status else set())
+    sold_price: dict[str, float | None] = {}
+    if sold_scoped:
+        from celerp.services.holdings import sold_prices
+        sold_rows = [r for r in rows if str((r.state or {}).get("status") or "").lower() == "sold"]
+        sold_doc_ids = {
+            str((r.state or {}).get("status_doc_id"))
+            for r in sold_rows if (r.state or {}).get("status_doc_id")
+        }
+        if sold_doc_ids:
+            sold_docs = (
+                await session.execute(
+                    select(Projection).where(
+                        Projection.company_id == company_id,
+                        Projection.entity_type == "doc",
+                        Projection.entity_id.in_(sold_doc_ids),
+                    )
+                )
+            ).scalars().all()
+            sold_price = sold_prices(
+                [(r.entity_id, r.state) for r in sold_rows],
+                [(d.entity_id, d.state) for d in sold_docs],
+            )
+
     if category:
         cats = {c.strip() for c in category.split(",") if c.strip()}
         result = [r for r in result if str(r.get("category") or "") in cats]
@@ -742,6 +770,12 @@ async def list_items(
     if holding_scoped:
         for r in result:
             r["holding_value"] = None if gate_cost else scope_value.get(r.get("id"), 0.0)
+
+    # Attach the realized sale price to each sold row (ungated: a sale price is not a cost).
+    if sold_scoped:
+        for r in result:
+            if str(r.get("status") or "").lower() == "sold":
+                r["sold_price"] = sold_price.get(r.get("id"))
 
     # FEFO: when company uses fefo, sort available items by expires_at ascending (soonest first)
     # so staff always see the items that need to be picked/sold first at the top.

--- a/default_modules/first_party.lock.json
+++ b/default_modules/first_party.lock.json
@@ -7,7 +7,7 @@
   "celerp-contacts": "899cf9febb388356290f6eb8c8ab6d67f1f92a9c9fa8377ebb6d46bf04cedbc3",
   "celerp-dashboard": "00d2e8d6ef46a3afd5d6caf8434217095aabd40c963bfac19d0e988c714443ce",
   "celerp-docs": "8b69661d972454099f94fd0f22d0d3ce614bbc6a257effb776fdb12462a56b7b",
-  "celerp-inventory": "0d3b85ddb73ce02a2a97a5e00827435e145bddaae79491a7ad6b7ade88f38c06",
+  "celerp-inventory": "8d38a88e3fd38d4eecaee27c78051cc88af2c9c1f6a8f38fd24d313110756f35",
   "celerp-labels": "1175c234602fbc80e20a33a4d03bf7abcc9a7a78d6e83729c73106cb0af53832",
   "celerp-manufacturing": "5cc089a345eeff66be25db51432481487e699f28c0a545731650843fce81dc01",
   "celerp-reports": "f100f83b3fc3e4565685d3a0c8e62dcc724bb35d32238f051b05c5f97ae10d13",

--- a/tests/test_browser/test_sold_price_column.py
+++ b/tests/test_browser/test_sold_price_column.py
@@ -1,0 +1,81 @@
+# Copyright (c) 2026 Noah Severs. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-Proprietary
+"""Browser check for the sold-inventory 'Sold' per-unit price column.
+
+Seeds real sold items (item -> finalized invoice -> fulfill-lines), then loads
+the sold inventory view and asserts the realized per-unit sale price is shown
+in a read-only 'Sold' column beside the catalog price columns. A screenshot is
+captured for visual review.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+pytestmark = pytest.mark.browser
+
+# A review screenshot is written only when SOLD_PRICE_SHOT_DIR is set; the DOM
+# assertions below are the durable test value and always run.
+_OUT = os.environ.get("SOLD_PRICE_SHOT_DIR")
+
+
+def _sell_item(api, sku, unit_price, qty=1, sell_by="carat"):
+    """Create an item and sell it via a finalized invoice; return its entity_id."""
+    r = api.post("/items", json={"status": "available", "sku": sku, "name": sku,
+                                 "quantity": qty, "sell_by": sell_by})
+    assert r.status_code in {200, 201}, f"create item failed: {r.text}"
+    item_id = r.json()["id"]
+    r = api.post("/docs", json={
+        "doc_type": "invoice",
+        "ref_id": f"SOLD-{uuid.uuid4().hex[:6]}",
+        "status": "draft",
+        "line_items": [{"sku": sku, "name": sku, "quantity": qty, "unit_price": unit_price,
+                        "line_total": unit_price * qty, "entity_id": item_id}],
+        "total": unit_price * qty,
+        "amount_outstanding": unit_price * qty,
+    })
+    assert r.status_code in {200, 201}, f"create doc failed: {r.text}"
+    doc_id = r.json()["id"]
+    assert api.post(f"/docs/{doc_id}/finalize").status_code in {200, 201}
+    r = api.post(f"/docs/{doc_id}/fulfill-lines", json={"line_entity_ids": [item_id]})
+    assert r.status_code in {200, 201}, f"fulfil failed: {r.text}"
+    assert api.get(f"/items/{item_id}").json()["status"] == "sold"
+    return item_id
+
+
+def test_sold_view_shows_realized_price_column(page, ui_server, api):
+    sku_a = f"SP-A-{uuid.uuid4().hex[:5]}"
+    sku_b = f"SP-B-{uuid.uuid4().hex[:5]}"
+    _sell_item(api, sku_a, unit_price=1250.0)
+    _sell_item(api, sku_b, unit_price=89.96)
+
+    # Wide enough that every column (including the trailing Sold column) is in view
+    # for the review screenshot; the assertions below query the DOM regardless.
+    page.set_viewport_size({"width": 2400, "height": 900})
+    page.goto(f"{ui_server}/inventory?status=sold", wait_until="domcontentloaded")
+    body = page.locator("body").inner_text()
+    assert "Internal Server Error" not in body and "Traceback" not in body
+
+    # The synthetic read-only money column is headed "Sold" (with the shared
+    # "(Unit Price)" annotation the other money headers carry).
+    header = page.locator('th[data-col="sold_price"], th:has-text("Sold")')
+    assert header.count() > 0, "sold-price column header missing from sold view"
+
+    # Realized per-unit prices render in read-only sold_price cells (never clickable).
+    cells = page.locator('td[data-col="sold_price"]')
+    assert cells.count() > 0, "no sold_price cells rendered"
+    texts = " ".join((cells.nth(i).inner_text() or "") for i in range(cells.count()))
+    assert "1,250" in texts, f"expected 1,250.00 in sold cells, got: {texts!r}"
+    assert "89.96" in texts, f"expected 89.96 in sold cells, got: {texts!r}"
+    # Read-only: no click-to-edit affordance on the sold price cell.
+    assert page.locator('td[data-col="sold_price"].cell--clickable').count() == 0, \
+        "sold_price cell must be read-only (no cell--clickable)"
+
+    if _OUT:
+        os.makedirs(_OUT, exist_ok=True)
+        shot = os.path.join(_OUT, "sold-price-column.png")
+        cells.first.scroll_into_view_if_needed()
+        page.screenshot(path=shot, full_page=True)
+        print(f"SOLD_PRICE_SCREENSHOT={shot}")

--- a/tests/test_browser/test_sticky_header.py
+++ b/tests/test_browser/test_sticky_header.py
@@ -581,3 +581,48 @@ def test_resize_while_pinned_persists(page, ui_server, sticky_inventory):
     assert stored_px > before + 150, (
         f"persisted width for '{key}' lost the drag: stored {stored_px:.0f}px, pre-drag {before:.0f}px"
     )
+
+
+# ── hidden columns: the pinned body must keep every visible column under its header ────────
+def test_pinned_columns_align_with_hidden_column_after_sideways_scroll(page, ui_server, sticky_inventory):
+    """Hide one column the way the column manager does (prefs in localStorage), scroll the
+    table sideways FIRST, then down until the header pins. Every visible column's body cells
+    must still sit under that column's header. The pin locks column geometry with a colgroup
+    built from the header row's cells; a hidden column's cell generates no box, so a col built
+    for it lands on the next visible column and every column after it drifts."""
+    _goto(page, ui_server)
+    keys = _data_keys(page)
+    assert len(keys) >= 4, f"need several columns to observe drift, got {keys}"
+    hidden = keys[1]
+    page.evaluate(
+        "(args) => { var p = {}; args.keys.forEach(function(k){ p[k] = k !== args.hidden; });"
+        " localStorage.setItem('celerp_cols_inventory', JSON.stringify(p)); }",
+        {"keys": keys, "hidden": hidden},
+    )
+    page.reload(wait_until="domcontentloaded")
+    page.wait_for_selector("#data-table thead th[data-key]", timeout=10000)
+    page.wait_for_function(
+        "(k) => { var th=document.querySelector('#data-table thead th[data-key=\"'+k+'\"]');"
+        " return !!th && th.style.display === 'none'; }",
+        arg=hidden, timeout=5000,
+    )
+
+    # Widen the first column so the table overflows its wrap, then scroll right BEFORE pinning.
+    page.evaluate(
+        "() => { var th=document.querySelector('#data-table thead th[data-key]'); if(th) th.style.width='900px'; }"
+    )
+    page.evaluate(
+        "() => { var w=document.querySelector('.table-scroll-wrap'); w.scrollLeft=300; w.dispatchEvent(new Event('scroll')); }"
+    )
+    _scroll_to_pin(page)
+    assert _pinned(page)
+
+    visible = [k for k in keys if k != hidden]
+    for key in visible:
+        lefts = _col_lefts(page, key)
+        if lefts is None:
+            continue  # column has no body cell rendered (never true for the seed rows)
+        assert abs(lefts[0] - lefts[1]) <= 2, (
+            f"column '{key}' drifted from its header while pinned with '{hidden}' hidden: "
+            f"header left {lefts[0]:.1f}px, body left {lefts[1]:.1f}px"
+        )

--- a/tests/test_browser/test_sticky_header.py
+++ b/tests/test_browser/test_sticky_header.py
@@ -315,6 +315,21 @@ def test_pinned_header_tracks_horizontal_scroll(page, ui_server, sticky_inventor
     assert lefts is not None and abs(lefts[0] - lefts[1]) <= 2
 
 
+def test_top_scroll_pinned_css_floors_width_before_js_sets_it(page, ui_server, sticky_inventory):
+    _goto(page, ui_server)
+    page.wait_for_selector(".table-top-scroll")
+    width = page.evaluate(
+        """() => {
+          var p = document.querySelector('.table-top-scroll');
+          p.classList.add('top-scroll-pinned');
+          var w = getComputedStyle(p).width;
+          p.classList.remove('top-scroll-pinned');
+          return w;
+        }"""
+    )
+    assert width == "0px", f"unsized .top-scroll-pinned resolved to {width}, not a safe 0px floor"
+
+
 # ── the frozen header stays clipped inside the table, never painting over the sidebar (#274) ──
 def test_pinned_header_never_overlaps_sidebar_when_scrolled_right(page, ui_server, sticky_inventory):
     _goto(page, ui_server)

--- a/tests/test_fulfillment.py
+++ b/tests/test_fulfillment.py
@@ -2388,3 +2388,53 @@ async def test_reserved_conflict_detail_structured(client, session, auth, _setup
                            json={"target_type": "invoice"})
     assert rc.status_code == 422, rc.text
     _check_detail(rc.json()["detail"])
+
+
+@pytest.mark.asyncio
+async def test_sold_view_attaches_realized_sale_price(client, session, auth, _setup_ids):
+    """A sold item listed under status=sold carries sold_price = its selling line's unit price.
+
+    Red statement: list_items does not attach a sold_price key, so the sold record
+    returned by GET /items?status=sold has no realized price to display
+    (celerp-inventory/routes.py list_items, pre-change).
+    """
+    from celerp.models.projections import Projection
+    from celerp.services.fulfill import execute_fulfill
+    from celerp.services.pick import compute_pick_plan
+
+    item_id = await _create_item(client, auth, "SOLDPX-A", 2, cost_price=4.0, sell_by="carat")
+    doc_id = await _create_and_finalize_invoice(
+        client, auth, [{"sku": "SOLDPX-A", "quantity": 2, "unit_price": 100.0}], ref_id="INV-SOLDPX-1")
+
+    doc_row = await session.get(Projection, {"company_id": _setup_ids["company_id"], "entity_id": doc_id})
+    inv_row = await session.get(Projection, {"company_id": _setup_ids["company_id"], "entity_id": item_id})
+    available_inv = [{
+        "entity_id": item_id, "sku": inv_row.state["sku"],
+        "quantity": float(inv_row.state["quantity"]),
+        "created_at": inv_row.created_at.isoformat() if inv_row.created_at else "",
+        "cost_total": float(inv_row.state.get("cost_total", 0)),
+    }]
+    pick_result = compute_pick_plan(doc_row.state.get("line_items", []), available_inv)
+    await execute_fulfill(
+        session, doc_entity_id=doc_id, doc_state=doc_row.state,
+        pick_result=pick_result, company_id=_setup_ids["company_id"],
+        user_id=str(_setup_ids["user_id"]),
+    )
+    await session.commit()
+
+    r = await client.get("/items", headers=auth["headers"], params={"status": "sold"})
+    assert r.status_code == 200, r.text
+    rows = {it["sku"]: it for it in r.json()["items"]}
+    assert "SOLDPX-A" in rows, "sold item missing from status=sold list"
+    assert rows["SOLDPX-A"]["sold_price"] == 100.0
+
+
+@pytest.mark.asyncio
+async def test_sold_price_absent_outside_sold_view(client, session, auth, _setup_ids):
+    """sold_price is computed only for the sold view, so an available item never carries it."""
+    await _create_item(client, auth, "SOLDPX-B", 5, cost_price=4.0, sell_by="carat")
+    r = await client.get("/items", headers=auth["headers"], params={"status": "available"})
+    assert r.status_code == 200, r.text
+    rows = {it["sku"]: it for it in r.json()["items"]}
+    assert "SOLDPX-B" in rows
+    assert "sold_price" not in rows["SOLDPX-B"]

--- a/tests/test_fulfillment.py
+++ b/tests/test_fulfillment.py
@@ -2428,10 +2428,7 @@ async def test_sold_view_attaches_realized_sale_price(client, session, auth, _se
     assert "SOLDPX-A" in rows, "sold item missing from status=sold list"
     assert rows["SOLDPX-A"]["sold_price"] == 100.0
 
-
-@pytest.mark.asyncio
-async def test_sold_price_absent_outside_sold_view(client, session, auth, _setup_ids):
-    """sold_price is computed only for the sold view, so an available item never carries it."""
+    # sold_price is computed only for the sold view: an available item never carries it.
     await _create_item(client, auth, "SOLDPX-B", 5, cost_price=4.0, sell_by="carat")
     r = await client.get("/items", headers=auth["headers"], params={"status": "available"})
     assert r.status_code == 200, r.text

--- a/tests/test_holdings.py
+++ b/tests/test_holdings.py
@@ -9,7 +9,7 @@ tests then layer the HTTP wiring on top.
 
 from __future__ import annotations
 
-from celerp.services.holdings import consignment_holdings, memo_holdings
+from celerp.services.holdings import consignment_holdings, memo_holdings, sold_prices
 
 
 # --- memo (consignment out to a customer) -----------------------------------
@@ -104,3 +104,44 @@ def test_consignment_excludes_item_from_a_different_supplier():
     items = [("item:1", {"consignment_flag": "in", "cost_total": 400.0})]
     docs = [("doc:C", {"received_item_ids": ["item:OTHER"]})]
     assert consignment_holdings(items, docs) == {}
+
+
+# --- sold price (realized per-unit sale price of a sold item) ----------------
+
+def test_sold_price_is_selling_line_unit_price():
+    items = [("item:1", {"status": "sold", "status_doc_id": "doc:A"})]
+    docs = [("doc:A", {"line_items": [{"item_id": "item:1", "unit_price": 89.96, "line_total": 206.0}]})]
+    assert sold_prices(items, docs) == {"item:1": 89.96}
+
+
+def test_sold_price_matches_line_by_item_id_when_entity_id_blank():
+    # Real docs carry the item reference on the line's item_id; entity_id is empty there.
+    items = [("item:1", {"status": "sold", "status_doc_id": "doc:A"})]
+    docs = [("doc:A", {"line_items": [{"entity_id": "", "item_id": "item:1", "unit_price": 50.0}]})]
+    assert sold_prices(items, docs) == {"item:1": 50.0}
+
+
+def test_sold_price_derives_per_unit_from_line_total_when_no_unit_price():
+    items = [("item:1", {"status": "sold", "status_doc_id": "doc:A"})]
+    docs = [("doc:A", {"line_items": [{"item_id": "item:1", "line_total": 206.0, "quantity": 2.0}]})]
+    assert sold_prices(items, docs) == {"item:1": 103.0}
+
+
+def test_sold_price_matches_line_by_sku_when_line_has_no_item_ref():
+    # Engine-fulfilled invoice: the line was created from a SKU and carries no item
+    # reference, so the match falls back to the item's own sku.
+    items = [("item:1", {"status": "sold", "status_doc_id": "doc:A", "sku": "GEM-1"})]
+    docs = [("doc:A", {"line_items": [{"sku": "GEM-1", "quantity": 2, "unit_price": 100.0}]})]
+    assert sold_prices(items, docs) == {"item:1": 100.0}
+
+
+def test_sold_price_is_none_when_selling_line_missing():
+    # Item marked sold but no matching line resolves (e.g. deleted doc): honest None, never 0.
+    items = [("item:1", {"status": "sold", "status_doc_id": "doc:A"})]
+    docs = [("doc:A", {"line_items": [{"item_id": "item:OTHER", "unit_price": 10.0}]})]
+    assert sold_prices(items, docs) == {"item:1": None}
+
+
+def test_sold_price_is_none_without_status_doc():
+    items = [("item:1", {"status": "sold"})]
+    assert sold_prices(items, []) == {"item:1": None}

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -1420,6 +1420,41 @@ class TestDocsPage:
         assert b"catalog-ac-list" in html, (
             "Draft doc must include catalog-ac-list dropdown container"
         )
+        # The catalog-link eye must render on draft lines too (shared helper).
+        assert b"item-link" in html, "Draft line must include the catalog-link eye"
+
+    @pytest.mark.asyncio
+    async def test_finalized_doc_line_has_catalog_link_eye(self, ui_client):
+        """The catalog-link eye must appear on lines of a FINALIZED doc, not only drafts.
+
+        A finalized (sent/paid) line coming from the catalog shows the active eye
+        linking to /inventory/{id}; a line with no catalog item shows the inert
+        placeholder. Same affordance in every document state (GDR 2h uniformity).
+        """
+        final_doc = {
+            **_DOCS[0],  # status "sent" -> non-editable, finalized render path
+            "line_items": [
+                {"description": "Ruby", "entity_id": "i:42", "quantity": 1,
+                 "unit_price": 100, "line_total": 100},
+                {"description": "Custom note", "quantity": 1,
+                 "unit_price": 5, "line_total": 5},
+            ],
+        }
+        with patch("ui.api_client.get_doc", new=AsyncMock(return_value=final_doc)):
+            r = await ui_client.get("/docs/d:1", cookies=_authed())
+        assert r.status_code == 200
+        html = r.content.decode()
+        # Catalog line: active eye linking to the item.
+        assert "item-link item-link--active" in html, (
+            "Finalized catalog line must show the active catalog-link eye"
+        )
+        assert "/inventory/i:42" in html, (
+            "Finalized catalog eye must link to /inventory/{entity_id}"
+        )
+        # Non-catalog line: inert placeholder eye, never a broken active link.
+        assert "item-link item-link--inactive" in html, (
+            "Finalized non-catalog line must show the inert placeholder eye"
+        )
 
     @pytest.mark.asyncio
     async def test_docs_type_filter(self, ui_client):

--- a/tests/test_unit_type.py
+++ b/tests/test_unit_type.py
@@ -235,7 +235,9 @@ class TestInventoryCellRenderers:
             "key": "sold_price", "label": "Sold", "type": "money", "editable": False,
         }]
 
-    def test_sold_price_renderer_shows_value_with_unit_annotation(self):
+    def test_sold_price_renderer_value_with_unit_annotation_read_only(self):
+        # A realized sale price renders as a plain money cell with its sell-by
+        # annotation, and is derived, not editable: no click-to-edit affordance.
         from ui.routes.inventory import _inventory_cell_renderers
         renderers = _inventory_cell_renderers(self._schema_with_sold_price(), units_map=self._umap())
         assert "sold_price" in renderers
@@ -243,13 +245,6 @@ class TestInventoryCellRenderers:
         s = self._render_str(td)
         assert "89.96" in s
         assert "/ carat" in s
-
-    def test_sold_price_renderer_is_read_only(self):
-        # A realized sale price is derived, not editable: no click-to-edit affordance.
-        from ui.routes.inventory import _inventory_cell_renderers
-        renderers = _inventory_cell_renderers(self._schema_with_sold_price(), units_map=self._umap())
-        td = renderers["sold_price"]("item:1", {"sold_price": 50.0, "sell_by": "piece"})
-        s = self._render_str(td)
         assert "hx-get" not in s.lower()
         assert "dblclick" not in s.lower()
         assert "cell--clickable" not in s

--- a/tests/test_unit_type.py
+++ b/tests/test_unit_type.py
@@ -230,6 +230,38 @@ class TestInventoryCellRenderers:
         from fasthtml.common import to_xml
         return to_xml(td)
 
+    def _schema_with_sold_price(self):
+        return self._schema() + [{
+            "key": "sold_price", "label": "Sold", "type": "money", "editable": False,
+        }]
+
+    def test_sold_price_renderer_shows_value_with_unit_annotation(self):
+        from ui.routes.inventory import _inventory_cell_renderers
+        renderers = _inventory_cell_renderers(self._schema_with_sold_price(), units_map=self._umap())
+        assert "sold_price" in renderers
+        td = renderers["sold_price"]("item:1", {"sold_price": 89.96, "sell_by": "carat"})
+        s = self._render_str(td)
+        assert "89.96" in s
+        assert "/ carat" in s
+
+    def test_sold_price_renderer_is_read_only(self):
+        # A realized sale price is derived, not editable: no click-to-edit affordance.
+        from ui.routes.inventory import _inventory_cell_renderers
+        renderers = _inventory_cell_renderers(self._schema_with_sold_price(), units_map=self._umap())
+        td = renderers["sold_price"]("item:1", {"sold_price": 50.0, "sell_by": "piece"})
+        s = self._render_str(td)
+        assert "hx-get" not in s.lower()
+        assert "dblclick" not in s.lower()
+        assert "cell--clickable" not in s
+
+    def test_sold_price_renderer_none_shows_dash_no_annotation(self):
+        from ui.routes.inventory import _inventory_cell_renderers
+        renderers = _inventory_cell_renderers(self._schema_with_sold_price(), units_map=self._umap())
+        td = renderers["sold_price"]("item:1", {"sold_price": None, "sell_by": "carat"})
+        s = self._render_str(td)
+        assert "--" in s
+        assert "/ carat" not in s
+
     def test_weight_renderer_derived_for_weight_sell_by(self):
         from ui.routes.inventory import _inventory_cell_renderers
         schema = self._schema()

--- a/ui/components/shell.py
+++ b/ui/components/shell.py
@@ -1157,7 +1157,13 @@ _STICKY_HEADER_JS = """
     var thead = t.tHead; if(!thead || !thead.rows.length) return;
     // Idempotent: drop any stale artifacts before recapturing, so re-pinning never duplicates them.
     clearPinArtifacts(t);
-    var cells = thead.rows[0].cells;
+    // Visible cells only: the column manager hides a column by display:none on its th and tds,
+    // and hidden cells generate no boxes. colgroup cols map to RENDERED boxes positionally, so a
+    // col emitted for a hidden column would land on the next visible column and shift every
+    // column after it under the wrong header.
+    var allCells = thead.rows[0].cells, cells = [], ci;
+    for(ci=0;ci<allCells.length;ci++){ if(getComputedStyle(allCells[ci]).display !== 'none') cells.push(allCells[ci]); }
+    if(!cells.length) return;
     var widths = [], i;
     for(i=0;i<cells.length;i++) widths.push(cells[i].getBoundingClientRect().width);
     var theadH = thead.getBoundingClientRect().height;

--- a/ui/routes/documents.py
+++ b/ui/routes/documents.py
@@ -373,6 +373,22 @@ def _item_status_badge_cell(status_val: str, eid: str, status_doc: tuple[str, st
     return Td(Span("-", cls="muted"), cls="col-item-status")
 
 
+def _item_link_eye(entity_id: str, title: str = "View item details") -> FT:
+    """Eye glyph on a document line linking to its catalog item, in EVERY document state.
+    Active (accent, opens the catalog) when the line came from the catalog; a greyed,
+    inert placeholder otherwise, so the SKU column reads the same in the draft and
+    finalized views. One source of truth for both row builders (the editable SKU input
+    and the finalized SKU cell); the draft autocomplete JS re-points the same element
+    live as the user picks an item."""
+    active = bool(entity_id)
+    return A("👁", href=f"/inventory/{entity_id}" if active else "#",
+             target="_blank" if active else "",
+             cls="item-link item-link--active" if active else "item-link item-link--inactive",
+             data_name="item_link",
+             title=title if active else "No linked item",
+             onclick="" if active else "event.preventDefault();")
+
+
 _DOC_TYPE_PAGE_LABELS: dict[str, str] = {
     "invoice": "Invoices",
     "purchase_order": "Purchase Orders",
@@ -6231,12 +6247,7 @@ def _doc_detail(doc: dict, locations: list | None = None, ledger: list | None = 
     line_body_id = "line-body"
     if is_editable:
         def _sku_input(val: str = "", entity_id: str = "", barcode: str = "") -> FT:
-            eye_cls = "item-link item-link--active" if entity_id else "item-link item-link--inactive"
-            eye_href = f"/inventory/{entity_id}" if entity_id else "#"
-            eye = A("👁", href=eye_href, target="_blank" if entity_id else "",
-                     cls=eye_cls, data_name="item_link",
-                     title="View item details" if entity_id else "No linked item",
-                     onclick="" if entity_id else "event.preventDefault();")
+            eye = _item_link_eye(entity_id)
             # Barcode is stamped on every line (hidden input) regardless of the display
             # mode, so the stored data never depends on the company's identifier setting.
             # The visible line under the SKU input exists only when barcodes are shown.
@@ -7984,16 +7995,17 @@ async function celerpCsvImport(input, entityId) {{
                 [Div(_ln, cls="li-measure") for _ln in measure_sublines(li, item_meta=_meta)]
                 if doc_type in _INVOICE_LAYOUT_DOC_TYPES else []
             )
-            # On a shipping document the catalog item is where HS code / origin are
-            # maintained, so the SKU links straight to it (one click to fix the source).
+            # The eye links to the catalog item in every state (shared with the editable
+            # view). On a shipping document the catalog item is where HS code / origin are
+            # maintained, so the eye there says so; one affordance, no duplicate SKU link.
             _ident_1st, _ident_2nd = line_identifier(li, line_identifier_mode)
             _ident_2nd_div = Div(_ident_2nd, cls="li-ident-2nd", title=_ident_2nd) if _ident_2nd else None
-            _sku_cell = (
-                Td(A(_ident_1st, href=f"/inventory/{li_eid}", target="_blank",
-                     title="Open this item in the catalog (HS code and origin live there)",
-                     cls="auth-link"), _ident_2nd_div, cls="col-sku")
-                if pol["customs"] and li_eid and _ident_1st
-                else Td(format_value(_ident_1st or None), _ident_2nd_div, cls="col-sku")
+            _eye_title = ("Open this item in the catalog (HS code and origin live there)"
+                          if pol["customs"] else "View item details")
+            _sku_cell = Td(
+                Div(_item_link_eye(li_eid, title=_eye_title),
+                    Span(format_value(_ident_1st or None)), cls="li-ident-view"),
+                _ident_2nd_div, cls="col-sku",
             )
             cells += [
                 _sku_cell,

--- a/ui/routes/inventory.py
+++ b/ui/routes/inventory.py
@@ -5491,50 +5491,41 @@ def _inventory_cell_renderers(schema: list[dict], unit_names: list[str] | None =
     price_keys = [f["key"] for f in schema if f.get("type") == "money" and not f.get("virtual") and f["key"] != "sold_price"]
     virtual_total_fields = {f["key"]: f for f in schema if f.get("virtual") and f.get("type") == "money"}
     _cur = currency
-    for pk in price_keys:
-        def _make_price_renderer(field=pk, _currency=_cur):
-            def renderer(entity_id: str, row: dict) -> FT:
-                sell_by = (row.get("sell_by") or "").strip()
-                val = row.get(field, "")
-                # Render formatted money value with currency symbol
-                try:
-                    formatted = fmt_money(val, _currency) if val not in (None, "", "--") else "--"
-                except (ValueError, TypeError):
-                    formatted = "--"
-                annotation = Span(f"/ {sell_by}", cls="cell-price-unit") if sell_by else ""
-                inner = Span(formatted, cls="cell-money") if formatted != "--" else Span("--")
-                _safe_eid = entity_id.replace(":", "-")
-                return Td(
-                    inner, annotation,
-                    id=f"cell-{_safe_eid}-{field}",
-                    cls="cell cell--money cell--clickable",
-                    data_col=field,
-                    hx_get=f"/api/items/{entity_id}/field/{field}/edit",
-                    hx_target="this", hx_swap="outerHTML", hx_trigger="dblclick",
-                )
-            return renderer
-        renderers[pk] = _make_price_renderer()
-
-    # Sold price: read-only realized per-unit sale price, shown with the same "/ sell_unit"
-    # annotation as the wholesale/retail columns but without any click-to-edit affordance.
-    if "sold_price" in schema_keys:
-        def _sold_price_renderer(entity_id: str, row: dict, _currency=_cur) -> FT:
+    def _make_price_renderer(field, _currency=_cur, editable=True):
+        def renderer(entity_id: str, row: dict) -> FT:
             sell_by = (row.get("sell_by") or "").strip()
-            val = row.get("sold_price")
+            val = row.get(field, "")
+            # Render formatted money value with currency symbol
             try:
                 formatted = fmt_money(val, _currency) if val not in (None, "", "--") else "--"
             except (ValueError, TypeError):
                 formatted = "--"
-            annotation = Span(f"/ {sell_by}", cls="cell-price-unit") if (sell_by and formatted != "--") else ""
+            # A read-only cell suppresses the unit annotation next to "--": there is
+            # no value the unit could belong to and no edit affordance to hint at.
+            annotate = sell_by and (editable or formatted != "--")
+            annotation = Span(f"/ {sell_by}", cls="cell-price-unit") if annotate else ""
             inner = Span(formatted, cls="cell-money") if formatted != "--" else Span("--")
             _safe_eid = entity_id.replace(":", "-")
-            return Td(
-                inner, annotation,
-                id=f"cell-{_safe_eid}-sold_price",
-                cls="cell cell--money",
-                data_col="sold_price",
-            )
-        renderers["sold_price"] = _sold_price_renderer
+            attrs: dict = {
+                "id": f"cell-{_safe_eid}-{field}",
+                "cls": "cell cell--money cell--clickable" if editable else "cell cell--money",
+                "data_col": field,
+            }
+            if editable:
+                attrs.update(
+                    hx_get=f"/api/items/{entity_id}/field/{field}/edit",
+                    hx_target="this", hx_swap="outerHTML", hx_trigger="dblclick",
+                )
+            return Td(inner, annotation, **attrs)
+        return renderer
+
+    for pk in price_keys:
+        renderers[pk] = _make_price_renderer(pk)
+
+    # Sold price: read-only realized per-unit sale price, shown with the same "/ sell_unit"
+    # annotation as the wholesale/retail columns but without any click-to-edit affordance.
+    if "sold_price" in schema_keys:
+        renderers["sold_price"] = _make_price_renderer("sold_price", editable=False)
 
     # Virtual total column renderers
     for vk, vf in virtual_total_fields.items():

--- a/ui/routes/inventory.py
+++ b/ui/routes/inventory.py
@@ -952,10 +952,25 @@ async def _inventory_content(
     else:
         scope_value_label = ""
 
+    # Sold price: on the sold view, surface each row's realized per-unit sale price as a
+    # read-only money column, alongside the wholesale/retail prices for direct comparison.
+    # The value is derived server-side from the selling document (list_items).
+    sold_view = "sold" in {s.strip().lower() for s in str(p.get("status") or "").split(",") if s.strip()}
+    show_sold_price = sold_view and any(i.get("sold_price") is not None for i in items)
+    if show_sold_price:
+        eff_schema = eff_schema + [{
+            "key": "sold_price", "label": "Sold", "type": "money",
+            "editable": False, "required": False, "options": [], "visible_to_roles": [],
+            "position": 98, "show_in_table": True,
+        }]
+
     visible_cols = _resolve_visible_cols(eff_schema, col_prefs, active_cat, p.get("cols") or [])
     if scope_value_label and "holding_value" not in visible_cols:
         # Saved column prefs predate this column, so make sure the scope value is shown.
         visible_cols = visible_cols + ["holding_value"]
+    if show_sold_price and "sold_price" not in visible_cols:
+        # Saved column prefs predate this column, so make sure the sold price is shown.
+        visible_cols = visible_cols + ["sold_price"]
     # Inject resolved cols into URL state so sort links and pagination always carry
     # the exact column set being rendered, even when it came from col_prefs not URL params.
     p_with_cols = {**p, "cols": visible_cols}
@@ -5471,7 +5486,9 @@ def _inventory_cell_renderers(schema: list[dict], unit_names: list[str] | None =
 
     # Price column renderers: show currency symbol + "/ sell_unit" annotation
     from ui.components.table import fmt_money
-    price_keys = [f["key"] for f in schema if f.get("type") == "money" and not f.get("virtual")]
+    # sold_price is derived and read-only, so it is excluded from the click-to-edit price
+    # loop below and gets its own display-only renderer.
+    price_keys = [f["key"] for f in schema if f.get("type") == "money" and not f.get("virtual") and f["key"] != "sold_price"]
     virtual_total_fields = {f["key"]: f for f in schema if f.get("virtual") and f.get("type") == "money"}
     _cur = currency
     for pk in price_keys:
@@ -5497,6 +5514,27 @@ def _inventory_cell_renderers(schema: list[dict], unit_names: list[str] | None =
                 )
             return renderer
         renderers[pk] = _make_price_renderer()
+
+    # Sold price: read-only realized per-unit sale price, shown with the same "/ sell_unit"
+    # annotation as the wholesale/retail columns but without any click-to-edit affordance.
+    if "sold_price" in schema_keys:
+        def _sold_price_renderer(entity_id: str, row: dict, _currency=_cur) -> FT:
+            sell_by = (row.get("sell_by") or "").strip()
+            val = row.get("sold_price")
+            try:
+                formatted = fmt_money(val, _currency) if val not in (None, "", "--") else "--"
+            except (ValueError, TypeError):
+                formatted = "--"
+            annotation = Span(f"/ {sell_by}", cls="cell-price-unit") if (sell_by and formatted != "--") else ""
+            inner = Span(formatted, cls="cell-money") if formatted != "--" else Span("--")
+            _safe_eid = entity_id.replace(":", "-")
+            return Td(
+                inner, annotation,
+                id=f"cell-{_safe_eid}-sold_price",
+                cls="cell cell--money",
+                data_col="sold_price",
+            )
+        renderers["sold_price"] = _sold_price_renderer
 
     # Virtual total column renderers
     for vk, vf in virtual_total_fields.items():

--- a/ui/routes/inventory.py
+++ b/ui/routes/inventory.py
@@ -935,42 +935,38 @@ async def _inventory_content(
         for _it in items:
             if str(_it.get("status") or "").lower() == "draft":
                 _it["_row_editable_keys"] = sorted(AMOUNT_EDIT_GATED_KEYS)
-    # Under a contact holdings scope the meaningful per-row value is the scope value the
-    # total is summed from (quoted memo price / consignment cost), not the catalog price.
-    # Surface it as a read-only column so the rows visibly add up to the banner figure.
+    # Derived read-only money columns, appended to the schema when their values exist:
+    # - Under a contact holdings scope the meaningful per-row value is the scope value the
+    #   total is summed from (quoted memo price / consignment cost), not the catalog
+    #   price; surfacing it makes the rows visibly add up to the banner figure.
+    # - On the sold view, each row's realized per-unit sale price sits alongside the
+    #   wholesale/retail prices for direct comparison (derived server-side, list_items).
     scope_value_label = ""
     if p.get("on_memo_to"):
         scope_value_label = "Quoted"
     elif p.get("consigned_from"):
         scope_value_label = "Cost"
-    if scope_value_label and any(i.get("holding_value") is not None for i in items):
-        eff_schema = eff_schema + [{
-            "key": "holding_value", "label": scope_value_label, "type": "money",
-            "editable": False, "required": False, "options": [], "visible_to_roles": [],
-            "position": 99, "show_in_table": True,
-        }]
-    else:
+    if not (scope_value_label and any(i.get("holding_value") is not None for i in items)):
         scope_value_label = ""
-
-    # Sold price: on the sold view, surface each row's realized per-unit sale price as a
-    # read-only money column, alongside the wholesale/retail prices for direct comparison.
-    # The value is derived server-side from the selling document (list_items).
     sold_view = "sold" in {s.strip().lower() for s in str(p.get("status") or "").split(",") if s.strip()}
     show_sold_price = sold_view and any(i.get("sold_price") is not None for i in items)
+    derived_money_cols = []
+    if scope_value_label:
+        derived_money_cols.append(("holding_value", scope_value_label, 99))
     if show_sold_price:
+        derived_money_cols.append(("sold_price", "Sold", 98))
+    for _key, _label, _position in derived_money_cols:
         eff_schema = eff_schema + [{
-            "key": "sold_price", "label": "Sold", "type": "money",
+            "key": _key, "label": _label, "type": "money",
             "editable": False, "required": False, "options": [], "visible_to_roles": [],
-            "position": 98, "show_in_table": True,
+            "position": _position, "show_in_table": True,
         }]
 
     visible_cols = _resolve_visible_cols(eff_schema, col_prefs, active_cat, p.get("cols") or [])
-    if scope_value_label and "holding_value" not in visible_cols:
-        # Saved column prefs predate this column, so make sure the scope value is shown.
-        visible_cols = visible_cols + ["holding_value"]
-    if show_sold_price and "sold_price" not in visible_cols:
-        # Saved column prefs predate this column, so make sure the sold price is shown.
-        visible_cols = visible_cols + ["sold_price"]
+    for _key, _label, _position in derived_money_cols:
+        if _key not in visible_cols:
+            # Saved column prefs predate this derived column, so force it visible.
+            visible_cols = visible_cols + [_key]
     # Inject resolved cols into URL state so sort links and pagination always carry
     # the exact column set being rendered, even when it came from col_prefs not URL params.
     p_with_cols = {**p, "cols": visible_cols}

--- a/ui/static/app.css
+++ b/ui/static/app.css
@@ -320,6 +320,9 @@ a:hover { text-decoration: underline; }
   .table-top-scroll.top-scroll-pinned {
     position: fixed;
     top: 0;
+    /* Floor at 0 until JS sets the real width right after this class lands - the base rule's
+       width:100% would otherwise resolve against the viewport for a moment and clamp scrollLeft. */
+    width: 0;
     z-index: 6;
     background: var(--c-bg3);
   }

--- a/ui/static/app.css
+++ b/ui/static/app.css
@@ -1882,6 +1882,9 @@ option.unit-unknown-option { color: var(--c-red, #ef4444); font-style: italic; }
 .item-link--active { color: var(--c-accent); }
 .item-link--active:hover { opacity: 0.7; }
 .item-link--inactive { color: var(--c-text2); opacity: 0.4; cursor: default; }
+/* Finalized SKU cell: eye icon and identifier text on one row, matching the editable view. */
+.li-ident-view { display: flex; align-items: center; gap: 4px; min-width: 0; }
+.li-ident-view > span { overflow: hidden; text-overflow: ellipsis; }
 .catalog-ac-input { width: 100%; padding-right: 20px !important; background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='6'%3E%3Cpath d='M0 0l5 6 5-6z' fill='%230ea57a'/%3E%3C/svg%3E"); background-repeat: no-repeat; background-position: right 6px center; }
 .catalog-ac-list { position: absolute; top: 100%; left: 0; right: 0; z-index: 1000; background: var(--c-bg); border: 1px solid var(--c-border); border-radius: 4px; max-height: 200px; overflow-y: auto; box-shadow: 0 4px 12px rgba(0,0,0,0.12); }
 .catalog-ac-option { padding: 6px 10px; font-size: 12px; cursor: pointer; border-bottom: 1px solid var(--c-bg3); }


### PR DESCRIPTION
Sold inventory now shows the price each item actually sold for. A read-only Sold (Unit Price) column appears in the sold inventory view beside the Retail and Wholesale columns, showing the per-unit price from the document that sold the item together with its sell-by unit. When the selling line cannot be resolved the cell shows "--" rather than a made-up figure. The column appears only in the sold view and is not editable.

The eye icon that links a document line to its catalog item now renders in finalized states too, so a sent or paid document can jump to the item it came from. Lines with no catalog item show a greyed, inert placeholder, keeping the SKU column uniform across draft and finalized views. On customs documents the eye keeps its HS-code tooltip and the duplicate SKU-text link is removed in favour of the single shared eye.

On list pages like Inventory, hiding some columns and then scrolling the table sideways and down made body columns slide under the wrong headers once the header row froze. The frozen header locks column widths from the header row cells, and a hidden column still has a header cell, so its zero width was applied to the next visible column and every column after it shifted. Column widths are now taken from visible columns only, so the body stays under the right headers no matter which columns are hidden or how far the table is scrolled.