### PR TITLE
Cost production runs from actuals and add printable run sheets

### DIFF
--- a/celerp/events/schemas.py
+++ b/celerp/events/schemas.py
@@ -718,8 +718,8 @@ class MfgOrderIssued(BaseModel):
 
 
 class MfgOrderReceived(BaseModel):
-    # Finished goods received from a run. quantity restocks the output (per allow_splitting);
-    # lot_item_id is set when a non-splittable output created a new lot under the product.
+    # Finished goods received from a run. quantity is received as a discrete lot under the product;
+    # lot_item_id is that lot's id.
     quantity: float
     lot_item_id: str | None = None
     received_by: str | None = None

--- a/celerp/events/schemas.py
+++ b/celerp/events/schemas.py
@@ -193,6 +193,14 @@ class ItemProduced(BaseModel):
     quantity_produced: float
 
 
+class ItemCostAdjusted(BaseModel):
+    # Restate a lot's goods cost after the fact. Manufacturing re-costs a produced lot to the run's
+    # actual input cost once completion knows the true received quantity. cost_total is the new
+    # absolute cost_base; landed contributions rescale from it.
+    cost_total: float
+    manufacturing_order_id: str | None = None   # the run that re-costed the lot (audit trail)
+
+
 # --- Manufacturing recipe (materials + labor + overhead) attached to an item ---
 # The recipe is the single source of truth for how a manufactured item is built.
 # Interpretation (cost roll-up, expansion) lives in celerp-manufacturing; the schema
@@ -1054,6 +1062,7 @@ EVENT_SCHEMA_MAP: dict[str, type[BaseModel]] = {
     "item.patched": ItemPatched,
     "item.consumed": ItemConsumed,
     "item.produced": ItemProduced,
+    "item.cost_adjusted": ItemCostAdjusted,
     "item.recipe.set": ItemRecipeSet,
     "item.workflow.set": ItemWorkflowSet,
     "item.reserved": ItemReserved,

--- a/celerp/events/types.py
+++ b/celerp/events/types.py
@@ -22,6 +22,7 @@ class EventType(StrEnum):
     ITEM_MERGED = "item.merged"
     ITEM_CONSUMED = "item.consumed"
     ITEM_PRODUCED = "item.produced"
+    ITEM_COST_ADJUSTED = "item.cost_adjusted"
     ITEM_RECIPE_SET = "item.recipe.set"
     ITEM_WORKFLOW_SET = "item.workflow.set"
     ITEM_RESERVED = "item.reserved"

--- a/default_modules/celerp-docs/tests/test_consolidate_lots.py
+++ b/default_modules/celerp-docs/tests/test_consolidate_lots.py
@@ -1,0 +1,47 @@
+# Copyright (c) 2026 Noah Severs
+# SPDX-License-Identifier: MIT
+"""Consolidation of a splittable SKU's lots for a forward sales doc.
+
+A fungible product that is produced or received as discrete lots keeps its catalog
+row at quantity 0 while stock lives in newer lots. When such a SKU is sold, the
+single consolidated option must bind to a lot that actually holds stock, not to the
+empty pick-first row - otherwise fulfillment rejects the line despite in-stock lots.
+"""
+from __future__ import annotations
+
+from ui.routes.documents import _consolidate_sales_lots
+
+
+def _lot(entity_id: str, sku: str, created_at: str, quantity: float) -> dict:
+    return {
+        "entity_id": entity_id,
+        "sku": sku,
+        "created_at": created_at,
+        "quantity": quantity,
+        "allow_splitting": True,
+    }
+
+
+def test_consolidate_prefers_stocked_lot() -> None:
+    """FIFO binds the pick-first lot WITH stock, not the empty older catalog row."""
+    empty_old = _lot("item:catalog", "WIDGET", "2026-01-01T00:00:00", 0)
+    stocked_new = _lot("item:lot-a", "WIDGET", "2026-02-01T00:00:00", 5)
+
+    out = _consolidate_sales_lots([empty_old, stocked_new], {})
+
+    assert len(out) == 1
+    rep = out[0]
+    assert rep["entity_id"] == "item:lot-a"  # the lot that holds stock, not the empty row
+    assert rep["quantity"] == 5  # aggregate on-hand across the SKU's lots
+
+
+def test_consolidate_all_empty_keeps_pick_first() -> None:
+    """Genuine out of stock: every lot empty, the pick-first row is bound and 0 is honest."""
+    empty_old = _lot("item:catalog", "WIDGET", "2026-01-01T00:00:00", 0)
+    empty_new = _lot("item:lot-a", "WIDGET", "2026-02-01T00:00:00", 0)
+
+    out = _consolidate_sales_lots([empty_old, empty_new], {})
+
+    assert len(out) == 1
+    assert out[0]["entity_id"] == "item:catalog"
+    assert out[0]["quantity"] == 0

--- a/default_modules/celerp-inventory/celerp_inventory/projections.py
+++ b/default_modules/celerp-inventory/celerp_inventory/projections.py
@@ -327,6 +327,12 @@ def apply_item_event(state: dict, event_type: str, data: dict) -> dict:
         if "cost_base" in data and data["cost_base"] is not None:
             current["cost_base"] = float(data["cost_base"])
         _recompute_cost(current)  # landed cost is per-unit, so it scales with quantity
+    elif event_type == "item.cost_adjusted":
+        # Restate the goods cost of a lot after the fact: manufacturing re-costs a produced lot to the
+        # run's actual input cost once completion knows the true received quantity. cost_total in the
+        # payload is the new absolute cost_base; landed contributions rescale from it.
+        current["cost_base"] = float(data["cost_total"])
+        _recompute_cost(current)
     elif event_type == "item.landed_cost.applied":
         # Absolute per-unit landed contribution for one (source bill, kind); overwrite-safe so
         # re-running allocation with changed freight self-corrects. amount=0 clears the contribution.
@@ -365,7 +371,16 @@ def apply_item_event(state: dict, event_type: str, data: dict) -> dict:
         _stamp_status_doc(current, {})
         current["merged_into"] = data.get("merged_into")
     elif event_type == "item.consumed":
-        current["quantity"] = max(0.0, float(current.get("quantity", 0)) - float(data["quantity_consumed"]))
+        # Relieve goods cost with the units, so unit cost stays put as a component is drawn down
+        # (perpetual costing: what leaves carries its share of cost_base, exactly as a sale relieves
+        # COGS). Landed cost is per-unit and _recompute_cost rescales it, so only cost_base moves here.
+        qty = float(current.get("quantity") or 0)
+        consumed = float(data["quantity_consumed"])
+        if qty > 0 and current.get("cost_base") is not None:
+            base_unit = float(current["cost_base"]) / qty
+            current["cost_base"] = round(max(0.0, float(current["cost_base"]) - base_unit * consumed), 2)
+        current["quantity"] = max(0.0, qty - consumed)
+        _recompute_cost(current)
     elif event_type == "item.produced":
         current["quantity"] = float(current.get("quantity", 0)) + float(data["quantity_produced"])
     elif event_type == "item.recipe.set":

--- a/default_modules/celerp-inventory/celerp_inventory/projections.py
+++ b/default_modules/celerp-inventory/celerp_inventory/projections.py
@@ -54,6 +54,8 @@ _CORE_ITEM_KEYS: frozenset[str] = frozenset({
     "parent_id", "parent_sku", "children", "child_skus", "merged_into", "split_from",
     "transformed_from", "transformed_into", "fulfilled_for_docs",
     "status_doc_id", "status_doc_number",
+    # manufactured-lot identity: a produced lot links to its product and its run, and flags itself
+    "parent_item_id", "manufacturing_order_id", "lot",
     # files / media
     "files", "attachments", "preview_image_id",
     # other structured internals

--- a/default_modules/celerp-manufacturing/celerp_manufacturing/projection_handler.py
+++ b/default_modules/celerp-manufacturing/celerp_manufacturing/projection_handler.py
@@ -19,6 +19,9 @@ def apply_manufacturing_event(state: dict, event_type: str, data: dict) -> dict:
         current.setdefault("actual_outputs", [])
         # Execution progress: how much of each input has been issued, and how much output received.
         current.setdefault("received_qty", 0.0)
+        # The lots this run has produced, in receipt order - the run's own record of its output,
+        # used to re-cost them at completion without scanning every item.
+        current.setdefault("received_lots", [])
         current["inputs"] = [{**i, "issued_qty": float(i.get("issued_qty") or 0)} for i in current.get("inputs", [])]
     elif event_type == "mfg.order.started":
         current["status"] = "in_progress"
@@ -44,6 +47,12 @@ def apply_manufacturing_event(state: dict, event_type: str, data: dict) -> dict:
                 inp["issued_qty"] = float(inp.get("issued_qty") or 0) + issued[inp["item_id"]]
     elif event_type == "mfg.order.received":
         current["received_qty"] = float(current.get("received_qty") or 0) + float(data.get("quantity") or 0)
+        lot_id = data.get("lot_item_id")
+        if lot_id:
+            lots = list(current.get("received_lots") or [])
+            if lot_id not in lots:
+                lots.append(lot_id)
+            current["received_lots"] = lots
     elif event_type == "mfg.order.scheduled":
         # Phase-A scheduling: apply only the keys provided (a blank value clears the field).
         for key in ("due_date", "planned_start", "priority"):

--- a/default_modules/celerp-manufacturing/celerp_manufacturing/routes.py
+++ b/default_modules/celerp-manufacturing/celerp_manufacturing/routes.py
@@ -98,7 +98,7 @@ class ReceiveBody(BaseModel):
 
 class CompleteBody(BaseModel):
     actual_outputs: list[MfgOutput] | None = None
-    waste_quantity: float | None = None
+    waste_quantity: float | None = Field(default=None, ge=0)
     waste_unit: str | None = None
     waste_reason: str | None = None
     labor_hours: float | None = None
@@ -343,7 +343,7 @@ async def build_item(
     """Create a production run to build N of a manufacturable item — inputs expand from its recipe.
 
     With ``complete=true`` this is a one-tap build: the run is created, its components issued,
-    its output received (restocked per ``allow_splitting``), and the run completed in a single call.
+    its output received as a discrete lot, and the run completed in a single call.
     """
     item = await session.get(Projection, {"company_id": company_id, "entity_id": item_id})
     if item is None or item.entity_type != "item":
@@ -572,7 +572,7 @@ async def _compute_to_make(session: AsyncSession, company_id) -> list[dict]:
     )).scalars().all()
     in_progress = _in_progress_by_item(runs)
 
-    # Non-splittable outputs restock as discrete lots under the product, so on-hand must include them.
+    # Every produced output is a discrete lot under the product, so on-hand must include them.
     lot_qty = _lot_qty_by_parent(states)
     hours_per_day = await _default_hours_per_day(session, company_id)
     items: list[dict] = []
@@ -1336,11 +1336,22 @@ def _component_unit_cost(state: dict | None) -> float:
 
 
 def _run_input_cost(run_state: dict, states: dict[str, dict]) -> float:
-    """Total standard input cost of a run = sum(required qty x component unit cost)."""
-    return round(sum(
-        float(inp.get("quantity") or 0) * _component_unit_cost(states.get(inp.get("item_id")))
-        for inp in run_state.get("inputs", [])
-    ), 2)
+    """Actual input cost of a run = sum(quantity issued x component unit cost), falling back to the
+    planned required quantity for an input nothing has been issued against yet so a bare run still
+    costs something. Feeds both the produced lot cost and the completion JE input relief, so the
+    actuals propagate from this one edit."""
+    total = 0.0
+    for inp in run_state.get("inputs", []):
+        unit = _component_unit_cost(states.get(inp.get("item_id")))
+        issued = float(inp.get("issued_qty") or 0)
+        qty = issued if issued > 0 else float(inp.get("quantity") or 0)
+        total += qty * unit
+    return round(total, 2)
+
+
+# Namespace for deterministic produced-lot ids: a receipt re-submitted with the same idempotency
+# key resolves to the same lot id, so the deduped event stream never mints a phantom second lot.
+_MFG_LOT_NS = uuid.UUID("6f1d0c2a-7b3e-4a9c-8d5f-2e0a1b4c6d8e")
 
 
 def _lot_qty_by_parent(states: dict[str, dict]) -> dict[str, float]:
@@ -1388,12 +1399,18 @@ async def _issue_and_record(session: AsyncSession, company_id, user, order_id: s
 
 
 async def _receive(session: AsyncSession, company_id, user, order_id: str, run_state: dict,
-                   qty: float, states: dict[str, dict]) -> str | None:
-    """Restock `qty` of the run's output product and record the receipt on the run.
+                   qty: float, states: dict[str, dict], idempotency_key: str | None = None) -> str | None:
+    """Restock `qty` of the run's output as a new discrete lot and record the receipt on the run.
 
-    Keyed on the product's `allow_splitting`: True increments the existing product SKU's quantity;
-    False creates a new discrete lot entry linked to the product. Returns the lot id (or None).
+    Every receipt mints its own lot under the product, exactly like a received purchase, so a
+    fungible product carries a true weighted-average cost across batches. The lot inherits the
+    product's splittability (so a fungible product's lot stays partially sellable) and takes a
+    provisional unit cost of issued-to-date input over received-to-date quantity; completion re-costs
+    it to the final actual output cost. A key re-submitted with the same request resolves to the same
+    lot id and deduped events, so a retry never mints a phantom second lot. Returns the lot id
+    (or None if the run has no resolvable output product).
     """
+    rk = idempotency_key or uuid.uuid4().hex
     out_id = run_state.get("output_item_id")
     product = states.get(out_id) if out_id else None
     if out_id and product is None:
@@ -1405,51 +1422,49 @@ async def _receive(session: AsyncSession, company_id, user, order_id: str, run_s
         if str(product.get("status") or "").lower() == "draft":
             raise HTTPException(status_code=422, detail=f"Cannot produce into a draft item ({out_id}); make it available first.")
         loc = product.get("location_id")
-        if bool(product.get("allow_splitting", True)):
-            # Fungible / bulk: add to the existing product's pile.
-            await emit_event(
-                session, company_id=company_id, entity_id=out_id, entity_type="item",
-                event_type="item.produced", data={"quantity_produced": qty}, actor_id=user.id,
-                location_id=loc, source="api", idempotency_key=str(uuid.uuid4()),
-                metadata_={"manufacturing_order_id": order_id},
-            )
-        else:
-            # Discrete / unique: a new lot under the same product, with its own cost and trace.
-            lot_id = f"item:{uuid.uuid4()}"
-            expected = float((run_state.get("expected_outputs") or [{}])[0].get("quantity") or 0) or qty
-            unit_cost = _run_input_cost(run_state, states) / (expected or 1)
-            await emit_event(
-                session, company_id=company_id, entity_id=lot_id, entity_type="item",
-                event_type="item.created",
-                data={
-                    "sku": product.get("sku"), "name": product.get("name"),
-                    "sell_by": product.get("sell_by"), "category": product.get("category"),
-                    "inventory_type": product.get("inventory_type"), "allow_splitting": False,
-                    "quantity": 0, "location_id": loc, "parent_item_id": out_id, "lot": True,
-                    "manufacturing_order_id": order_id, "cost_total": round(unit_cost * qty, 2),
-                },
-                actor_id=user.id, location_id=loc, source="api", idempotency_key=str(uuid.uuid4()),
-                metadata_={"manufacturing_order_id": order_id},
-            )
-            await emit_event(
-                session, company_id=company_id, entity_id=lot_id, entity_type="item",
-                event_type="item.produced", data={"quantity_produced": qty}, actor_id=user.id,
-                location_id=loc, source="api", idempotency_key=str(uuid.uuid4()),
-                metadata_={"manufacturing_order_id": order_id},
-            )
+        received_after = float(run_state.get("received_qty") or 0) + qty
+        unit_cost = _run_input_cost(run_state, states) / (received_after or 1)
+        lot_id = f"item:{uuid.uuid5(_MFG_LOT_NS, f'{order_id}:{rk}')}"
+        await emit_event(
+            session, company_id=company_id, entity_id=lot_id, entity_type="item",
+            event_type="item.created",
+            data={
+                "sku": product.get("sku"), "name": product.get("name"),
+                "sell_by": product.get("sell_by"), "category": product.get("category"),
+                "inventory_type": product.get("inventory_type"),
+                "allow_splitting": bool(product.get("allow_splitting", True)),
+                "quantity": 0, "location_id": loc, "parent_item_id": out_id, "lot": True,
+                "manufacturing_order_id": order_id, "cost_total": round(unit_cost * qty, 2),
+            },
+            actor_id=user.id, location_id=loc, source="api",
+            idempotency_key=f"mfg:{order_id}:receive:{rk}:created",
+            metadata_={"manufacturing_order_id": order_id},
+        )
+        await emit_event(
+            session, company_id=company_id, entity_id=lot_id, entity_type="item",
+            event_type="item.produced", data={"quantity_produced": qty}, actor_id=user.id,
+            location_id=loc, source="api",
+            idempotency_key=f"mfg:{order_id}:receive:{rk}:produced",
+            metadata_={"manufacturing_order_id": order_id},
+        )
 
     await emit_event(
         session, company_id=company_id, entity_id=order_id, entity_type="mfg_order",
         event_type="mfg.order.received",
         data={"quantity": qty, "lot_item_id": lot_id, "received_by": str(user.id)},
-        actor_id=user.id, location_id=None, source="api", idempotency_key=str(uuid.uuid4()), metadata_={},
+        actor_id=user.id, location_id=None, source="api",
+        idempotency_key=f"mfg:{order_id}:receive:{rk}:received", metadata_={},
     )
     return lot_id
 
 
 async def _close_run(session: AsyncSession, company_id, user, order_id: str, run_state: dict,
                      states: dict[str, dict], payload: "CompleteBody | None" = None) -> None:
-    """Emit mfg.order.completed (with actuals/waste/labor) and post the completion journal entry."""
+    """Close a run: record the actual yield, post the completion journal entry, and re-cost the run's
+    lots to the final actual output cost so they reconcile exactly against that entry.
+
+    Idempotent: the completion event, its journal entry, and every lot re-cost carry deterministic
+    keys derived from the order id, so closing the same run twice dedups rather than double posting."""
     input_cost = _run_input_cost(run_state, states)
     waste = None
     waste_cost = 0.0
@@ -1457,24 +1472,57 @@ async def _close_run(session: AsyncSession, company_id, user, order_id: str, run
         waste = {"quantity": payload.waste_quantity, "unit": payload.waste_unit, "reason": payload.waste_reason}
         total_in = sum(float(i.get("quantity", 0) or 0) for i in run_state.get("inputs", [])) or 0.0
         if payload.waste_quantity and total_in > 0:
-            waste_cost = input_cost * (float(payload.waste_quantity) / total_in)
+            # Clamp so waste can never exceed the input cost and drive output cost negative.
+            waste_cost = min(input_cost * (float(payload.waste_quantity) / total_in), input_cost)
+    if payload is not None and payload.actual_outputs is not None:
+        actual_outputs = [o.model_dump() for o in payload.actual_outputs]
+    else:
+        # No explicit yield given: record what was actually received as the actual output.
+        received = float(run_state.get("received_qty") or 0)
+        expected = (run_state.get("expected_outputs") or [{}])[0]
+        actual_outputs = [{**expected, "quantity": received}] if expected else []
     await emit_event(
         session, company_id=company_id, entity_id=order_id, entity_type="mfg_order",
         event_type="mfg.order.completed",
         data={
             "completed_by": str(user.id),
-            "actual_outputs": run_state.get("expected_outputs", []),
+            "actual_outputs": actual_outputs,
             "waste": waste,
             "labor_hours": payload.labor_hours if payload is not None else None,
         },
         actor_id=user.id, location_id=None, source="api",
-        idempotency_key=(payload.idempotency_key if payload is not None else None) or str(uuid.uuid4()),
+        idempotency_key=f"mfg:{order_id}:completed",
         metadata_={},
     )
     await auto_je.create_for_mfg_completed(
         session, company_id=company_id, user_id=user.id, order_id=order_id,
         input_cost=input_cost, waste_cost=waste_cost,
     )
+    await _recost_run_lots(session, company_id, user, order_id, run_state, input_cost - waste_cost)
+
+
+async def _recost_run_lots(session: AsyncSession, company_id, user, order_id: str, run_state: dict,
+                           output_cost: float) -> None:
+    """Restate every lot this run produced to a shared unit cost of output_cost / total received, so
+    the sum of the lots' cost equals the completion entry's output leg under single or multiple
+    receipts and with or without waste. Emits one deterministic item.cost_adjusted per lot."""
+    total_received = float(run_state.get("received_qty") or 0)
+    if total_received <= 0:
+        return  # nothing received: no lot to re-cost, and never divide by a zero yield
+    unit_cost = float(output_cost) / total_received
+    fresh = await _all_item_states(session, company_id)
+    for lot_id in run_state.get("received_lots") or []:
+        lot = fresh.get(lot_id)
+        if lot is None:
+            continue
+        new_total = round(unit_cost * float(lot.get("quantity") or 0), 2)
+        await emit_event(
+            session, company_id=company_id, entity_id=lot_id, entity_type="item",
+            event_type="item.cost_adjusted",
+            data={"cost_total": new_total, "manufacturing_order_id": order_id},
+            actor_id=user.id, location_id=lot.get("location_id"), source="api",
+            idempotency_key=f"mfg:{order_id}:recost:{lot_id}", metadata_={"manufacturing_order_id": order_id},
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -1719,7 +1767,7 @@ async def receive_order(
     _: None = require_permission("manage_manufacturing"),
     session: AsyncSession = Depends(get_session),
 ) -> dict:
-    """Receive finished goods from a run — restocks the output per `allow_splitting`. Omitting
+    """Receive finished goods from a run as a discrete lot under the product. Omitting
     `quantity` receives everything still outstanding; once fully received the run auto-completes."""
     row = await _get_order(session, company_id, order_id)
     if row.state.get("status") in {"completed", "cancelled"}:
@@ -1729,7 +1777,8 @@ async def receive_order(
     if qty <= 0:
         raise HTTPException(status_code=422, detail="Receive quantity must be greater than zero")
     states = await _all_item_states(session, company_id)
-    lot_id = await _receive(session, company_id, user, order_id, row.state, qty, states)
+    lot_id = await _receive(session, company_id, user, order_id, row.state, qty, states,
+                            idempotency_key=(payload.idempotency_key if payload else None))
     # Auto-complete once the full expected output has been received.
     row = await _get_order(session, company_id, order_id)
     if _outstanding_output(row.state) <= 1e-9:
@@ -1749,8 +1798,8 @@ async def complete_order(
 ) -> dict:
     """Finish a run now: issue any outstanding components, receive all outstanding output, and close.
 
-    This is the one-tap close used by the product hub's Complete action; the output is restocked per
-    `allow_splitting` (incrementing the SKU or creating a new lot) — never a nameless throwaway item.
+    This is the one-tap close used by the product hub's Complete action; the output lands as a
+    discrete lot under the product, never a nameless throwaway item.
     """
     row = await _get_order(session, company_id, order_id)
     if row.state.get("status") in {"completed", "cancelled"}:

--- a/default_modules/celerp-manufacturing/tests/test_build_api.py
+++ b/default_modules/celerp-manufacturing/tests/test_build_api.py
@@ -44,7 +44,8 @@ async def test_build_creates_planned_run_with_expanded_inputs(client) -> None:
 
 @pytest.mark.asyncio
 async def test_build_complete_one_tap_increments_splittable_sku(client) -> None:
-    """allow_splitting default true: one-tap build increments the existing product, no nameless item."""
+    """allow_splitting default true: one-tap build lands the output as a discrete lot under the
+    product; the product's own on-hand is untouched and no nameless item is created."""
     token = await _register(client)
     gold = await _item(client, token, "GOLD2", quantity=100, cost_total=8000)
     ring = await _item(client, token, "RING2", quantity=4)
@@ -52,11 +53,17 @@ async def test_build_complete_one_tap_increments_splittable_sku(client) -> None:
                      json={"output_qty": 1, "components": [{"item_id": gold, "quantity": 5}], "labor": [], "overhead": []})
     r = await client.post(f"/manufacturing/items/{ring}/build", headers=_h(token), json={"quantity": 2, "complete": True})
     assert r.status_code == 200
-    assert (await client.get(f"/manufacturing/{r.json()['id']}", headers=_h(token))).json()["status"] == "completed"
-    assert (await client.get(f"/items/{ring}", headers=_h(token))).json()["quantity"] == 6  # 4 + 2, same SKU
+    run = r.json()["id"]
+    assert (await client.get(f"/manufacturing/{run}", headers=_h(token))).json()["status"] == "completed"
+    assert (await client.get(f"/items/{ring}", headers=_h(token))).json()["quantity"] == 4  # product on-hand untouched
     assert (await client.get(f"/items/{gold}", headers=_h(token))).json()["quantity"] == 90  # 100 - 10
-    skus = [i.get("sku") for i in (await client.get("/items", headers=_h(token))).json()["items"]]
-    assert skus.count("RING2") == 1  # restocked in place — no second/throwaway RING2 entry
+    items = (await client.get("/items", headers=_h(token))).json()["items"]
+    rings = [i for i in items if i.get("sku") == "RING2"]
+    assert len(rings) == 2  # product + one discrete lot (always auto-split)
+    lot = next(i for i in rings if i["id"] != ring)
+    assert lot["quantity"] == 2 and lot["parent_item_id"] == ring and lot.get("lot") is True
+    assert lot.get("allow_splitting") is True  # a splittable product yields a splittable lot
+    assert not any(i.get("name") in (None, "") for i in items)  # no nameless throwaway item
 
 
 @pytest.mark.asyncio

--- a/default_modules/celerp-manufacturing/tests/test_manufacture_from_doc.py
+++ b/default_modules/celerp-manufacturing/tests/test_manufacture_from_doc.py
@@ -49,6 +49,27 @@ async def _to_make(client, token) -> dict:
 
 
 @pytest.mark.asyncio
+async def test_board_on_hand_counts_produced_lots(client) -> None:
+    """A manufactured product's stock lives in produced lots, not the catalog row, so the To-Make
+    board's on-hand must aggregate those lots - otherwise every built product reads as 0 on hand
+    and the board over-suggests builds."""
+    token = await _register(client)
+    gold = await _item(client, token, "GOLDB", quantity=100, cost_total=8000)
+    ring = await _item(client, token, "RINGB", quantity=0)  # catalog row stays empty
+    await _recipe(client, token, ring, [{"item_id": gold, "quantity": 1}])
+    await _doc(client, token, [{"item_id": ring, "sku": "RINGB", "name": "Ring", "quantity": 10, "unit_price": 100}])
+
+    # One-tap build 6: produced as a lot under the product, catalog row still 0.
+    r = await client.post(f"/manufacturing/items/{ring}/build", headers=_h(token),
+                          json={"quantity": 6, "complete": True})
+    assert r.status_code == 200, r.text
+
+    row = (await _to_make(client, token))[ring]
+    assert row["on_hand"] == 6.0  # the produced lot, not the empty catalog row
+    assert row["to_make"] == 4.0  # 10 demand - 6 on hand
+
+
+@pytest.mark.asyncio
 async def test_no_runs_auto_created_from_docs(client) -> None:
     """In the product-centric model, opening the runs list does NOT spawn runs from documents."""
     token = await _register(client)

--- a/default_modules/celerp-manufacturing/tests/test_manufacturing.py
+++ b/default_modules/celerp-manufacturing/tests/test_manufacturing.py
@@ -2,9 +2,9 @@
 # SPDX-License-Identifier: MIT
 """Production-run execution: build -> issue components -> receive finished goods.
 
-Covers the headline P3 correctness rule — completion restocks the *real* product (keyed on
-``allow_splitting``: increment the SKU, or create a discrete lot under it) and never spawns a
-nameless throwaway item — plus the completion journal entry and status transitions.
+Covers the headline P3 correctness rule - every completion lands the output as a discrete lot
+under the real product (never a nameless throwaway item, never a silent SKU-pile bump), so a run
+is always a record of a specific batch - plus the completion journal entry and status transitions.
 """
 from __future__ import annotations
 
@@ -49,8 +49,8 @@ def _balanced(entries: list[dict]) -> None:
 
 @pytest.mark.asyncio
 async def test_build_issue_receive_restocks_product_and_posts_je(client, session):
-    """The full two-step run: issue decrements components and starts the run; receive restocks the
-    product (same SKU, incremented) and completes it. No nameless item is ever created."""
+    """The full two-step run: issue decrements components and starts the run; receive lands the
+    output as a discrete lot under the product and completes it. No nameless item is ever created."""
     token = await _register(client)
     gold = await _item(client, token, "GOLD", quantity=100, cost_total=8000)  # unit cost 80
     ring = await _item(client, token, "RING", quantity=0)
@@ -64,14 +64,19 @@ async def test_build_issue_receive_restocks_product_and_posts_je(client, session
     assert state["status"] == "in_progress" and state["is_in_production"] is True
     assert (await client.get(f"/items/{gold}", headers=_h(token))).json()["quantity"] == 90  # 100 - 10
 
-    # Receive all -> product restocked (same item), run auto-completes.
+    # Receive all -> output lands as a discrete lot under the product, run auto-completes.
     assert (await client.post(f"/manufacturing/{run}/receive", headers=_h(token))).status_code == 200
     state = (await client.get(f"/manufacturing/{run}", headers=_h(token))).json()
     assert state["status"] == "completed" and state["is_in_production"] is False
 
     items = (await client.get("/items", headers=_h(token))).json()["items"]
     rings = [i for i in items if i.get("sku") == "RING"]
-    assert len(rings) == 1 and rings[0]["id"] == ring and rings[0]["quantity"] == 2  # incremented, not a clone
+    assert len(rings) == 2  # the catalog product + one discrete lot (always auto-split, like invoices)
+    product = next(i for i in rings if i["id"] == ring)
+    lot = next(i for i in rings if i["id"] != ring)
+    assert product["quantity"] == 0  # the product itself is never the pile
+    assert lot["quantity"] == 2 and lot["manufacturing_order_id"] == run and lot.get("lot") is True
+    assert lot.get("allow_splitting") is True  # a splittable product yields a splittable lot
     assert not any(i.get("name") in (None, "") for i in items)  # no nameless throwaway item
 
     ledger = (await client.get("/ledger?entity_type=journal_entry", headers=_h(token))).json()["items"]
@@ -95,7 +100,13 @@ async def test_one_tap_build_completes_in_one_call(client):
                              json={"quantity": 3, "complete": True})).json()["id"]
     assert (await client.get(f"/manufacturing/{run}", headers=_h(token))).json()["status"] == "completed"
     assert (await client.get(f"/items/{gold}", headers=_h(token))).json()["quantity"] == 85  # 100 - 15
-    assert (await client.get(f"/items/{ring}", headers=_h(token))).json()["quantity"] == 3
+    assert (await client.get(f"/items/{ring}", headers=_h(token))).json()["quantity"] == 0  # product is never the pile
+
+    items = (await client.get("/items", headers=_h(token))).json()["items"]
+    rings = [i for i in items if i.get("sku") == "R"]
+    assert len(rings) == 2  # product + one discrete lot from the one-tap run
+    lot = next(i for i in rings if i["id"] != ring)
+    assert lot["quantity"] == 3 and lot["manufacturing_order_id"] == run and lot.get("lot") is True
 
 
 @pytest.mark.asyncio

--- a/default_modules/celerp-manufacturing/tests/test_run_records.py
+++ b/default_modules/celerp-manufacturing/tests/test_run_records.py
@@ -1,0 +1,401 @@
+# Copyright (c) 2026 Noah Severs
+# SPDX-License-Identifier: MIT
+"""Production runs as records of what actually happened: cost flows from the quantities the run
+really issued and received, not from the recipe's planned figures.
+
+Every run produces its output as a discrete lot (like a received purchase), so fungible items carry
+a true weighted-average cost across batches. Completion re-costs those lots to the run's actual
+output cost, and the completion journal entry reconciles against the sum of the lots it created.
+"""
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from sqlalchemy import select
+
+from celerp.models.company import Company, User
+from celerp.models.ledger import LedgerEntry
+
+
+async def _register(client, email: str | None = None) -> str:
+    addr = email or f"admin-{uuid.uuid4().hex[:8]}@mfg.test"
+    r = await client.post("/auth/register", json={"company_name": "Run Co", "email": addr, "name": "Admin", "password": "pw"})
+    assert r.status_code == 200, r.text
+    return r.json()["access_token"]
+
+
+def _h(token: str) -> dict:
+    return {"Authorization": f"Bearer {token}"}
+
+
+async def _item(client, token, sku, **kw) -> str:
+    body = {"sku": sku, "name": sku, "quantity": kw.pop("quantity", 0), "sell_by": "piece",
+            "status": kw.pop("status", "available"), **kw}
+    r = await client.post("/items", headers=_h(token), json=body)
+    assert r.status_code == 200, r.text
+    return r.json()["id"]
+
+
+async def _recipe(client, token, item_id, components) -> None:
+    r = await client.put(f"/manufacturing/items/{item_id}/recipe", headers=_h(token),
+                         json={"output_qty": 1, "components": components, "labor": [], "overhead": []})
+    assert r.status_code == 200, r.text
+
+
+async def _build(client, token, item_id, quantity, complete=False) -> str:
+    r = await client.post(f"/manufacturing/items/{item_id}/build", headers=_h(token),
+                          json={"quantity": quantity, "complete": complete})
+    assert r.status_code == 200, r.text
+    return r.json()["id"]
+
+
+async def _issue(client, token, run, items=None):
+    body = {"items": items} if items is not None else {}
+    return await client.post(f"/manufacturing/{run}/issue", headers=_h(token), json=body)
+
+
+def _balanced(entries: list[dict]) -> None:
+    d = sum(float(x.get("debit", 0) or 0) for x in entries)
+    c = sum(float(x.get("credit", 0) or 0) for x in entries)
+    assert abs(d - c) < 1e-6, entries
+
+
+async def _completion_entries(client, token, run) -> list[dict]:
+    led = (await client.get("/ledger?entity_type=journal_entry", headers=_h(token))).json()["items"]
+    je = next(e for e in led if (e["data"].get("memo") or "") == f"Auto JE for {run} completion")
+    return je["data"]["entries"]
+
+
+def _input_relief(entries: list[dict]) -> float:
+    return next(float(x["credit"]) for x in entries if x["account"] == "1130-P" and float(x.get("credit") or 0) > 0)
+
+
+def _output_cap(entries: list[dict]) -> float:
+    return next((float(x["debit"]) for x in entries if x["account"] == "1130-P" and float(x.get("debit") or 0) > 0), 0.0)
+
+
+def _waste_leg(entries: list[dict]) -> float:
+    return next((float(x["debit"]) for x in entries if x["account"] == "5100" and float(x.get("debit") or 0) > 0), 0.0)
+
+
+async def _lots(client, token, run) -> list[dict]:
+    items = (await client.get("/items", headers=_h(token))).json()["items"]
+    return [i for i in items if i.get("manufacturing_order_id") == run and i.get("lot") is True]
+
+
+async def _actors(session):
+    company = (await session.execute(select(Company))).scalars().first()
+    user = (await session.execute(select(User))).scalars().first()
+    return company.id, user
+
+
+# ---------------------------------------------------------------------------
+# Input cost = what was actually issued
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_input_cost_uses_issued(client):
+    """The completion input relief reflects the components actually issued, not the recipe plan;
+    with nothing issued it falls back to the planned figure so a bare run still costs something."""
+    token = await _register(client)
+    gold = await _item(client, token, "GOLD1", quantity=1000, cost_total=80000)  # unit 80
+    ring = await _item(client, token, "RING1", quantity=0)
+    await _recipe(client, token, ring, [{"item_id": gold, "quantity": 5}])  # planned 10 for a build of 2
+
+    run = await _build(client, token, ring, 2)
+    assert (await _issue(client, token, run, [{"item_id": gold, "quantity": 6}])).status_code == 200
+    assert (await client.post(f"/manufacturing/{run}/receive", headers=_h(token))).status_code == 200  # auto-completes
+    assert _input_relief(await _completion_entries(client, token, run)) == pytest.approx(6 * 80)
+
+    bare = await _build(client, token, ring, 2)
+    assert (await client.post(f"/manufacturing/{bare}/receive", headers=_h(token))).status_code == 200
+    assert _input_relief(await _completion_entries(client, token, bare)) == pytest.approx(10 * 80)
+
+
+# ---------------------------------------------------------------------------
+# Output unit cost = run cost / quantity actually received
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_output_unit_cost_actual_received(client):
+    """Over-yield: receiving more than the planned output spreads the same input cost over the
+    real quantity, so the lot's total cost equals the run input and its unit cost drops."""
+    token = await _register(client)
+    gold = await _item(client, token, "GOLD2", quantity=1000, cost_total=80000)  # unit 80
+    ring = await _item(client, token, "RING2", quantity=0, allow_splitting=False)
+    await _recipe(client, token, ring, [{"item_id": gold, "quantity": 5}])  # planned 50 for a build of 10
+
+    run = await _build(client, token, ring, 10)
+    assert (await _issue(client, token, run)).status_code == 200  # 50 gold -> input 4000
+    assert (await client.post(f"/manufacturing/{run}/receive", headers=_h(token),
+                              json={"quantity": 12})).status_code == 200  # over-yield, auto-completes
+
+    lots = await _lots(client, token, run)
+    assert len(lots) == 1
+    lot = lots[0]
+    assert lot["quantity"] == 12
+    assert float(lot["cost_total"]) == pytest.approx(4000, abs=0.05)  # not 12 * (4000/10)
+
+
+# ---------------------------------------------------------------------------
+# Every output is a discrete lot at actual cost, fungible included
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_fungible_output_creates_lot_at_actual_cost(client):
+    """A splittable (fungible) product no longer folds into a single SKU pile: each run yields its
+    own lot carrying that run's actual cost, leaving the catalog product itself at zero on-hand."""
+    token = await _register(client)
+    gold = await _item(client, token, "GOLD3", quantity=1000, cost_total=80000)  # unit 80
+    ring = await _item(client, token, "RING3", quantity=0)  # splittable by default
+    await _recipe(client, token, ring, [{"item_id": gold, "quantity": 5}])
+
+    run = await _build(client, token, ring, 2, complete=True)  # input 10 * 80 = 800
+
+    lots = await _lots(client, token, run)
+    assert len(lots) == 1
+    lot = lots[0]
+    assert lot["parent_item_id"] == ring and lot["quantity"] == 2
+    assert float(lot["cost_total"]) == pytest.approx(800, abs=0.05)
+    assert (await client.get(f"/items/{ring}", headers=_h(token))).json()["quantity"] == 0
+
+
+@pytest.mark.asyncio
+async def test_fungible_sale_cogs_actual_lot_cost(client):
+    """Two fungible runs at different actual costs create two lots; a sale draws them FIFO so COGS
+    is the real cost of the specific lots consumed, not a recipe-standard figure."""
+    token = await _register(client)
+    gold = await _item(client, token, "GOLD4", quantity=1000, cost_total=80000)  # unit 80
+    ring = await _item(client, token, "RING4", quantity=0)  # splittable
+    await _recipe(client, token, ring, [{"item_id": gold, "quantity": 5}])
+
+    run_a = await _build(client, token, ring, 2)
+    assert (await _issue(client, token, run_a)).status_code == 200  # input 800
+    assert (await client.post(f"/manufacturing/{run_a}/receive", headers=_h(token))).status_code == 200  # 2 @ 400
+
+    run_b = await _build(client, token, ring, 2)
+    assert (await _issue(client, token, run_b)).status_code == 200  # input 800
+    assert (await client.post(f"/manufacturing/{run_b}/receive", headers=_h(token),
+                              json={"quantity": 4})).status_code == 200  # over-yield, 4 @ 200
+
+    lot_a = (await _lots(client, token, run_a))[0]["id"]
+    doc = await _create_and_finalize_invoice(client, token, [
+        {"sku": "RING4", "name": "RING4", "quantity": 3, "unit_price": 10.0, "entity_id": lot_a},
+    ])
+    r = await client.post(f"/docs/{doc}/fulfill-lines", headers=_h(token), json={"line_entity_ids": [lot_a]})
+    assert r.status_code == 200, r.text
+    assert (await _fulfilled_cogs(client, token, doc)) == pytest.approx(2 * 400 + 1 * 200)  # 1000
+
+
+# ---------------------------------------------------------------------------
+# actual_outputs is honored by _close_run
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_close_run_honors_actual_outputs(client):
+    """Completing with an explicit actual_outputs records that yield on the run, rather than echoing
+    the recipe's expected output back as the actual."""
+    token = await _register(client)
+    gold = await _item(client, token, "GOLD5", quantity=1000, cost_total=80000)
+    ring = await _item(client, token, "RING5", quantity=0)
+    await _recipe(client, token, ring, [{"item_id": gold, "quantity": 5}])
+
+    run = await _build(client, token, ring, 10)
+    assert (await _issue(client, token, run)).status_code == 200
+    r = await client.post(f"/manufacturing/{run}/complete", headers=_h(token),
+                          json={"actual_outputs": [{"sku": "RING5", "name": "RING5", "quantity": 7}]})
+    assert r.status_code == 200, r.text
+    state = (await client.get(f"/manufacturing/{run}", headers=_h(token))).json()
+    assert float(state["actual_outputs"][0]["quantity"]) == 7
+
+
+# ---------------------------------------------------------------------------
+# Completion JE reconciles with the lots it created (end to end, through a sale)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_completion_je_reconciles_with_lots(client, session):
+    """Multi-receipt run: the completion journal entry's output cost equals the sum of the lot costs
+    it produced, and selling all of them relieves exactly that cost as COGS. Nothing is stranded."""
+    token = await _register(client)
+    gold = await _item(client, token, "GOLD6", quantity=1000, cost_total=80000)  # unit 80
+    ring = await _item(client, token, "RING6", quantity=0)  # splittable
+    await _recipe(client, token, ring, [{"item_id": gold, "quantity": 5}])  # planned 50 for a build of 10
+
+    run = await _build(client, token, ring, 10)
+    assert (await _issue(client, token, run)).status_code == 200  # input 4000
+    assert (await client.post(f"/manufacturing/{run}/receive", headers=_h(token),
+                              json={"quantity": 6})).status_code == 200
+    assert (await client.post(f"/manufacturing/{run}/receive", headers=_h(token),
+                              json={"quantity": 6})).status_code == 200  # total 12, over-yield, auto-completes
+
+    lots = await _lots(client, token, run)
+    assert len(lots) == 2
+    lots_total = sum(float(l["cost_total"]) for l in lots)
+    entries = await _completion_entries(client, token, run)
+    _balanced(entries)
+    assert lots_total == pytest.approx(4000, abs=0.1)
+    assert _output_cap(entries) == pytest.approx(4000, abs=0.1)
+    assert _input_relief(entries) == pytest.approx(4000, abs=0.1)
+
+    lot_a = sorted(lots, key=lambda l: l["id"])[0]["id"]
+    doc = await _create_and_finalize_invoice(client, token, [
+        {"sku": "RING6", "name": "RING6", "quantity": 12, "unit_price": 10.0, "entity_id": lot_a},
+    ])
+    r = await client.post(f"/docs/{doc}/fulfill-lines", headers=_h(token), json={"line_entity_ids": [lot_a]})
+    assert r.status_code == 200, r.text
+    assert (await _fulfilled_cogs(client, token, doc)) == pytest.approx(4000, abs=0.1)
+
+
+# ---------------------------------------------------------------------------
+# Waste routes to COGS; lots reconcile to input minus waste; boundaries are clamped
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_waste_to_cogs_and_reconcile(client):
+    """Declared waste at completion posts to COGS and the lots reconcile to input cost minus waste,
+    so the output inventory carries only the cost of what was kept."""
+    token = await _register(client)
+    gold = await _item(client, token, "GOLD7", quantity=1000, cost_total=80000)  # unit 80
+    ring = await _item(client, token, "RING7", quantity=0)  # splittable
+    await _recipe(client, token, ring, [{"item_id": gold, "quantity": 5}])  # planned 50 for a build of 10
+
+    run = await _build(client, token, ring, 10)
+    assert (await _issue(client, token, run)).status_code == 200  # input 4000
+    r = await client.post(f"/manufacturing/{run}/complete", headers=_h(token), json={"waste_quantity": 5})
+    assert r.status_code == 200, r.text
+
+    entries = await _completion_entries(client, token, run)
+    _balanced(entries)
+    assert _waste_leg(entries) == pytest.approx(400)  # 4000 * 5/50
+    assert _output_cap(entries) == pytest.approx(3600)
+    assert sum(float(l["cost_total"]) for l in await _lots(client, token, run)) == pytest.approx(3600, abs=0.1)
+
+
+@pytest.mark.asyncio
+async def test_waste_over_input_clamped(client):
+    """Negative waste is rejected outright, and waste exceeding the input cost is clamped so the
+    completion entry can never go unbalanced or drive output cost below zero."""
+    token = await _register(client)
+    gold = await _item(client, token, "GOLD8", quantity=1000, cost_total=80000)  # unit 80
+    ring = await _item(client, token, "RING8", quantity=0)
+    await _recipe(client, token, ring, [{"item_id": gold, "quantity": 5}])
+
+    neg = await _build(client, token, ring, 2)
+    assert (await _issue(client, token, neg)).status_code == 200
+    assert (await client.post(f"/manufacturing/{neg}/complete", headers=_h(token),
+                              json={"waste_quantity": -1})).status_code == 422
+
+    over = await _build(client, token, ring, 2)
+    assert (await _issue(client, token, over)).status_code == 200  # input 800
+    assert (await client.post(f"/manufacturing/{over}/complete", headers=_h(token),
+                              json={"waste_quantity": 1000})).status_code == 200
+    entries = await _completion_entries(client, token, over)
+    _balanced(entries)
+    assert _output_cap(entries) == pytest.approx(0)
+    assert _waste_leg(entries) == pytest.approx(800)  # clamped to input cost
+
+
+# ---------------------------------------------------------------------------
+# Idempotency: a re-submitted receipt or a repeated close does not double up
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_receive_idempotent_on_double_submit(client):
+    """A partial receipt re-submitted with the same idempotency key produces one lot and counts the
+    quantity once, so a retried network request never creates a phantom second lot."""
+    token = await _register(client)
+    gold = await _item(client, token, "GOLD9", quantity=1000, cost_total=80000)
+    ring = await _item(client, token, "RING9", quantity=0, allow_splitting=False)
+    await _recipe(client, token, ring, [{"item_id": gold, "quantity": 5}])
+
+    run = await _build(client, token, ring, 10)
+    assert (await _issue(client, token, run)).status_code == 200
+    body = {"quantity": 3, "idempotency_key": "recv-1"}
+    assert (await client.post(f"/manufacturing/{run}/receive", headers=_h(token), json=body)).status_code == 200
+    assert (await client.post(f"/manufacturing/{run}/receive", headers=_h(token), json=body)).status_code == 200
+
+    lots = await _lots(client, token, run)
+    assert len(lots) == 1 and lots[0]["quantity"] == 3
+    assert float((await client.get(f"/manufacturing/{run}", headers=_h(token))).json()["received_qty"]) == 3
+
+
+@pytest.mark.asyncio
+async def test_complete_idempotent_double_call(client, session):
+    """Closing the same run twice emits a single completion event: the deterministic completion key
+    dedups the second call rather than posting a duplicate."""
+    import celerp_manufacturing.routes as mfg
+
+    token = await _register(client)
+    gold = await _item(client, token, "GOLDA", quantity=1000, cost_total=80000)
+    ring = await _item(client, token, "RINGA", quantity=0)
+    await _recipe(client, token, ring, [{"item_id": gold, "quantity": 5}])
+    run = await _build(client, token, ring, 2)
+
+    company_id, user = await _actors(session)
+    row = await mfg._get_order(session, company_id, run)
+    states = await mfg._all_item_states(session, company_id)
+    await mfg._close_run(session, company_id, user, run, row.state, states, None)
+    await mfg._close_run(session, company_id, user, run, row.state, states, None)
+    await session.commit()
+
+    rows = (await session.execute(select(LedgerEntry).where(
+        LedgerEntry.entity_id == run, LedgerEntry.event_type == "mfg.order.completed"))).scalars().all()
+    assert len(rows) == 1
+
+
+@pytest.mark.asyncio
+async def test_complete_zero_received_relieves_actual_input(client, session):
+    """A run closed with components issued but nothing received relieves the actually-issued input
+    cost, creates no lot, and does not divide by a zero received quantity."""
+    import celerp_manufacturing.routes as mfg
+
+    token = await _register(client)
+    gold = await _item(client, token, "GOLDB", quantity=1000, cost_total=80000)  # unit 80
+    ring = await _item(client, token, "RINGB", quantity=0)
+    await _recipe(client, token, ring, [{"item_id": gold, "quantity": 5}])  # planned 10 for a build of 2
+    run = await _build(client, token, ring, 2)
+    assert (await _issue(client, token, run, [{"item_id": gold, "quantity": 6}])).status_code == 200  # actual 480
+
+    company_id, user = await _actors(session)
+    row = await mfg._get_order(session, company_id, run)
+    states = await mfg._all_item_states(session, company_id)
+    await mfg._close_run(session, company_id, user, run, row.state, states, None)
+    await session.commit()
+
+    assert _input_relief(await _completion_entries(client, token, run)) == pytest.approx(6 * 80)
+    assert await _lots(client, token, run) == []
+
+
+# ---------------------------------------------------------------------------
+# Local sale helpers (one company/token, mirrors the fulfillment suite's flow)
+# ---------------------------------------------------------------------------
+
+
+async def _create_and_finalize_invoice(client, token, line_items) -> str:
+    payload = {
+        "doc_type": "invoice",
+        "ref_id": f"RUN-{uuid.uuid4().hex[:6]}",
+        "line_items": line_items,
+        "total": sum(li.get("quantity", 0) * li.get("unit_price", 0) for li in line_items),
+    }
+    r = await client.post("/docs", headers=_h(token), json=payload)
+    assert r.status_code == 200, r.text
+    doc_id = r.json()["id"]
+    r2 = await client.post(f"/docs/{doc_id}/finalize", headers=_h(token))
+    assert r2.status_code == 200, r2.text
+    return doc_id
+
+
+async def _fulfilled_cogs(client, token, doc) -> float:
+    led = (await client.get(f"/ledger?entity_id={doc}", headers=_h(token))).json()["items"]
+    fulfilled = next(e for e in led if e.get("event_type") == "doc.fulfilled")
+    return float(fulfilled["data"].get("total_cogs", 0))

--- a/default_modules/celerp-manufacturing/tests/test_to_make_allocation.py
+++ b/default_modules/celerp-manufacturing/tests/test_to_make_allocation.py
@@ -159,8 +159,9 @@ async def test_make_work_orders_complete_one_tap(client):
     assert len(res["created"]) == 1
     run_id = res["created"][0]["run_id"]
     assert (await client.get(f"/manufacturing/{run_id}", headers=_h(token))).json()["status"] == "completed"
-    # Output restocked, components consumed.
-    assert (await client.get(f"/items/{ring}", headers=_h(token))).json()["quantity"] == 3.0
+    # Output landed as a discrete lot under the product; components consumed.
+    items = (await client.get("/items", headers=_h(token))).json()["items"]
+    assert sum(float(i["quantity"]) for i in items if i.get("sku") == "RC") == 3.0
     assert (await client.get(f"/items/{gold}", headers=_h(token))).json()["quantity"] == 97.0
 
 
@@ -199,7 +200,8 @@ async def test_bulk_run_action_start_then_complete(client):
     completed = (await client.post("/manufacturing/bulk-action", headers=_h(token),
                                    json={"run_ids": [r1, r2], "action": "complete"})).json()
     assert set(completed["done"]) == {r1, r2}
-    assert (await client.get(f"/items/{ring}", headers=_h(token))).json()["quantity"] == 3.0
+    items = (await client.get("/items", headers=_h(token))).json()["items"]
+    assert sum(float(i["quantity"]) for i in items if i.get("sku") == "RB") == 3.0
 
     # Re-completing closed runs is skipped, not an error.
     again = (await client.post("/manufacturing/bulk-action", headers=_h(token),

--- a/default_modules/first_party.lock.json
+++ b/default_modules/first_party.lock.json
@@ -6,10 +6,10 @@
   "celerp-connectors": "50a4a7e40e5d667462b805c4993741edc4125d71be04bbf1abbdaba56ee710b9",
   "celerp-contacts": "899cf9febb388356290f6eb8c8ab6d67f1f92a9c9fa8377ebb6d46bf04cedbc3",
   "celerp-dashboard": "00d2e8d6ef46a3afd5d6caf8434217095aabd40c963bfac19d0e988c714443ce",
-  "celerp-docs": "8b69661d972454099f94fd0f22d0d3ce614bbc6a257effb776fdb12462a56b7b",
-  "celerp-inventory": "0d3b85ddb73ce02a2a97a5e00827435e145bddaae79491a7ad6b7ade88f38c06",
+  "celerp-docs": "9fc3c2434f37a40b7fa86bbfef8b4a32c01fcdb45b899471e96159440a1bc889",
+  "celerp-inventory": "64503e1c3002fca1315929a114ad7ae80d0ce3f4d42ba60c1020a672095f5b1f",
   "celerp-labels": "1175c234602fbc80e20a33a4d03bf7abcc9a7a78d6e83729c73106cb0af53832",
-  "celerp-manufacturing": "5cc089a345eeff66be25db51432481487e699f28c0a545731650843fce81dc01",
+  "celerp-manufacturing": "662c99889b31b25105e5a2251be5a139eb8db961c0399b0fa8795366f3476255",
   "celerp-reports": "f100f83b3fc3e4565685d3a0c8e62dcc724bb35d32238f051b05c5f97ae10d13",
   "celerp-subscriptions": "9c1797ebf9afab23fc834512b7265e7a1739eb1acd5ee70a7273e360453fbc68",
   "celerp-verticals": "f8b8c15e263eb8d61e16c0b8beadfbdfe8e91b76d73882551934c8751242d70d"

--- a/tests/test_browser/test_demand_planning.py
+++ b/tests/test_browser/test_demand_planning.py
@@ -364,8 +364,10 @@ def test_demand_planning_interactions(page, ui_server, api):
     assert _has(lambda o: o.get("output_item_id") == pendant and o.get("status") == "completed"), (
         "No completed run for DP-PENDANT via the 'Make & complete' toolbar action"
     )
-    assert float(api.get(f"/items/{pendant}").json().get("quantity", 0)) > 0, (
-        "DP-PENDANT stock should be > 0 after Make & complete"
+    lots = [i for i in api.get("/items").json()["items"]
+            if i.get("parent_item_id") == pendant and i.get("lot") is True]
+    assert lots and sum(l["quantity"] for l in lots) > 0, (
+        "DP-PENDANT output should land as a discrete lot after Make & complete"
     )
 
 

--- a/tests/test_browser/test_manufacturing_hub.py
+++ b/tests/test_browser/test_manufacturing_hub.py
@@ -86,8 +86,11 @@ def test_product_hub_work_orders_and_action_dropdown(page, ui_server, api):
     done = _poll_run_status(api, run_id, "completed")
     assert done["status"] == "completed"
 
-    # Finished stock went up; the gold component was consumed (5 per ring * 2 = 10 g).
-    assert api.get(f"/items/{ring}").json()["quantity"] == 2.0
+    # Finished output lands as a discrete lot under the ring; the gold component was consumed (5 per ring * 2 = 10 g).
+    assert api.get(f"/items/{ring}").json()["quantity"] == 0.0  # the product row is never the pile
+    lot = next(i for i in api.get("/items").json()["items"]
+               if i.get("parent_item_id") == ring and i.get("lot") is True)
+    assert lot["quantity"] == 2.0  # output received as a discrete lot
     assert api.get(f"/items/{gold}").json()["quantity"] == 90.0
 
 

--- a/tests/test_browser/test_manufacturing_journey.py
+++ b/tests/test_browser/test_manufacturing_journey.py
@@ -154,7 +154,10 @@ def test_full_manufacturing_journey(page, ui_server, api):
 
     assert api.get(f"/manufacturing/{run_id}").json()["status"] == "completed"
     rings = [i for i in api.get("/items").json()["items"] if i.get("sku") == "JNY-RING"]
-    assert len(rings) == 1 and rings[0]["id"] == ring  # restocked in place — one ring item, no clone
+    parent = [i for i in rings if i["id"] == ring]
+    lots = [i for i in rings if i.get("parent_item_id") == ring and i.get("lot") is True]
+    assert len(parent) == 1 and parent[0]["quantity"] == 0  # original product row preserved, never the pile
+    assert len(lots) == 1 and lots[0]["quantity"] > 0  # output lands as exactly one discrete lot
     assert rings[0]["quantity"] == 2.0  # made the 2 demanded
     assert api.get(f"/items/{gold}").json()["quantity"] == 90.0  # 100 - 5*2 issued
 

--- a/tests/test_browser/test_manufacturing_wip.py
+++ b/tests/test_browser/test_manufacturing_wip.py
@@ -116,8 +116,7 @@ def test_wip_bulk_actions_and_priority_funnel(page, ui_server, api):
     page.wait_for_selector("#mfg-table", timeout=8000)
     page.screenshot(path=str(SHOTS / "wip-after-start.png"), full_page=True)
 
-    # ── Bulk Complete via the Action dropdown (accept the confirm) -> completed + stock up ──
-    stock_before = float(api.get(f"/items/{widget}").json().get("quantity", 0))
+    # ── Bulk Complete via the Action dropdown (accept the confirm) -> completed + output lots ──
     page.on("dialog", lambda d: d.accept())
     page.wait_for_selector("#mfg-table:has-text('WIP-WIDGET')", timeout=8000)
     # Tick both runs and confirm "2 selected" actually registered before dispatching Complete. The
@@ -141,11 +140,14 @@ def test_wip_bulk_actions_and_priority_funnel(page, ui_server, api):
     assert _poll(api, lambda items: all(
         o.get("status") == "completed" for o in items if o.get("id") in both
     )), "both runs should be completed after the bulk Complete UI action"
-    # 3 + 5 = 8 widgets produced.
-    assert _poll(api, lambda _items: float(api.get(f"/items/{widget}").json().get("quantity", 0)) > stock_before), \
-        "WIP-WIDGET stock should increase after Complete"
-    assert float(api.get(f"/items/{widget}").json()["quantity"]) >= stock_before + 8, \
-        "WIP-WIDGET stock should rise by the produced quantity (8)"
+    # 3 + 5 = 8 widgets produced, each run's output landing as a discrete lot under the widget.
+    def _lot_total() -> float:
+        return sum(i["quantity"] for i in api.get("/items").json()["items"]
+                   if i.get("parent_item_id") == widget and i.get("lot") is True)
+    assert _poll(api, lambda _items: _lot_total() > 0), \
+        "WIP-WIDGET output should land as discrete lots after Complete"
+    assert _lot_total() >= 8, "produced quantity (8) should land as discrete lots"
+    assert float(api.get(f"/items/{widget}").json()["quantity"]) == 0  # the product row is never the pile
 
     # ── Priority Excel funnel filters live (data-col 3) ──
     page.goto(f"{ui_server}/manufacturing/production?status=completed", wait_until="domcontentloaded")

--- a/tests/test_browser/test_manufacturing_wip.py
+++ b/tests/test_browser/test_manufacturing_wip.py
@@ -145,7 +145,7 @@ def test_wip_bulk_actions_and_priority_funnel(page, ui_server, api):
         return sum(i["quantity"] for i in api.get("/items").json()["items"]
                    if i.get("parent_item_id") == widget and i.get("lot") is True)
     assert _poll(api, lambda _items: _lot_total() > 0), \
-        "WIP-WIDGET output should land as discrete lots after Complete"
+        "widget output should land as discrete lots after Complete"
     assert _lot_total() >= 8, "produced quantity (8) should land as discrete lots"
     assert float(api.get(f"/items/{widget}").json()["quantity"]) == 0  # the product row is never the pile
 

--- a/tests/test_browser/test_run_records_print.py
+++ b/tests/test_browser/test_run_records_print.py
@@ -1,0 +1,57 @@
+# Copyright (c) 2026 Noah Severs. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-Proprietary
+"""Print views for production runs: the worksheet names its components, and a run has its own
+run sheet of the calculated (scaled) input quantities."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.browser
+
+SHOTS = Path("context/reviews/run-records")
+
+
+def test_worksheet_print_names_components(page, ui_server, api):
+    """The worksheet resolves each material's name from the item list, so an imported recipe whose
+    component rows carry only a SKU still prints the readable name next to it."""
+    SHOTS.mkdir(parents=True, exist_ok=True)
+    gold = api.post("/items", json={"sku": "WN-GOLD", "name": "Rose Gold Alloy", "quantity": 100,
+                                    "sell_by": "gram", "cost_total": 8000, "inventory_type": "component"}).json()["id"]
+    ring = api.post("/items", json={"sku": "WN-RING", "name": "Name Ring", "quantity": 0, "sell_by": "piece"}).json()["id"]
+    # The stored recipe row carries sku + unit but no denormalized name (imported-recipe shape).
+    api.put(f"/manufacturing/items/{ring}/recipe", json={
+        "output_qty": 1,
+        "components": [{"item_id": gold, "sku": "WN-GOLD", "quantity": 5, "unit": "gram"}],
+        "labor": [], "overhead": [],
+    })
+
+    page.goto(f"{ui_server}/inventory/{ring}/worksheet/print", wait_until="domcontentloaded")
+    body = page.locator("body").inner_text()
+    assert "WN-GOLD" in body                 # the SKU
+    assert "Rose Gold Alloy" in body         # name resolved from the item list, not the stored recipe row
+    page.screenshot(path=str(SHOTS / "worksheet-names.png"), full_page=True)
+
+
+def test_run_sheet_print_renders_scaled_inputs(page, ui_server, api):
+    """A production run's run sheet prints the calculated input quantities for that run's build size,
+    each row showing SKU and name, under a 'Run - build qty N' header."""
+    SHOTS.mkdir(parents=True, exist_ok=True)
+    gold = api.post("/items", json={"sku": "RS-GOLD", "name": "Yellow Gold", "quantity": 100, "sell_by": "gram",
+                                    "cost_total": 8000, "inventory_type": "component", "status": "available"}).json()["id"]
+    ring = api.post("/items", json={"sku": "RS-RING", "name": "Sheet Ring", "quantity": 0,
+                                    "sell_by": "piece", "status": "available"}).json()["id"]
+    api.put(f"/manufacturing/items/{ring}/recipe", json={
+        "output_qty": 1,
+        "components": [{"item_id": gold, "sku": "RS-GOLD", "quantity": 5, "unit": "gram"}],
+        "labor": [], "overhead": [],
+    })
+    run = api.post(f"/manufacturing/items/{ring}/build", json={"quantity": 3}).json()["id"]  # planned 15 gold
+
+    page.goto(f"{ui_server}/manufacturing/{run}/run-sheet/print", wait_until="domcontentloaded")
+    body = page.locator("body").inner_text()
+    assert "Run - build qty 3" in body
+    assert "RS-GOLD" in body and "Yellow Gold" in body
+    assert "15" in body                      # 5 per unit scaled by the build of 3
+    page.screenshot(path=str(SHOTS / "run-sheet.png"), full_page=True)

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -23,7 +23,7 @@ def test_event_type_values() -> None:
     assert EventType.ITEM_TRANSFORM == "item.transform"
     assert EventType.ITEM_TRANSFORMED_FROM == "item.transformed_from"
     # Spot-check total count
-    assert len(EventType) == 110
+    assert len(EventType) == 111
 
 
 def test_log_level_default_is_info() -> None:

--- a/tests/test_routers/test_user_journeys.py
+++ b/tests/test_routers/test_user_journeys.py
@@ -1175,7 +1175,7 @@ async def test_wf_manufacturing_full_cycle(client):
     await client.put(f"/manufacturing/items/{fg_id}/recipe", headers=h,
                      json={"output_qty": 2, "components": [{"item_id": raw_id, "quantity": 5}], "labor": [], "overhead": []})
 
-    # Build 2 of the finished good, then issue components and complete (restocks the FG in place).
+    # Build 2 of the finished good, then issue components and complete (output lands as a discrete lot under the FG).
     oid = (await client.post(f"/manufacturing/items/{fg_id}/build", headers=h, json={"quantity": 2})).json()["id"]
     assert (await client.post(f"/manufacturing/{oid}/issue", headers=h)).status_code == 200
     assert (await client.post(f"/manufacturing/{oid}/complete", headers=h, json={})).status_code == 200
@@ -1187,7 +1187,10 @@ async def test_wf_manufacturing_full_cycle(client):
     assert raw_state["quantity"] == 15  # 20 - 5
 
     fg = (await client.get(f"/items/{fg_id}", headers=h)).json()
-    assert fg["sku"] == "FG-WF" and fg["quantity"] == 2  # restocked in place
+    assert fg["sku"] == "FG-WF" and fg["quantity"] == 0  # the product row is never the pile
+    items = (await client.get("/items", headers=h)).json()["items"]
+    lot = next(i for i in items if i.get("parent_item_id") == fg_id and i.get("lot") is True)
+    assert lot["sku"] == "FG-WF" and lot["quantity"] == 2  # output received as a discrete lot
 
 
 

--- a/ui/api_client.py
+++ b/ui/api_client.py
@@ -1172,6 +1172,12 @@ async def list_mfg_orders(token: str, params: dict | None = None) -> dict:
         return _raise(await c.get("/manufacturing", params=params or {})).json()
 
 
+async def get_mfg_order(token: str, order_id: str) -> dict:
+    """A single production run (raises 404 through APIError for an unknown id)."""
+    async with _api_client(token) as c:
+        return _raise(await c.get(f"/manufacturing/{order_id}")).json()
+
+
 async def manufacturing_to_make(token: str) -> dict:
     async with _api_client(token) as c:
         return _raise(await c.get("/manufacturing/to-make")).json()

--- a/ui/api_client.py
+++ b/ui/api_client.py
@@ -1245,7 +1245,7 @@ async def issue_mfg_order(token: str, order_id: str, items: list[dict] | None = 
 
 
 async def receive_mfg_order(token: str, order_id: str, quantity: float | None = None) -> dict:
-    """Receive finished goods from a run (restocks per allow_splitting). None = receive all remaining."""
+    """Receive finished goods from a run as a discrete lot. None = receive all remaining."""
     async with _api_client(token) as c:
         return _raise(await c.post(f"/manufacturing/{order_id}/receive", json={"quantity": quantity})).json()
 

--- a/ui/routes/documents.py
+++ b/ui/routes/documents.py
@@ -228,7 +228,12 @@ def _consolidate_sales_lots(items: list[dict], company_settings: dict) -> list[d
             out.extend(group)  # unique / non-splittable -> keep each lot (labeled)
             continue
         method = resolve_pick_method(group[0], company_settings)
-        rep = dict(_sorted_inventory(group, method)[0])  # bind the pick-first lot
+        sorted_lots = _sorted_inventory(group, method)
+        stocked = [g for g in sorted_lots if float(g.get("quantity") or 0) > 0]
+        # Bind the pick-first lot WITH stock; a lot-only product's catalog row sits at qty 0, and
+        # binding that empty row makes fulfillment reject the line despite in-stock sibling lots.
+        # Fall back to the pick-first row only when every lot is empty (genuine out of stock).
+        rep = dict((stocked or sorted_lots)[0])
         rep["quantity"] = sum(float(g.get("quantity") or 0) for g in group)  # aggregate on-hand
         out.append(rep)
     return out

--- a/ui/routes/inventory.py
+++ b/ui/routes/inventory.py
@@ -6381,6 +6381,8 @@ body { font-family: Arial, sans-serif; font-size: 10pt; color: #111; background:
 table.ws-tbl { width: 100%; border-collapse: collapse; font-size: 9pt; }
 .ws-tbl th, .ws-tbl td { border: 1px solid #ccc; padding: 1.6mm 2.6mm; text-align: left; vertical-align: top; }
 .ws-tbl th { background: #f2f2f2; }
+.ws-tbl th:not(.ws-num) { text-align: center; }
+.ws-tbl th.ws-num, .ws-tbl td.ws-num { text-align: right; }
 .ws-num { text-align: right; font-variant-numeric: tabular-nums; white-space: nowrap; }
 .ws-pre { white-space: pre-wrap; }
 .ws-images { display: flex; flex-wrap: wrap; gap: 4mm; }
@@ -6503,6 +6505,52 @@ def _worksheet_print_view(entity_id: str, item: dict, items: list[dict], today: 
             materials,
             workflow,
             Div(Span(f"{sku} - {name}"), Span("Powered by celerp.com"), cls="ws-foot"),
+            Script("window.onload = function() { window.print(); }"),
+        ),
+    )
+
+
+def _run_sheet_print_view(order: dict, items: list[dict], today: str) -> FT:
+    """Standalone printable run sheet: a production run's calculated (scaled) input quantities.
+    Reuses the worksheet's print shell, CSS and auto-print. Costs never appear here - it is a
+    shop-floor pick list for one run, so it shows required vs issued-to-date quantity only."""
+    EM = EMPTY
+    by_id = {(it.get("id") or it.get("entity_id") or ""): it for it in items}
+    outs = order.get("expected_outputs") or [{}]
+    build_qty = float(outs[0].get("quantity") or 0)
+    inputs = order.get("inputs") or []
+
+    def _row(inp: dict) -> FT:
+        it = by_id.get(inp.get("item_id") or "") or {}
+        return Tr(
+            Td(it.get("sku") or inp.get("item_id") or EM),
+            Td(it.get("name") or EM),
+            Td(f"{float(inp.get('quantity') or 0):g}", cls="ws-num"),
+            Td(f"{float(inp.get('issued_qty') or 0):g}", cls="ws-num"),
+        )
+
+    table = Table(
+        Thead(Tr(Th("SKU"), Th("Name"), Th("Required", cls="ws-num"), Th("Issued", cls="ws-num"))),
+        Tbody(*[_row(inp) for inp in inputs]),
+        cls="ws-tbl",
+    ) if inputs else P("No inputs on this run.", cls="ws-muted")
+
+    title = f"Run - build qty {build_qty:g}"
+    return Html(
+        Head(
+            Meta(charset="utf-8"),
+            Meta(name="viewport", content="width=device-width, initial-scale=1"),
+            Title(title),
+            Style(_WORKSHEET_PRINT_CSS),
+        ),
+        Body(
+            Div(
+                Div(Div(title, cls="ws-title"), cls="ws-headl"),
+                Div(Div("Run Sheet"), Div(today, cls="ws-muted"), cls="ws-meta"),
+                cls="ws-header",
+            ),
+            Div(H2("Inputs"), table, cls="ws-section"),
+            Div(Span(title), Span("Powered by celerp.com"), cls="ws-foot"),
             Script("window.onload = function() { window.print(); }"),
         ),
     )

--- a/ui/routes/inventory.py
+++ b/ui/routes/inventory.py
@@ -2331,8 +2331,9 @@ function celerpPrintLabel(entityId, templateId) {
             item = await api.get_item(token, entity_id)
         except APIError as e:
             return P(str(e.detail), cls="cell-error")
+        items = (await api.list_items(token, {"limit": 1000, "status": "all"})).get("items", [])
         today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
-        return HTMLResponse(to_xml(_worksheet_print_view(entity_id, item, today)))
+        return HTMLResponse(to_xml(_worksheet_print_view(entity_id, item, items, today)))
 
     @app.post("/api/items/{entity_id}/gallery-hero/{file_id}")
     async def gallery_set_hero(request: Request, entity_id: str, file_id: str):
@@ -6396,12 +6397,21 @@ def _worksheet_unit_label(unit: str) -> str:
     return {"min": "min", "hr": "hr", "day": "day"}.get(unit, unit or "min")
 
 
-def _worksheet_print_view(entity_id: str, item: dict, today: str) -> FT:
+def _component_label(c: dict, by_id: dict[str, dict]) -> str:
+    """SKU plus name for a recipe component. Imported-recipe rows carry only a SKU, so the name
+    is resolved from the item list at render; an item that no longer exists shows its SKU alone."""
+    sku = c.get("sku") or c.get("item_id") or ""
+    name = c.get("name") or (by_id.get(c.get("item_id") or "") or {}).get("name") or ""
+    return f"{sku} - {name}".strip(" -") or EMPTY
+
+
+def _worksheet_print_view(entity_id: str, item: dict, items: list[dict], today: str) -> FT:
     """Standalone printable production worksheet: product info + images + materials + workflow.
     Costs never appear here — this is a shop-floor build sheet, not a costing document. Mirrors
     the document print view (auto window.print(); the browser saves it as one PDF)."""
     recipe = item.get("recipe") or {}
     EM = EMPTY
+    by_id = {(it.get("id") or it.get("entity_id") or ""): it for it in items}
 
     # ── Product images ──
     images = _item_image_files(item)
@@ -6422,7 +6432,7 @@ def _worksheet_print_view(entity_id: str, item: dict, today: str) -> FT:
             Table(
                 Thead(Tr(Th("Component"), Th("Qty", cls="ws-num"), Th("Unit"))),
                 Tbody(*[Tr(
-                    Td(f"{c.get('sku') or ''} {('- ' + c['name']) if c.get('name') else ''}".strip(" -") or EM),
+                    Td(_component_label(c, by_id)),
                     Td(f"{float(c.get('quantity') or 0):g}", cls="ws-num"),
                     Td(c.get("unit") or EM),
                 ) for c in comps]),

--- a/ui/routes/manufacturing.py
+++ b/ui/routes/manufacturing.py
@@ -139,6 +139,8 @@ def _order_row(order: dict, today: str = "") -> FT:
         Td(format_value((order.get("created_at") or "")[:10])),
         Td(str(len(inputs)), cls="cell--number"),
         Td(src_cell),
+        Td(A("Run sheet", href=f"/manufacturing/{rid}/run-sheet/print", target="_blank",
+             cls="btn btn--xs btn--secondary"), cls="cell--actions"),
         cls="data-row",
     )
 
@@ -267,7 +269,7 @@ def _order_table(orders: list[dict], today: str = "") -> FT:
                 cls="col-checkbox"),
             filter_th("Product", 1), Th(t("th.status")), filter_th("Priority", 3, center=True),
             Th("Due", cls="cell--center"), Th(t("msg.created")), Th(t("th.inputs"), cls="cell--number"),
-            Th("Source order"),
+            Th("Source order"), Th("Run sheet", cls="cell--actions"),
         )),
         Tbody(*[_order_row(o, today) for o in _sched_sort(orders)]),
         cls="data-table",
@@ -578,6 +580,25 @@ def setup_routes(app):
             nav_active="manufacturing",
             request=request,
         )
+
+    @app.get("/manufacturing/{order_id}/run-sheet/print")
+    async def run_sheet_print(request: Request, order_id: str):
+        """Standalone printable run sheet: one production run's calculated (scaled) input quantities
+        (auto window.print(); the user saves it as a PDF). Reuses the worksheet print shell."""
+        from ui.routes.inventory import _run_sheet_print_view
+
+        token = _token(request)
+        if not token:
+            return RedirectResponse("/login", status_code=302)
+        try:
+            order = await api.get_mfg_order(token, order_id)
+        except APIError as e:
+            if e.status == 401:
+                return RedirectResponse("/login", status_code=302)
+            return HTMLResponse(str(e.detail), status_code=e.status or 404)
+        items = (await api.list_items(token, {"limit": 1000, "status": "all"})).get("items", [])
+        today = date.today().isoformat()
+        return HTMLResponse(to_xml(_run_sheet_print_view(order, items, today)))
 
     @app.get("/manufacturing/to-make-search")
     async def to_make_search(request: Request):


### PR DESCRIPTION
Production run costing now follows what actually happened on the run instead of the recipe's planned figures.

- Run input cost is the value of the components actually issued to the run, and output unit cost is the run cost divided by the quantity actually received. An over-yield lowers the unit cost and an under-yield raises it, so inventory and cost of sales carry the real cost of each batch.
- Every run receives its output as a discrete lot under its product, the same way a purchase or consignment receipt does. The lot carries its own actual cost, and completing the run trues each of the run's lots up so they reconcile exactly to the completion entry. A product's on-hand and its cost of sales are read from those lots.
- Completing a run now honours the quantities you actually received rather than the planned yield, and a run that issued materials but received nothing still relieves the issued cost cleanly.

The recipe stays the reference for planning and pricing; the run is the record of what actually happened.

Two smaller improvements to production paperwork:

- The printed production worksheet shows each material's name next to its SKU, so a sheet is readable even when a recipe was imported without denormalised names.
- A production run has a Print run sheet action that prints the run's calculated input quantities for its build size, rather than only the recipe's per-batch amounts.
