### PR TITLE
Reserve the invoiced quantity only, unify the Allow Splitting default, and post COGS at invoice issue

### DIFF
--- a/celerp/main.py
+++ b/celerp/main.py
@@ -281,6 +281,22 @@ async def lifespan(_app: FastAPI):
             "may show their status without a document link until a later boot"
         )
 
+    # One-time backfill: post the missing COGS JE for invoices finalized before
+    # COGS moved into the finalize JE and never fulfilled since. Marker-gated
+    # (runs once; retries stragglers while any doc is locked or errored);
+    # non-fatal like the backfill above.
+    try:
+        from celerp.db import SessionLocal as _CogsSession
+        from celerp.services.cogs_backfill import run_cogs_backfill
+        async with _CogsSession() as _cogs_sess:
+            await run_cogs_backfill(_cogs_sess)
+            await _cogs_sess.commit()
+    except Exception:
+        logging.getLogger(__name__).exception(
+            "COGS backfill failed (non-fatal); affected invoices keep their "
+            "missing COGS until a later boot retries"
+        )
+
     # Bring up the relay tunnel per the lazy free-tier lifecycle (3.1). A token-holder
     # is past first activation and never re-enters it. Paid instances (public_url set)
     # keep the tunnel always-on; a free instance opens it at boot only when it already

--- a/celerp/routers/doctor.py
+++ b/celerp/routers/doctor.py
@@ -426,33 +426,19 @@ async def _check_legacy_item_prices(
 async def _emit_finalize_je(
     session: AsyncSession, company_id, user_id, doc_id: str, state: dict,
 ) -> None:
-    total = float(state.get("total", 0) or 0)
-    subtotal = float(state.get("subtotal", total) or total)
-    tax = float(state.get("tax", 0) or 0)
-    ts = state.get("issue_date") or state.get("created_at") or state.get("finalized_at")
+    """Delegate to auto_je.create_for_doc_finalized for DRY compliance.
 
-    je_id = f"je:auto:{doc_id}:fin"
-    entries = [
-        {"account": "1120", "debit": total, "credit": 0.0},
-        {"account": "4100", "debit": 0.0, "credit": subtotal},
-    ]
-    if tax > 0:
-        entries.append({"account": "2120", "debit": 0.0, "credit": tax})
+    A repaired invoice gets the same JE a live finalize posts - revenue, tax,
+    and the COGS pair - in the company's base currency.
+    """
+    from celerp.models.company import Company
+    from celerp.services import auto_je as _auto_je
 
-    await emit_event(
-        session, company_id=company_id, entity_id=je_id,
-        entity_type="journal_entry", event_type="acc.journal_entry.created",
-        data={"memo": f"Auto JE for {doc_id} finalized", "entries": entries, "ts": ts},
-        actor_id=user_id, location_id=None, source="auto_je",
-        idempotency_key=je_idempotency_key(doc_id, "invoice.finalized", "c"),
-        metadata_={"trigger": "doc.finalized", "doc_id": doc_id},
-    )
-    await emit_event(
-        session, company_id=company_id, entity_id=je_id,
-        entity_type="journal_entry", event_type="acc.journal_entry.posted",
-        data={}, actor_id=user_id, location_id=None, source="auto_je",
-        idempotency_key=je_idempotency_key(doc_id, "invoice.finalized", "p"),
-        metadata_={"trigger": "doc.finalized", "doc_id": doc_id},
+    company = await session.get(Company, company_id)
+    base_currency = (company.settings.get("currency", "USD") if company else "USD")
+    await _auto_je.create_for_doc_finalized(
+        session, company_id=company_id, user_id=user_id, doc_id=doc_id,
+        doc=state, base_currency=base_currency,
     )
 
 

--- a/celerp/services/auto_je.py
+++ b/celerp/services/auto_je.py
@@ -10,12 +10,16 @@ duplicate JEs regardless of trigger source (API, import, doctor repair).
 from __future__ import annotations
 
 import uuid
+from dataclasses import dataclass, field
 from decimal import Decimal as _Dec
 
 from celerp.events.engine import emit_event
 from celerp.models.projections import Projection
 from celerp.services.je_keys import je_idempotency_key, je_void_data
+from celerp.services.line_measures import splitting_allowed
 from celerp.services.money import round_money, to_base, to_decimal, to_stored_float
+from celerp.services.pick import plan_lot_draws, resolve_pick_method
+from celerp.services.units import is_non_stock_line
 from sqlalchemy import select as _select
 
 # Canonical goods-inventory account. Every goods movement - purchase/receive, bill, manufacturing,
@@ -109,18 +113,108 @@ async def _emit_auto_posted_je(
     )
 
 
-async def compute_doc_cogs(session, company_id, doc: dict) -> float:
-    """Sum COGS for a document's stock lines at posting time.
+@dataclass
+class CogsResult:
+    """COGS for a document with its per-line lot allocation.
 
-    Per stock line the per-unit cost is the parcel's cost_total spread over its own
-    quantity (cost_total / parcel_qty) when that quantity is positive, and the parcel
-    cost_price otherwise, so a partially-invoiced line costs only the quantity it draws
-    rather than the whole parcel. Each line's contribution is clamped at zero so one
-    mis-costed parcel cannot cancel correctly-costed lines; non-stock and zero-quantity
-    lines contribute nothing.
+    ``allocations`` is keyed by the line's index in doc["line_items"] as a
+    string (JSON metadata round-trips string keys). Each entry carries the lots
+    the line prices at (lot_entity_id, qty, unit_cost), the provisional_qty no
+    lot could cover (priced at the bound lot's unit cost), and the line's total
+    amount. ``ambiguous`` is True when at least one splittable line exceeds its
+    bound lot, so bound-lot-only pricing is a guess rather than an exact cost.
     """
-    total_cogs = 0.0
-    for li in doc.get("line_items", []):
+    total: float = 0.0
+    allocations: dict[str, dict] = field(default_factory=dict)
+    ambiguous: bool = False
+
+
+def _lot_unit_cost(state: dict) -> float:
+    """A lot's per-unit cost: cost_total spread over its own quantity when that
+    quantity is positive, the lot's cost_price otherwise."""
+    cost_total = state.get("cost_total")
+    qty = float(state.get("quantity") or 0)
+    if cost_total is not None and qty > 0:
+        return float(cost_total) / qty
+    return float(state.get("cost_price") or 0)
+
+
+async def _span_line_lots(
+    session, company_id, primary_proj, needed: float, doc_id: str | None,
+) -> tuple[list[dict], float, float]:
+    """Resolve a spanning line's draws across the SKU's sibling lots.
+
+    Eligible siblings: same company, item entity, same SKU, positive quantity,
+    and either available or reserved by doc_id (this document's own hold).
+    Draw order is the bound lot first, then the effective pick method. Returns
+    (lots, provisional_qty, amount); the shortfall no lot covers is priced
+    provisionally at the bound lot's unit cost.
+    """
+    from celerp.models.company import Company
+
+    sku = str(primary_proj.state.get("sku") or "").strip()
+    company = await session.get(Company, company_id)
+    method = resolve_pick_method(primary_proj.state, (company.settings or {}) if company else {})
+
+    def _lot(entity_id: str, created_at, state: dict) -> dict:
+        return {
+            "entity_id": entity_id,
+            "quantity": float(state.get("quantity") or 0),
+            "created_at": created_at.isoformat() if created_at else "",
+            "expires_at": state.get("expires_at"),
+            "unit_cost": _lot_unit_cost(state),
+        }
+
+    rows = (await session.execute(_select(Projection).where(
+        Projection.company_id == company_id, Projection.entity_type == "item"))).scalars().all()
+    siblings: list[dict] = []
+    for r in rows:
+        if r.entity_id == primary_proj.entity_id:
+            continue
+        s = r.state or {}
+        if str(s.get("sku") or "").strip() != sku:
+            continue
+        if float(s.get("quantity") or 0) <= 1e-9:
+            continue
+        status = s.get("status") or "available"
+        if not (status == "available"
+                or (status == "reserved" and doc_id is not None and s.get("status_doc_id") == doc_id)):
+            continue
+        siblings.append(_lot(r.entity_id, r.created_at, s))
+
+    primary = _lot(primary_proj.entity_id, primary_proj.created_at, primary_proj.state)
+    draws, short_qty = plan_lot_draws(primary, needed, siblings, method)
+    lots = [{"lot_entity_id": lot["entity_id"], "qty": take, "unit_cost": lot["unit_cost"]}
+            for lot, take, _is_full in draws]
+    amount = sum(take * lot["unit_cost"] for lot, take, _is_full in draws)
+    if short_qty > 1e-9:
+        amount += short_qty * primary["unit_cost"]
+    return lots, short_qty, amount
+
+
+async def compute_doc_cogs(
+    session, company_id, doc: dict, *, span_lots: bool = False, doc_id: str | None = None,
+) -> CogsResult:
+    """Cost a document's stock lines at posting time, lot by lot.
+
+    Each line prices at the specific lots it draws (specific identification by
+    lot). A splittable line whose quantity exceeds its bound lot is flagged
+    ambiguous: the remainder physically comes from sibling lots at their own
+    costs, so extrapolating the bound lot's unit cost is a guess.
+
+    span_lots=False prices the whole line at the bound lot's unit cost (the
+    historical extrapolation) and leaves the ambiguity to the caller - the
+    backfill refuses to post a guess. span_lots=True (live finalize) resolves
+    the remainder across the SKU's other lots - available ones plus lots
+    reserved by doc_id - in the effective pick order; whatever no lot covers
+    stays priced at the bound lot's cost as provisional_qty.
+
+    Non-stock lines (service, freight) hold no goods and contribute nothing.
+    Per-line amounts are clamped at zero so one mis-costed lot cannot cancel
+    correctly costed siblings.
+    """
+    result = CogsResult()
+    for index, li in enumerate(doc.get("line_items", [])):
         line_qty = float(li.get("quantity") or 0)
         if line_qty <= 0:
             continue
@@ -130,17 +224,29 @@ async def compute_doc_cogs(session, company_id, doc: dict) -> float:
         proj = await session.get(Projection, {"company_id": company_id, "entity_id": str(item_id)})
         if not proj:
             continue
-        cost_total = proj.state.get("cost_total")
-        parcel_qty = float(proj.state.get("quantity") or 0)
-        if cost_total is not None and parcel_qty > 0:
-            unit_cost = float(cost_total) / parcel_qty
+        state = proj.state
+        if is_non_stock_line(state.get("inventory_type"), state.get("sell_by")):
+            continue
+        unit_cost = _lot_unit_cost(state)
+        bound_qty = float(state.get("quantity") or 0)
+        spans = line_qty > bound_qty + 1e-9 and splitting_allowed(state)
+        if spans:
+            result.ambiguous = True
+        if spans and span_lots:
+            lots, provisional_qty, amount = await _span_line_lots(
+                session, company_id, proj, line_qty, doc_id)
         else:
-            unit_cost = float(proj.state.get("cost_price") or 0)
-        total_cogs += max(0.0, unit_cost * line_qty)
-    return total_cogs
+            lots = [{"lot_entity_id": str(item_id), "qty": line_qty, "unit_cost": unit_cost}]
+            provisional_qty = 0.0
+            amount = unit_cost * line_qty
+        amount = max(0.0, amount)
+        result.allocations[str(index)] = {
+            "lots": lots, "provisional_qty": provisional_qty, "amount": amount}
+        result.total += amount
+    return result
 
 
-async def create_for_doc_finalized(session, *, company_id, user_id, doc_id: str, doc: dict, base_currency: str = "USD") -> None:
+async def create_for_doc_finalized(session, *, company_id, user_id, doc_id: str, doc: dict, base_currency: str = "USD", span_lots: bool = False) -> None:
     currency = doc.get("currency", "USD")
     rate = _Dec(str(doc.get("conversion_rate") or 1))
     total_d = round_money(doc.get("total", 0), currency)
@@ -161,7 +267,10 @@ async def create_for_doc_finalized(session, *, company_id, user_id, doc_id: str,
     ]
     # Recognize COGS with revenue: cost of the goods sold posts on the same JE, dated
     # the invoice date, so the P&L matches even when the invoice is never fulfilled.
-    cogs = await compute_doc_cogs(session, company_id, doc)
+    # span_lots is set only by the live finalize route, where a line exceeding its
+    # bound lot recognizes at the sibling lots that will actually be drawn.
+    cogs_result = await compute_doc_cogs(session, company_id, doc, span_lots=span_lots, doc_id=doc_id)
+    cogs = cogs_result.total
     if cogs > 0:
         entries.append({"account": "5100", "debit": cogs, "credit": 0.0})
         entries.append({"account": _INVENTORY_ACCT, "debit": 0.0, "credit": cogs})
@@ -657,7 +766,7 @@ async def create_for_doc_unvoided(session, *, company_id, user_id, doc_id: str, 
         ]
         # Restore COGS symmetrically with revenue: the finalize JE carries both, so
         # unvoiding must re-post the same COGS pair it originally recognized.
-        cogs = await compute_doc_cogs(session, company_id, doc)
+        cogs = (await compute_doc_cogs(session, company_id, doc)).total
         if cogs > 0:
             entries.append({"account": "5100", "debit": cogs, "credit": 0.0})
             entries.append({"account": _INVENTORY_ACCT, "debit": 0.0, "credit": cogs})

--- a/celerp/services/auto_je.py
+++ b/celerp/services/auto_je.py
@@ -664,8 +664,8 @@ def _recognition_root(suffix: str) -> str | None:
 
     The root is the suffix with any unvoid-restore generations stripped, so a
     restore shares its original's root: fin, fin:2, fin:unvoid, fin:2:unvoid:1
-    all root to their cycle id; cogs-adj:fulfill-0:unvoid:1 roots to
-    cogs-adj:fulfill-0. A payment (pay:0) or fulfillment (fulfill-1) suffix
+    all root to their cycle id; cogs-adj:fulfill-0:l0:unvoid:1 roots to
+    cogs-adj:fulfill-0:l0. A payment (pay:0) or fulfillment (fulfill-1) suffix
     returns None.
     """
     root = re.sub(r"(?::unvoid(?::\d+)?)+$", "", suffix)
@@ -851,9 +851,10 @@ async def create_for_doc_cogs_adjustment(session, *, company_id, user_id, doc_id
 
     A positive delta (actual cost above recognized) debits 5100 and relieves
     inventory; a negative one reverses that. cycle_tag scopes the JE id and its
-    idempotency keys to the fulfillment cycle (fulfill-0, fulfill-1, ...), so a
-    replay within a cycle is a no-op and each re-finalize cycle trues up on its
-    own JE.
+    idempotency keys to the fulfillment cycle plus the batch of lines fulfilled
+    in one call (fulfill-0:l0-1, fulfill-1:l2, ...), so replaying a batch is a
+    no-op while each distinct batch, and each re-finalize cycle, trues up on
+    its own JE.
     """
     amount = round(abs(float(delta)), 2)
     if amount <= 0:

--- a/celerp/services/auto_je.py
+++ b/celerp/services/auto_je.py
@@ -510,6 +510,31 @@ async def create_for_bill_conversion(
     )
 
 
+async def _void_je_if_posted(session, *, company_id, user_id, doc_id: str, je_id: str, idem_key: str, reason: str, trigger: str) -> bool:
+    """Void a single auto-JE when it is currently posted. Returns True if it voided one.
+
+    Voiding an entry already in 'void' status is a no-op (the status guard skips it),
+    so callers may safely sweep a set of candidate JEs without tracking which are live.
+    """
+    row = await session.get(Projection, {"company_id": company_id, "entity_id": je_id})
+    if row is None or row.state.get("status") != "posted":
+        return False
+    await emit_event(
+        session,
+        company_id=company_id,
+        entity_id=je_id,
+        entity_type="journal_entry",
+        event_type="acc.journal_entry.voided",
+        data=je_void_data(reason, row.state),
+        actor_id=user_id,
+        location_id=None,
+        source="auto_je",
+        idempotency_key=idem_key,
+        metadata_={"trigger": trigger, "doc_id": doc_id},
+    )
+    return True
+
+
 async def void_for_doc_finalized(session, *, company_id, user_id, doc_id: str, revert_count: int = 0) -> None:
     """Void the auto-JE that was created when a doc was finalized (invoice or bill).
 
@@ -519,26 +544,48 @@ async def void_for_doc_finalized(session, *, company_id, user_id, doc_id: str, r
     # Cycle-aware invoice JE id (matches create_for_doc_finalized logic).
     cycle = revert_count
     fin_suffix = f"fin:{cycle}" if cycle else "fin"
+    # Void idempotency key is cycle-aware to allow multiple revert cycles.
+    void_cycle_key = f"revert_to_draft:{revert_count}"
     for je_suffix in (fin_suffix, "bill"):
-        je_id = f"je:auto:{doc_id}:{je_suffix}"
-        row = await session.get(Projection, {"company_id": company_id, "entity_id": je_id})
-        if row is not None and row.state.get("status") == "posted":
-            # Void idempotency key is cycle-aware to allow multiple revert cycles.
-            void_cycle_key = f"revert_to_draft:{revert_count}"
-            await emit_event(
-                session,
-                company_id=company_id,
-                entity_id=je_id,
-                entity_type="journal_entry",
-                event_type="acc.journal_entry.voided",
-                data=je_void_data(f"Reversed: {doc_id} reverted to draft", row.state),
-                actor_id=user_id,
-                location_id=None,
-                source="auto_je",
-                idempotency_key=je_idempotency_key(doc_id, void_cycle_key, "void"),
-                metadata_={"trigger": "doc.reverted_to_draft", "doc_id": doc_id},
-            )
+        voided = await _void_je_if_posted(
+            session,
+            company_id=company_id,
+            user_id=user_id,
+            doc_id=doc_id,
+            je_id=f"je:auto:{doc_id}:{je_suffix}",
+            idem_key=je_idempotency_key(doc_id, void_cycle_key, "void"),
+            reason=f"Reversed: {doc_id} reverted to draft",
+            trigger="doc.reverted_to_draft",
+        )
+        if voided:
             return  # void the first found; at most one exists per doc
+
+
+async def void_for_doc_voided(session, *, company_id, user_id, doc_id: str, revert_count: int = 0) -> None:
+    """Reverse every posted finalize-family auto-JE when a finalized doc is voided.
+
+    Symmetric with create_for_doc_unvoided, which re-posts the finalize JE on unvoid.
+    Without this, voiding leaves the finalize JE posted and a subsequent unvoid posts a
+    second one (je:auto:{doc}:fin:unvoid), double-counting revenue and COGS in the
+    ledger. Sweeping every finalize-family suffix rather than returning on the first
+    keeps the books flat across any finalize/revert/unvoid history: at most one is live
+    at void time and the rest are already void (skipped by the status guard).
+
+    revert_count: the current revert_count from doc state, so cycle-aware finalize ids
+    (fin, fin:1, ... fin:{revert_count}) are all covered.
+    """
+    fin_suffixes = [f"fin:{c}" if c else "fin" for c in range(revert_count + 1)]
+    for je_suffix in fin_suffixes + ["fin:unvoid", "bill"]:
+        await _void_je_if_posted(
+            session,
+            company_id=company_id,
+            user_id=user_id,
+            doc_id=doc_id,
+            je_id=f"je:auto:{doc_id}:{je_suffix}",
+            idem_key=je_idempotency_key(doc_id, f"voided:{je_suffix}", "void"),
+            reason=f"Reversed: {doc_id} voided",
+            trigger="doc.voided",
+        )
 
 
 async def create_for_doc_unvoided(session, *, company_id, user_id, doc_id: str, doc: dict, base_currency: str = "USD") -> None:

--- a/celerp/services/auto_je.py
+++ b/celerp/services/auto_je.py
@@ -9,6 +9,7 @@ duplicate JEs regardless of trigger source (API, import, doctor repair).
 
 from __future__ import annotations
 
+import re
 import uuid
 from dataclasses import dataclass, field
 from decimal import Decimal as _Dec
@@ -649,75 +650,126 @@ async def _void_je_if_posted(session, *, company_id, user_id, doc_id: str, je_id
     return True
 
 
-def finalize_family_suffixes(revert_count: int = 0) -> list[str]:
-    """Every JE id suffix that can carry a doc's finalize recognition.
+# The JE families that carry a doc's recognized economics: finalize (fin, and
+# fin:{cycle} after reverts), bill conversion, the one-time COGS backfill, and
+# the fulfillment COGS adjustment (cogs-adj:{cycle_tag}). These are what a doc
+# void reverses and an unvoid restores. Settlement and stock-movement JEs
+# (payments, credit-note applications, fulfillment, receiving, landed cost,
+# returns) are not recognition: they reverse through their own flows.
+_RECOGNITION_FAMILIES = ("fin", "bill", "cogs-backfill", "cogs-adj")
 
-    Covers each finalize cycle (fin, fin:1, ... fin:{revert_count}) plus the
-    unvoid restore. At most one is posted at any time; the rest are void.
+
+def _recognition_root(suffix: str) -> str | None:
+    """The recognition root of a JE id suffix, or None for non-recognition JEs.
+
+    The root is the suffix with any unvoid-restore generations stripped, so a
+    restore shares its original's root: fin, fin:2, fin:unvoid, fin:2:unvoid:1
+    all root to their cycle id; cogs-adj:fulfill-0:unvoid:1 roots to
+    cogs-adj:fulfill-0. A payment (pay:0) or fulfillment (fulfill-1) suffix
+    returns None.
     """
-    cycles = [f"fin:{c}" if c else "fin" for c in range(int(revert_count or 0) + 1)]
-    return cycles + ["fin:unvoid"]
+    root = re.sub(r"(?::unvoid(?::\d+)?)+$", "", suffix)
+    for family in _RECOGNITION_FAMILIES:
+        if root == family or root.startswith(f"{family}:"):
+            return root
+    return None
 
 
-def _void_sweep_suffixes(revert_count: int = 0) -> list[str]:
-    """Every JE id suffix a void sweep must cover: the finalize family plus the
-    one-time COGS backfill JE and the bill finalize JE."""
-    return finalize_family_suffixes(revert_count) + ["cogs-backfill", "bill"]
+async def _doc_recognition_jes(session, company_id, doc_id: str) -> dict[str, Projection]:
+    """suffix -> JE projection for every recognition-family auto-JE of the doc."""
+    prefix = f"je:auto:{doc_id}:"
+    rows = (await session.execute(_select(Projection).where(
+        Projection.company_id == company_id,
+        Projection.entity_type == "journal_entry",
+    ))).scalars().all()
+    jes: dict[str, Projection] = {}
+    for row in rows:
+        if not row.entity_id.startswith(prefix):
+            continue
+        suffix = row.entity_id[len(prefix):]
+        if _recognition_root(suffix) is not None:
+            jes[suffix] = row
+    return jes
+
+
+async def _doc_void_events(session, company_id, doc_id: str) -> list:
+    """Every acc.journal_entry.voided ledger event on the doc's auto-JEs, oldest
+    first (ledger id order)."""
+    from celerp.models.ledger import LedgerEntry
+
+    prefix = f"je:auto:{doc_id}:"
+    rows = (await session.execute(
+        _select(LedgerEntry)
+        .where(
+            LedgerEntry.company_id == company_id,
+            LedgerEntry.event_type == "acc.journal_entry.voided",
+        )
+        .order_by(LedgerEntry.id)
+    )).scalars().all()
+    return [r for r in rows if r.entity_id.startswith(prefix)]
 
 
 async def void_for_doc_finalized(session, *, company_id, user_id, doc_id: str, revert_count: int = 0) -> None:
-    """Void every posted auto-JE tied to a doc's finalized state when it reverts
-    to draft (invoice or bill).
+    """Void every posted recognition-family auto-JE when a doc reverts to draft
+    (invoice or bill).
 
-    Sweeps the full finalize family plus the COGS backfill JE rather than
-    stopping at the first hit: a backfilled invoice carries two posted JEs
-    (finalize and cogs-backfill), and an unvoided invoice's live finalize JE is
-    fin:unvoid, not the cycle id. _void_je_if_posted skips anything already
+    The candidates are enumerated from the doc's actual JE projections, so any
+    recognition JE the doc has accumulated - finalize cycles, unvoid restores,
+    the COGS backfill, fulfillment COGS adjustments - is reversed without a
+    fixed list to fall out of date. _void_je_if_posted skips anything already
     void, so the sweep only ever reverses what is live.
 
-    revert_count: the current revert_count from doc state (before this revert increments it).
-    Used to derive the correct JE entity ids for cycle-aware invoice JEs.
+    revert_count: the current revert_count from doc state (before this revert
+    increments it), scoping the void idempotency keys per revert cycle.
     """
-    for je_suffix in _void_sweep_suffixes(revert_count):
+    for suffix in await _doc_recognition_jes(session, company_id, doc_id):
         await _void_je_if_posted(
             session,
             company_id=company_id,
             user_id=user_id,
             doc_id=doc_id,
-            je_id=f"je:auto:{doc_id}:{je_suffix}",
+            je_id=f"je:auto:{doc_id}:{suffix}",
             # Cycle- and suffix-aware so multiple revert cycles and multiple
             # live JEs in one revert each get their own void event.
-            idem_key=je_idempotency_key(doc_id, f"revert_to_draft:{revert_count}:{je_suffix}", "void"),
+            idem_key=je_idempotency_key(doc_id, f"revert_to_draft:{revert_count}:{suffix}", "void"),
             reason=f"Reversed: {doc_id} reverted to draft",
             trigger="doc.reverted_to_draft",
         )
 
 
-async def void_for_doc_voided(session, *, company_id, user_id, doc_id: str, revert_count: int = 0) -> None:
-    """Reverse every posted finalize-family auto-JE when a finalized doc is voided.
+async def void_for_doc_voided(session, *, company_id, user_id, doc_id: str) -> None:
+    """Reverse every posted recognition-family auto-JE when a finalized doc is
+    voided, stamping each void event with this void's batch number.
 
-    Symmetric with create_for_doc_unvoided, which re-posts the finalize JE on unvoid.
-    Without this, voiding leaves the finalize JE posted and a subsequent unvoid posts a
-    second one (je:auto:{doc}:fin:unvoid), double-counting revenue and COGS in the
-    ledger. Sweeping every finalize-family suffix rather than returning on the first
-    keeps the books flat across any finalize/revert/unvoid history: at most one is live
-    at void time and the rest are already void (skipped by the status guard). The
-    one-time COGS backfill JE is part of the sweep too, since a backfilled invoice
-    holds its COGS in that separate JE.
-
-    revert_count: the current revert_count from doc state, so cycle-aware finalize ids
-    (fin, fin:1, ... fin:{revert_count}) are all covered.
+    Symmetric with create_for_doc_unvoided, which restores exactly the JEs the
+    most recent batch voided. The candidates come from the doc's actual JE
+    projections (finalize cycles, unvoid restores, COGS backfill, COGS
+    adjustments), so nothing live is left behind and nothing settled (payments,
+    fulfillment stock moves) is touched. The batch number in both the metadata
+    and the idempotency key keeps every void/unvoid cycle's events distinct:
+    a second cycle's voids can never dedup against the first's.
     """
-    for je_suffix in _void_sweep_suffixes(revert_count):
-        await _void_je_if_posted(
+    void_events = await _doc_void_events(session, company_id, doc_id)
+    batch = 1 + max(
+        (int((e.metadata_ or {}).get("void_batch") or 0) for e in void_events),
+        default=0,
+    )
+    for suffix, row in (await _doc_recognition_jes(session, company_id, doc_id)).items():
+        je_id = f"je:auto:{doc_id}:{suffix}"
+        if (row.state or {}).get("status") != "posted":
+            continue
+        await emit_event(
             session,
             company_id=company_id,
-            user_id=user_id,
-            doc_id=doc_id,
-            je_id=f"je:auto:{doc_id}:{je_suffix}",
-            idem_key=je_idempotency_key(doc_id, f"voided:{je_suffix}", "void"),
-            reason=f"Reversed: {doc_id} voided",
-            trigger="doc.voided",
+            entity_id=je_id,
+            entity_type="journal_entry",
+            event_type="acc.journal_entry.voided",
+            data=je_void_data(f"Reversed: {doc_id} voided", row.state),
+            actor_id=user_id,
+            location_id=None,
+            source="auto_je",
+            idempotency_key=je_idempotency_key(doc_id, f"voided:{batch}:{suffix}", "void"),
+            metadata_={"trigger": "doc.voided", "doc_id": doc_id, "void_batch": batch},
         )
 
 
@@ -830,92 +882,85 @@ async def create_for_doc_cogs_adjustment(session, *, company_id, user_id, doc_id
     )
 
 
-async def create_for_doc_unvoided(session, *, company_id, user_id, doc_id: str, doc: dict, base_currency: str = "USD") -> None:
-    """Re-apply the finalize JE when a doc is unvoided.
+async def create_for_doc_unvoided(session, *, company_id, user_id, doc_id: str) -> None:
+    """Restore exactly what the immediately preceding void removed.
 
-    Uses 'unvoid' suffix in idempotency keys to avoid colliding with original JEs
-    (which may still exist if voiding didn't delete them).
+    Finds the recognition JEs the most recent void batch reversed and re-posts
+    each as a new JE copying its memo, entries, and date verbatim - never
+    recomputing: costs may have moved since the doc was voided, and an unvoid
+    must put back the numbers the void took out, not today's. Each restore
+    lives at je:auto:{doc_id}:{root}:unvoid:{n}, so repeated void/unvoid cycles
+    keep every generation distinct, and a family that already holds a posted JE
+    is skipped (the restore already happened). One copy mechanism covers every
+    doc type and family: invoice finalize, bill conversion, COGS backfill, and
+    COGS adjustments alike.
+
+    Docs voided before batch stamping existed have per-JE void events with no
+    batch number; for those, each recognition family whose latest void event
+    came from a doc void (not a revert to draft) restores the JE that event
+    reversed.
     """
-    doc_type = doc.get("doc_type", "")
-    currency = doc.get("currency", "USD")
-    rate = _Dec(str(doc.get("conversion_rate") or 1))
-    total = float(doc.get("total", 0) or 0)
-    if total <= 0:
-        return
+    from celerp.models.ledger import LedgerEntry
 
-    if doc_type == "invoice":
-        tax_d = round_money(doc.get("tax", 0), currency)
-        total_d = round_money(total, currency)
-        base_total = to_base(to_stored_float(total_d), rate, base_currency)
-        base_tax = to_base(to_stored_float(tax_d), rate, base_currency)
-        base_revenue = to_base(to_stored_float(round_money(total_d - tax_d, currency)), rate, base_currency)
-        entries = [
-            {"account": "1120", "debit": base_total, "credit": 0.0},
-            {"account": "4100", "debit": 0.0, "credit": base_revenue},
-            {"account": "2120", "debit": 0.0, "credit": base_tax},
-        ]
-        # Restore COGS symmetrically with revenue: the finalize JE carries both, so
-        # unvoiding must re-post the same COGS pair it originally recognized.
-        cogs = (await compute_doc_cogs(session, company_id, doc)).total
-        if cogs > 0:
-            entries.append({"account": "5100", "debit": cogs, "credit": 0.0})
-            entries.append({"account": _INVENTORY_ACCT, "debit": 0.0, "credit": cogs})
+    prefix = f"je:auto:{doc_id}:"
+    jes = await _doc_recognition_jes(session, company_id, doc_id)
+    void_events = await _doc_void_events(session, company_id, doc_id)
+
+    batched = [e for e in void_events if (e.metadata_ or {}).get("void_batch")]
+    if batched:
+        last_batch = max(int(e.metadata_["void_batch"]) for e in batched)
+        to_restore = [e.entity_id for e in batched
+                      if int(e.metadata_["void_batch"]) == last_batch]
+    else:
+        last_void_by_root: dict[str, object] = {}
+        for event in void_events:  # oldest first, so the latest event wins
+            root = _recognition_root(event.entity_id[len(prefix):])
+            if root is not None:
+                last_void_by_root[root] = event
+        to_restore = [e.entity_id for e in last_void_by_root.values()
+                      if (e.metadata_ or {}).get("trigger") == "doc.voided"]
+
+    for voided_je_id in to_restore:
+        suffix = voided_je_id[len(prefix):]
+        root = _recognition_root(suffix)
+        source = jes.get(suffix)
+        if root is None or source is None:
+            continue
+        family = {s: r for s, r in jes.items() if _recognition_root(s) == root}
+        if any((r.state or {}).get("status") == "posted" for r in family.values()):
+            continue
+        state = source.state or {}
+        entries = state.get("entries") or []
+        if not entries:
+            continue
+        generation = 1 + sum(1 for s in family if s != root)
+        created = (await session.execute(
+            _select(LedgerEntry)
+            .where(
+                LedgerEntry.company_id == company_id,
+                LedgerEntry.entity_id == voided_je_id,
+                LedgerEntry.event_type == "acc.journal_entry.created",
+            )
+            .order_by(LedgerEntry.id.desc())
+            .limit(1)
+        )).scalars().first()
+        metadata_ = {"trigger": "doc.unvoided", "doc_id": doc_id, "restores": voided_je_id}
+        allocations = ((created.metadata_ or {}) if created else {}).get("cogs_allocations")
+        if allocations:
+            # The allocation snapshot rides along so fulfillment still trues up
+            # against what the restored JE recognizes.
+            metadata_["cogs_allocations"] = allocations
         await _emit_auto_posted_je(
             session,
             company_id=company_id,
             user_id=user_id,
-            je_id=f"je:auto:{doc_id}:fin:unvoid",
-            idem_create=je_idempotency_key(doc_id, "invoice.finalized.unvoid", "c"),
-            idem_posted=je_idempotency_key(doc_id, "invoice.finalized.unvoid", "p"),
-            memo=f"Auto JE for {doc_id} unvoided (restore finalize)",
-            ts=doc.get("finalized_at") or doc.get("issue_date"),
+            je_id=f"je:auto:{doc_id}:{root}:unvoid:{generation}",
+            idem_create=je_idempotency_key(doc_id, f"unvoid:{root}:{generation}", "c"),
+            idem_posted=je_idempotency_key(doc_id, f"unvoid:{root}:{generation}", "p"),
+            memo=state.get("memo") or f"Auto JE for {doc_id} unvoided",
+            ts=state.get("ts"),
             entries=entries,
-            metadata_={"trigger": "doc.unvoided", "doc_id": doc_id},
-        )
-    elif doc_type in ("bill", "purchase_order"):
-        line_items = doc.get("line_items", [])
-        debit_entries: list[dict] = []
-        tax_total_d = _Dec(0)
-        if line_items:
-            for li in line_items:
-                line_total = to_stored_float(round_money(
-                    to_decimal(li.get("line_total") or 0) or
-                    to_decimal(li.get("quantity", 0)) * to_decimal(li.get("unit_price", 0)),
-                    currency,
-                ))
-                if line_total <= 0:
-                    continue
-                receive_as = (li.get("receive_as") or "").strip().lower()
-                if li.get("account_code"):
-                    account = li["account_code"]
-                elif receive_as == "expense":
-                    account = "6950"
-                elif receive_as == "asset":
-                    account = "1210"
-                else:
-                    account = _INVENTORY_ACCT if li.get("sku") else "6950"
-                debit_entries.append({"account": account, "debit": to_base(line_total, rate, base_currency), "credit": 0.0})
-            # Input VAT from the doc's effective tax (see create_for_bill_conversion), which keeps the JE balanced.
-            tax_total_d = round_money(to_decimal(doc.get("tax", 0) or 0), currency)
-            if tax_total_d > 0:
-                debit_entries.append({"account": "1150", "debit": to_base(to_stored_float(tax_total_d), rate, base_currency), "credit": 0.0})
-        base_total = to_base(total, rate, base_currency)
-        if not debit_entries:
-            if total <= 0:
-                return
-            debit_entries.append({"account": "6950", "debit": base_total, "credit": 0.0})
-        entries = debit_entries + [{"account": "2110", "debit": 0.0, "credit": base_total}]
-        await _emit_auto_posted_je(
-            session,
-            company_id=company_id,
-            user_id=user_id,
-            je_id=f"je:auto:{doc_id}:bill:unvoid",
-            idem_create=je_idempotency_key(doc_id, "po.converted_to_bill.unvoid", "c"),
-            idem_posted=je_idempotency_key(doc_id, "po.converted_to_bill.unvoid", "p"),
-            memo=f"Auto JE for {doc_id} unvoided (restore bill conversion)",
-            ts=doc.get("issue_date") or doc.get("finalized_at"),
-            entries=entries,
-            metadata_={"trigger": "doc.unvoided", "doc_id": doc_id},
+            metadata_=metadata_,
         )
 
 

--- a/celerp/services/auto_je.py
+++ b/celerp/services/auto_je.py
@@ -109,6 +109,37 @@ async def _emit_auto_posted_je(
     )
 
 
+async def compute_doc_cogs(session, company_id, doc: dict) -> float:
+    """Sum COGS for a document's stock lines at posting time.
+
+    Per stock line the per-unit cost is the parcel's cost_total spread over its own
+    quantity (cost_total / parcel_qty) when that quantity is positive, and the parcel
+    cost_price otherwise, so a partially-invoiced line costs only the quantity it draws
+    rather than the whole parcel. Each line's contribution is clamped at zero so one
+    mis-costed parcel cannot cancel correctly-costed lines; non-stock and zero-quantity
+    lines contribute nothing.
+    """
+    total_cogs = 0.0
+    for li in doc.get("line_items", []):
+        line_qty = float(li.get("quantity") or 0)
+        if line_qty <= 0:
+            continue
+        item_id = li.get("item_id") or li.get("entity_id")
+        if not item_id:
+            continue
+        proj = await session.get(Projection, {"company_id": company_id, "entity_id": str(item_id)})
+        if not proj:
+            continue
+        cost_total = proj.state.get("cost_total")
+        parcel_qty = float(proj.state.get("quantity") or 0)
+        if cost_total is not None and parcel_qty > 0:
+            unit_cost = float(cost_total) / parcel_qty
+        else:
+            unit_cost = float(proj.state.get("cost_price") or 0)
+        total_cogs += max(0.0, unit_cost * line_qty)
+    return total_cogs
+
+
 async def create_for_doc_finalized(session, *, company_id, user_id, doc_id: str, doc: dict, base_currency: str = "USD") -> None:
     currency = doc.get("currency", "USD")
     rate = _Dec(str(doc.get("conversion_rate") or 1))
@@ -123,6 +154,17 @@ async def create_for_doc_finalized(session, *, company_id, user_id, doc_id: str,
     cycle = int(doc.get("revert_count", 0))
     cycle_suffix = f"fin:{cycle}" if cycle else "fin"
     je_type_key = f"invoice.finalized:{cycle}" if cycle else "invoice.finalized"
+    entries = [
+        {"account": "1120", "debit": total, "credit": 0.0},
+        {"account": "4100", "debit": 0.0, "credit": revenue},
+        {"account": "2120", "debit": 0.0, "credit": tax},
+    ]
+    # Recognize COGS with revenue: cost of the goods sold posts on the same JE, dated
+    # the invoice date, so the P&L matches even when the invoice is never fulfilled.
+    cogs = await compute_doc_cogs(session, company_id, doc)
+    if cogs > 0:
+        entries.append({"account": "5100", "debit": cogs, "credit": 0.0})
+        entries.append({"account": _INVENTORY_ACCT, "debit": 0.0, "credit": cogs})
     await _emit_auto_posted_je(
         session,
         company_id=company_id,
@@ -132,11 +174,7 @@ async def create_for_doc_finalized(session, *, company_id, user_id, doc_id: str,
         idem_posted=je_idempotency_key(doc_id, je_type_key, "p"),
         memo=f"Auto JE for {doc_id} finalized",
         ts=doc.get("finalized_at") or doc.get("issue_date"),
-        entries=[
-            {"account": "1120", "debit": total, "credit": 0.0},
-            {"account": "4100", "debit": 0.0, "credit": revenue},
-            {"account": "2120", "debit": 0.0, "credit": tax},
-        ],
+        entries=entries,
         metadata_={"trigger": "doc.finalized", "doc_id": doc_id},
     )
 
@@ -522,6 +560,17 @@ async def create_for_doc_unvoided(session, *, company_id, user_id, doc_id: str, 
         base_total = to_base(to_stored_float(total_d), rate, base_currency)
         base_tax = to_base(to_stored_float(tax_d), rate, base_currency)
         base_revenue = to_base(to_stored_float(round_money(total_d - tax_d, currency)), rate, base_currency)
+        entries = [
+            {"account": "1120", "debit": base_total, "credit": 0.0},
+            {"account": "4100", "debit": 0.0, "credit": base_revenue},
+            {"account": "2120", "debit": 0.0, "credit": base_tax},
+        ]
+        # Restore COGS symmetrically with revenue: the finalize JE carries both, so
+        # unvoiding must re-post the same COGS pair it originally recognized.
+        cogs = await compute_doc_cogs(session, company_id, doc)
+        if cogs > 0:
+            entries.append({"account": "5100", "debit": cogs, "credit": 0.0})
+            entries.append({"account": _INVENTORY_ACCT, "debit": 0.0, "credit": cogs})
         await _emit_auto_posted_je(
             session,
             company_id=company_id,
@@ -531,11 +580,7 @@ async def create_for_doc_unvoided(session, *, company_id, user_id, doc_id: str, 
             idem_posted=je_idempotency_key(doc_id, "invoice.finalized.unvoid", "p"),
             memo=f"Auto JE for {doc_id} unvoided (restore finalize)",
             ts=doc.get("finalized_at") or doc.get("issue_date"),
-            entries=[
-                {"account": "1120", "debit": base_total, "credit": 0.0},
-                {"account": "4100", "debit": 0.0, "credit": base_revenue},
-                {"account": "2120", "debit": 0.0, "credit": base_tax},
-            ],
+            entries=entries,
             metadata_={"trigger": "doc.unvoided", "doc_id": doc_id},
         )
     elif doc_type in ("bill", "purchase_order"):

--- a/celerp/services/auto_je.py
+++ b/celerp/services/auto_je.py
@@ -535,30 +535,48 @@ async def _void_je_if_posted(session, *, company_id, user_id, doc_id: str, je_id
     return True
 
 
+def finalize_family_suffixes(revert_count: int = 0) -> list[str]:
+    """Every JE id suffix that can carry a doc's finalize recognition.
+
+    Covers each finalize cycle (fin, fin:1, ... fin:{revert_count}) plus the
+    unvoid restore. At most one is posted at any time; the rest are void.
+    """
+    cycles = [f"fin:{c}" if c else "fin" for c in range(int(revert_count or 0) + 1)]
+    return cycles + ["fin:unvoid"]
+
+
+def _void_sweep_suffixes(revert_count: int = 0) -> list[str]:
+    """Every JE id suffix a void sweep must cover: the finalize family plus the
+    one-time COGS backfill JE and the bill finalize JE."""
+    return finalize_family_suffixes(revert_count) + ["cogs-backfill", "bill"]
+
+
 async def void_for_doc_finalized(session, *, company_id, user_id, doc_id: str, revert_count: int = 0) -> None:
-    """Void the auto-JE that was created when a doc was finalized (invoice or bill).
+    """Void every posted auto-JE tied to a doc's finalized state when it reverts
+    to draft (invoice or bill).
+
+    Sweeps the full finalize family plus the COGS backfill JE rather than
+    stopping at the first hit: a backfilled invoice carries two posted JEs
+    (finalize and cogs-backfill), and an unvoided invoice's live finalize JE is
+    fin:unvoid, not the cycle id. _void_je_if_posted skips anything already
+    void, so the sweep only ever reverses what is live.
 
     revert_count: the current revert_count from doc state (before this revert increments it).
-    Used to derive the correct JE entity id for cycle-aware invoice JEs.
+    Used to derive the correct JE entity ids for cycle-aware invoice JEs.
     """
-    # Cycle-aware invoice JE id (matches create_for_doc_finalized logic).
-    cycle = revert_count
-    fin_suffix = f"fin:{cycle}" if cycle else "fin"
-    # Void idempotency key is cycle-aware to allow multiple revert cycles.
-    void_cycle_key = f"revert_to_draft:{revert_count}"
-    for je_suffix in (fin_suffix, "bill"):
-        voided = await _void_je_if_posted(
+    for je_suffix in _void_sweep_suffixes(revert_count):
+        await _void_je_if_posted(
             session,
             company_id=company_id,
             user_id=user_id,
             doc_id=doc_id,
             je_id=f"je:auto:{doc_id}:{je_suffix}",
-            idem_key=je_idempotency_key(doc_id, void_cycle_key, "void"),
+            # Cycle- and suffix-aware so multiple revert cycles and multiple
+            # live JEs in one revert each get their own void event.
+            idem_key=je_idempotency_key(doc_id, f"revert_to_draft:{revert_count}:{je_suffix}", "void"),
             reason=f"Reversed: {doc_id} reverted to draft",
             trigger="doc.reverted_to_draft",
         )
-        if voided:
-            return  # void the first found; at most one exists per doc
 
 
 async def void_for_doc_voided(session, *, company_id, user_id, doc_id: str, revert_count: int = 0) -> None:
@@ -569,13 +587,14 @@ async def void_for_doc_voided(session, *, company_id, user_id, doc_id: str, reve
     second one (je:auto:{doc}:fin:unvoid), double-counting revenue and COGS in the
     ledger. Sweeping every finalize-family suffix rather than returning on the first
     keeps the books flat across any finalize/revert/unvoid history: at most one is live
-    at void time and the rest are already void (skipped by the status guard).
+    at void time and the rest are already void (skipped by the status guard). The
+    one-time COGS backfill JE is part of the sweep too, since a backfilled invoice
+    holds its COGS in that separate JE.
 
     revert_count: the current revert_count from doc state, so cycle-aware finalize ids
     (fin, fin:1, ... fin:{revert_count}) are all covered.
     """
-    fin_suffixes = [f"fin:{c}" if c else "fin" for c in range(revert_count + 1)]
-    for je_suffix in fin_suffixes + ["fin:unvoid", "bill"]:
+    for je_suffix in _void_sweep_suffixes(revert_count):
         await _void_je_if_posted(
             session,
             company_id=company_id,
@@ -586,6 +605,30 @@ async def void_for_doc_voided(session, *, company_id, user_id, doc_id: str, reve
             reason=f"Reversed: {doc_id} voided",
             trigger="doc.voided",
         )
+
+
+async def create_for_doc_cogs_backfill(session, *, company_id, user_id, doc_id: str, cogs: float, ts: str | None) -> None:
+    """Post the one-time COGS JE for a finalized invoice that predates
+    COGS-at-finalize and never received its COGS at fulfillment.
+
+    ts carries the doc's finalize-family JE date so the expense lands in the
+    period that recognized the revenue; a dateless doc stays dateless.
+    """
+    await _emit_auto_posted_je(
+        session,
+        company_id=company_id,
+        user_id=user_id,
+        je_id=f"je:auto:{doc_id}:cogs-backfill",
+        idem_create=je_idempotency_key(doc_id, "invoice.cogs_backfill", "c"),
+        idem_posted=je_idempotency_key(doc_id, "invoice.cogs_backfill", "p"),
+        memo=f"Auto JE for {doc_id} COGS backfill",
+        ts=ts,
+        entries=[
+            {"account": "5100", "debit": float(cogs), "credit": 0.0},
+            {"account": _INVENTORY_ACCT, "debit": 0.0, "credit": float(cogs)},
+        ],
+        metadata_={"trigger": "doc.cogs_backfill", "doc_id": doc_id},
+    )
 
 
 async def create_for_doc_unvoided(session, *, company_id, user_id, doc_id: str, doc: dict, base_currency: str = "USD") -> None:

--- a/celerp/services/auto_je.py
+++ b/celerp/services/auto_je.py
@@ -274,6 +274,11 @@ async def create_for_doc_finalized(session, *, company_id, user_id, doc_id: str,
     if cogs > 0:
         entries.append({"account": "5100", "debit": cogs, "credit": 0.0})
         entries.append({"account": _INVENTORY_ACCT, "debit": 0.0, "credit": cogs})
+    # The per-line allocation snapshot rides on the JE so fulfillment can true up
+    # actual lot costs against exactly what this JE recognized, per line.
+    metadata_ = {"trigger": "doc.finalized", "doc_id": doc_id}
+    if cogs_result.allocations:
+        metadata_["cogs_allocations"] = cogs_result.allocations
     await _emit_auto_posted_je(
         session,
         company_id=company_id,
@@ -284,7 +289,7 @@ async def create_for_doc_finalized(session, *, company_id, user_id, doc_id: str,
         memo=f"Auto JE for {doc_id} finalized",
         ts=doc.get("finalized_at") or doc.get("issue_date"),
         entries=entries,
-        metadata_={"trigger": "doc.finalized", "doc_id": doc_id},
+        metadata_=metadata_,
     )
 
 
@@ -737,6 +742,91 @@ async def create_for_doc_cogs_backfill(session, *, company_id, user_id, doc_id: 
             {"account": _INVENTORY_ACCT, "debit": 0.0, "credit": float(cogs)},
         ],
         metadata_={"trigger": "doc.cogs_backfill", "doc_id": doc_id},
+    )
+
+
+async def recognized_cogs_allocations(session, company_id, doc_id: str) -> dict | None:
+    """The per-line COGS the doc's live finalize-family JE recognized.
+
+    Reads the allocation snapshot off the creation event of the currently posted
+    finalize-family JE (fin, a re-finalize cycle, or an unvoid restore of one).
+    Returns the allocations dict keyed by line index, or None when no posted
+    finalize-family JE carries a snapshot - which is every doc finalized before
+    snapshots existed, where fulfillment has no recognized basis to true up
+    against and must post no adjustment.
+    """
+    from celerp.models.ledger import LedgerEntry
+
+    prefix = f"je:auto:{doc_id}:"
+    rows = (await session.execute(_select(Projection).where(
+        Projection.company_id == company_id,
+        Projection.entity_type == "journal_entry",
+    ))).scalars().all()
+    live = None
+    for row in rows:
+        if not row.entity_id.startswith(prefix):
+            continue
+        suffix = row.entity_id[len(prefix):]
+        if not (suffix == "fin" or suffix.startswith("fin:")):
+            continue
+        if (row.state or {}).get("status") != "posted":
+            continue
+        if live is None or (
+            row.created_at is not None
+            and (live.created_at is None or row.created_at > live.created_at)
+        ):
+            live = row
+    if live is None:
+        return None
+    created = (await session.execute(
+        _select(LedgerEntry)
+        .where(
+            LedgerEntry.company_id == company_id,
+            LedgerEntry.entity_id == live.entity_id,
+            LedgerEntry.event_type == "acc.journal_entry.created",
+        )
+        .order_by(LedgerEntry.id.desc())
+        .limit(1)
+    )).scalars().first()
+    if created is None:
+        return None
+    return (created.metadata_ or {}).get("cogs_allocations") or None
+
+
+async def create_for_doc_cogs_adjustment(session, *, company_id, user_id, doc_id: str, delta: float, cycle_tag: str, doc_number: str, ts: str | None = None) -> None:
+    """Post the fulfillment true-up JE: the difference between the actual cost of
+    the lots drawn and the COGS recognized at finalize.
+
+    A positive delta (actual cost above recognized) debits 5100 and relieves
+    inventory; a negative one reverses that. cycle_tag scopes the JE id and its
+    idempotency keys to the fulfillment cycle (fulfill-0, fulfill-1, ...), so a
+    replay within a cycle is a no-op and each re-finalize cycle trues up on its
+    own JE.
+    """
+    amount = round(abs(float(delta)), 2)
+    if amount <= 0:
+        return
+    if delta > 0:
+        entries = [
+            {"account": "5100", "debit": amount, "credit": 0.0},
+            {"account": _INVENTORY_ACCT, "debit": 0.0, "credit": amount},
+        ]
+    else:
+        entries = [
+            {"account": _INVENTORY_ACCT, "debit": amount, "credit": 0.0},
+            {"account": "5100", "debit": 0.0, "credit": amount},
+        ]
+    await _emit_auto_posted_je(
+        session,
+        company_id=company_id,
+        user_id=user_id,
+        je_id=f"je:auto:{doc_id}:cogs-adj:{cycle_tag}",
+        idem_create=je_idempotency_key(doc_id, f"cogs_adjustment:{cycle_tag}", "c"),
+        idem_posted=je_idempotency_key(doc_id, f"cogs_adjustment:{cycle_tag}", "p"),
+        memo=f"COGS adjustment for {doc_number} at fulfillment",
+        ts=ts,
+        entries=entries,
+        metadata_={"trigger": "doc.fulfilled", "doc_id": doc_id, "cogs_delta": round(float(delta), 2)},
     )
 
 

--- a/celerp/services/cogs_backfill.py
+++ b/celerp/services/cogs_backfill.py
@@ -177,7 +177,7 @@ async def run_cogs_backfill(session) -> dict:
         ts = fin_je.get("ts") or state.get("finalized_at") or state.get("issue_date")
         try:
             async with session.begin_nested():
-                cogs = await compute_doc_cogs(session, doc.company_id, state)
+                cogs = (await compute_doc_cogs(session, doc.company_id, state)).total
                 if cogs > 0:
                     await auto_je.create_for_doc_cogs_backfill(
                         session,

--- a/celerp/services/cogs_backfill.py
+++ b/celerp/services/cogs_backfill.py
@@ -1,0 +1,233 @@
+# Copyright (c) 2026 Noah Severs
+# SPDX-License-Identifier: BUSL-1.1
+
+"""One-time COGS backfill for finalized invoices missing their COGS journal entry.
+
+Invoices finalized before COGS moved into the finalize JE only received their
+COGS at full fulfillment, so any of them never (or only partially) fulfilled
+carries recognized revenue with no matching cost. This backfill posts the
+missing Dr 5100 / Cr 1130-P pair once per database, dated to the invoice's own
+finalize JE, and tells each affected company what happened via a bell
+notification.
+
+Runs at startup behind an instance_meta marker, exactly like the status-doc
+backfill. A doc inside a locked accounting period (or one whose legacy state
+the cost computation rejects) is skipped and counted; the marker stays unset in
+that case so the next boot retries the stragglers - the emit idempotency keys
+make re-posting impossible for docs already handled.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from fastapi import HTTPException
+from sqlalchemy import select
+
+from celerp.migrations._data_reconcile import get_meta, set_meta
+from celerp.models.notification import Notification
+from celerp.models.projections import Projection
+from celerp.notifications import service as notification_service
+from celerp.services import auto_je
+from celerp.services.auto_je import compute_doc_cogs, finalize_family_suffixes
+
+log = logging.getLogger(__name__)
+
+COGS_BACKFILL_KEY = "cogs_backfill"
+
+_CATEGORY = "accounting"
+_TITLE = "Cost of goods posted for past invoices"
+
+
+def _je_doc_id(je_id: str, doc_ids: set[str]) -> str | None:
+    """Recover the owning doc id from an auto-JE entity id.
+
+    Auto-JE ids are je:auto:{doc_id}:{suffix} where both the doc id and the
+    suffix can contain colons, so the split is resolved against the company's
+    actual doc-id set: the longest candidate that is a real doc wins.
+    """
+    if not je_id.startswith("je:auto:"):
+        return None
+    rest = je_id[len("je:auto:"):]
+    for parts in (1, 2):
+        candidate = rest.rsplit(":", parts)[0]
+        if candidate in doc_ids:
+            return candidate
+    return None
+
+
+def _has_posted_cogs(je_states: list[dict]) -> bool:
+    """True when any posted JE already debits 5100 - the doc's COGS exists."""
+    for state in je_states:
+        if state.get("status") != "posted":
+            continue
+        for entry in state.get("entries", []):
+            if entry.get("account") == "5100" and float(entry.get("debit") or 0) > 0:
+                return True
+    return False
+
+
+def _live_finalize_je(je_by_suffix: dict[str, dict], revert_count: int) -> dict | None:
+    """The posted finalize-family JE state, latest cycle (or unvoid) winning."""
+    live = None
+    for suffix in finalize_family_suffixes(revert_count):
+        state = je_by_suffix.get(suffix)
+        if state is not None and state.get("status") == "posted":
+            live = state
+    return live
+
+
+def _notify_body(c: dict) -> str:
+    posted = c["posted"]
+    parts = [f"{posted} invoice{'s' if posted != 1 else ''}, total {c['total']:.2f}."]
+    if c["zero_cost"]:
+        parts.append(f"{c['zero_cost']} zero cost, nothing to post.")
+    if c["deferred"]:
+        parts.append(f"{c['deferred']} deferred: accounting period locked.")
+    if c["errored"]:
+        parts.append(f"{c['errored']} could not be computed.")
+    return " ".join(parts)
+
+
+async def _notify(session, company_id, c: dict) -> None:
+    """One bell notice per company, deduped on the unread stable title so a
+    retrying boot never stacks duplicates."""
+    existing = (await session.execute(
+        select(Notification.id)
+        .where(
+            Notification.company_id == company_id,
+            Notification.category == _CATEGORY,
+            Notification.title == _TITLE,
+            Notification.read == False,  # noqa: E712
+        )
+        .limit(1)
+    )).scalar()
+    if existing:
+        return
+    action_url = "/accounting?q=COGS%20backfill"
+    if c["earliest"] and c["latest"]:
+        action_url += f"&from={c['earliest']}&to={c['latest']}"
+    await notification_service.create(
+        session,
+        company_id,
+        _CATEGORY,
+        _TITLE,
+        _notify_body(c),
+        user_id=None,
+        action_url=action_url,
+        priority="high",
+    )
+
+
+async def run_cogs_backfill(session) -> dict:
+    """Post the missing COGS JE for every affected finalized invoice.
+
+    Affected: doc_type invoice, a posted finalize-family JE exists, and no
+    posted JE anywhere on the doc debits 5100. The JE amount comes from
+    compute_doc_cogs over current projections; zero-cost docs post nothing and
+    are only counted. Returns aggregate counts; the caller commits.
+    """
+    conn = await session.connection()
+    already = await conn.run_sync(lambda c: get_meta(c, COGS_BACKFILL_KEY))
+    if already:
+        return {"changed": False}
+
+    docs = (await session.execute(
+        select(Projection).where(Projection.entity_type == "doc")
+    )).scalars().all()
+    jes = (await session.execute(
+        select(Projection).where(Projection.entity_type == "journal_entry")
+    )).scalars().all()
+
+    doc_ids_by_company: dict = {}
+    for doc in docs:
+        doc_ids_by_company.setdefault(doc.company_id, set()).add(doc.entity_id)
+
+    # (company_id, doc_id) -> {suffix: je_state}
+    doc_jes: dict = {}
+    for je in jes:
+        doc_ids = doc_ids_by_company.get(je.company_id)
+        if not doc_ids:
+            continue
+        doc_id = _je_doc_id(je.entity_id, doc_ids)
+        if doc_id is None:
+            continue
+        suffix = je.entity_id[len(f"je:auto:{doc_id}:"):]
+        doc_jes.setdefault((je.company_id, doc_id), {})[suffix] = je.state or {}
+
+    per_company: dict = {}
+    for doc in docs:
+        state = doc.state or {}
+        if state.get("doc_type") != "invoice":
+            continue
+        je_by_suffix = doc_jes.get((doc.company_id, doc.entity_id), {})
+        if not je_by_suffix:
+            continue
+        revert_count = int(state.get("revert_count") or 0)
+        fin_je = _live_finalize_je(je_by_suffix, revert_count)
+        if fin_je is None:
+            continue
+        if _has_posted_cogs(list(je_by_suffix.values())):
+            continue
+
+        c = per_company.setdefault(doc.company_id, {
+            "posted": 0, "total": 0.0, "zero_cost": 0,
+            "deferred": 0, "errored": 0, "earliest": None, "latest": None,
+        })
+        ts = fin_je.get("ts") or state.get("finalized_at") or state.get("issue_date")
+        try:
+            async with session.begin_nested():
+                cogs = await compute_doc_cogs(session, doc.company_id, state)
+                if cogs > 0:
+                    await auto_je.create_for_doc_cogs_backfill(
+                        session,
+                        company_id=doc.company_id,
+                        user_id=None,
+                        doc_id=doc.entity_id,
+                        cogs=cogs,
+                        ts=ts,
+                    )
+        except HTTPException as exc:
+            if exc.status_code == 503:
+                # Backup in progress: run-level, nothing lands, next boot retries.
+                raise
+            if exc.status_code == 422 and "locked" in str(exc.detail).lower():
+                c["deferred"] += 1
+            else:
+                c["errored"] += 1
+                log.warning("COGS backfill could not post for %s: %s",
+                            doc.entity_id, exc.detail)
+        except Exception:
+            c["errored"] += 1
+            log.exception("COGS backfill could not compute %s", doc.entity_id)
+        else:
+            if cogs > 0:
+                c["posted"] += 1
+                c["total"] += cogs
+                day = str(ts)[:10] if ts else None
+                if day:
+                    if c["earliest"] is None or day < c["earliest"]:
+                        c["earliest"] = day
+                    if c["latest"] is None or day > c["latest"]:
+                        c["latest"] = day
+            else:
+                c["zero_cost"] += 1
+
+    totals = {"posted": 0, "zero_cost": 0, "deferred": 0, "errored": 0}
+    for company_id, c in per_company.items():
+        for key in totals:
+            totals[key] += c[key]
+        if any((c["posted"], c["zero_cost"], c["deferred"], c["errored"])):
+            await _notify(session, company_id, c)
+
+    pending = totals["deferred"] or totals["errored"]
+    if not pending:
+        conn = await session.connection()
+        await conn.run_sync(lambda c: set_meta(c, COGS_BACKFILL_KEY, "done"))
+
+    log.info(
+        "COGS backfill: %d posted, %d zero cost, %d deferred, %d errored%s",
+        totals["posted"], totals["zero_cost"], totals["deferred"], totals["errored"],
+        "" if not pending else " (marker left unset; next boot retries)",
+    )
+    return {"changed": True, **totals}

--- a/celerp/services/cogs_backfill.py
+++ b/celerp/services/cogs_backfill.py
@@ -12,9 +12,12 @@ notification.
 
 Runs at startup behind an instance_meta marker, exactly like the status-doc
 backfill. A doc inside a locked accounting period (or one whose legacy state
-the cost computation rejects) is skipped and counted; the marker stays unset in
-that case so the next boot retries the stragglers - the emit idempotency keys
-make re-posting impossible for docs already handled.
+the cost computation rejects) is deferred and counted; the marker stays unset
+in that case so the next boot retries the stragglers - the emit idempotency
+keys make re-posting impossible for docs already handled. A doc whose line
+quantity exceeds its bound lot is skipped terminally instead: the remainder was
+drawn from sibling lots at costs unknowable now, so the owner posts that JE
+manually from the notification.
 """
 
 from __future__ import annotations
@@ -29,7 +32,7 @@ from celerp.models.notification import Notification
 from celerp.models.projections import Projection
 from celerp.notifications import service as notification_service
 from celerp.services import auto_je
-from celerp.services.auto_je import compute_doc_cogs, finalize_family_suffixes
+from celerp.services.auto_je import compute_doc_cogs
 
 log = logging.getLogger(__name__)
 
@@ -67,14 +70,15 @@ def _has_posted_cogs(je_states: list[dict]) -> bool:
     return False
 
 
-def _live_finalize_je(je_by_suffix: dict[str, dict], revert_count: int) -> dict | None:
-    """The posted finalize-family JE state, latest cycle (or unvoid) winning."""
-    live = None
-    for suffix in finalize_family_suffixes(revert_count):
-        state = je_by_suffix.get(suffix)
-        if state is not None and state.get("status") == "posted":
-            live = state
-    return live
+def _live_finalize_je(je_by_suffix: dict[str, dict]) -> dict | None:
+    """The posted finalize-family JE state (fin, a re-finalize cycle, or an
+    unvoid restore of one). The void sweep keeps at most one of them posted at
+    any time, so the first posted match is the live one."""
+    for suffix, state in je_by_suffix.items():
+        if suffix == "fin" or suffix.startswith("fin:"):
+            if state.get("status") == "posted":
+                return state
+    return None
 
 
 def _notify_body(c: dict) -> str:
@@ -86,6 +90,8 @@ def _notify_body(c: dict) -> str:
         parts.append(f"{c['deferred']} deferred: accounting period locked.")
     if c["errored"]:
         parts.append(f"{c['errored']} could not be computed.")
+    if c["skipped"]:
+        parts.append(f"{c['skipped']} skipped: cost spans multiple lots, post manually.")
     return " ".join(parts)
 
 
@@ -163,8 +169,7 @@ async def run_cogs_backfill(session) -> dict:
         je_by_suffix = doc_jes.get((doc.company_id, doc.entity_id), {})
         if not je_by_suffix:
             continue
-        revert_count = int(state.get("revert_count") or 0)
-        fin_je = _live_finalize_je(je_by_suffix, revert_count)
+        fin_je = _live_finalize_je(je_by_suffix)
         if fin_je is None:
             continue
         if _has_posted_cogs(list(je_by_suffix.values())):
@@ -172,13 +177,15 @@ async def run_cogs_backfill(session) -> dict:
 
         c = per_company.setdefault(doc.company_id, {
             "posted": 0, "total": 0.0, "zero_cost": 0,
-            "deferred": 0, "errored": 0, "earliest": None, "latest": None,
+            "deferred": 0, "errored": 0, "skipped": 0,
+            "earliest": None, "latest": None,
         })
         ts = fin_je.get("ts") or state.get("finalized_at") or state.get("issue_date")
         try:
             async with session.begin_nested():
-                cogs = (await compute_doc_cogs(session, doc.company_id, state)).total
-                if cogs > 0:
+                cogs_result = await compute_doc_cogs(session, doc.company_id, state)
+                cogs = cogs_result.total
+                if not cogs_result.ambiguous and cogs > 0:
                     await auto_je.create_for_doc_cogs_backfill(
                         session,
                         company_id=doc.company_id,
@@ -201,7 +208,17 @@ async def run_cogs_backfill(session) -> dict:
             c["errored"] += 1
             log.exception("COGS backfill could not compute %s", doc.entity_id)
         else:
-            if cogs > 0:
+            if cogs_result.ambiguous:
+                # The line drew beyond its bound lot, so the remainder's true lot
+                # costs are unknowable now. Posting an extrapolated guess would put
+                # a wrong number in the books; a skip is terminal and the owner
+                # posts the JE manually from the notification.
+                c["skipped"] += 1
+                log.warning(
+                    "COGS backfill skipped %s (%s): cost spans multiple lots, post manually",
+                    doc.entity_id, state.get("doc_number") or "no number",
+                )
+            elif cogs > 0:
                 c["posted"] += 1
                 c["total"] += cogs
                 day = str(ts)[:10] if ts else None
@@ -213,11 +230,11 @@ async def run_cogs_backfill(session) -> dict:
             else:
                 c["zero_cost"] += 1
 
-    totals = {"posted": 0, "zero_cost": 0, "deferred": 0, "errored": 0}
+    totals = {"posted": 0, "zero_cost": 0, "deferred": 0, "errored": 0, "skipped": 0}
     for company_id, c in per_company.items():
         for key in totals:
             totals[key] += c[key]
-        if any((c["posted"], c["zero_cost"], c["deferred"], c["errored"])):
+        if any((c["posted"], c["zero_cost"], c["deferred"], c["errored"], c["skipped"])):
             await _notify(session, company_id, c)
 
     pending = totals["deferred"] or totals["errored"]
@@ -226,8 +243,9 @@ async def run_cogs_backfill(session) -> dict:
         await conn.run_sync(lambda c: set_meta(c, COGS_BACKFILL_KEY, "done"))
 
     log.info(
-        "COGS backfill: %d posted, %d zero cost, %d deferred, %d errored%s",
+        "COGS backfill: %d posted, %d zero cost, %d deferred, %d errored, %d skipped%s",
         totals["posted"], totals["zero_cost"], totals["deferred"], totals["errored"],
+        totals["skipped"],
         "" if not pending else " (marker left unset; next boot retries)",
     )
     return {"changed": True, **totals}

--- a/celerp/services/line_measures.py
+++ b/celerp/services/line_measures.py
@@ -19,6 +19,15 @@ from __future__ import annotations
 from celerp.services.units import is_pieces_unit, is_weight_unit
 
 
+def splitting_allowed(state: dict) -> bool:
+    """Whether a parcel/item may be split, resolving a possibly-unset default.
+
+    Unset or None allow_splitting means splittable; only an explicit False
+    blocks. Single source of truth for the split default across every consumer.
+    """
+    return state.get("allow_splitting") is not False
+
+
 def _g(value) -> str:
     """Format a measure number without trailing zeros (3.0 -> '3', 4.5 -> '4.5')."""
     return f"{float(value):g}"
@@ -32,7 +41,7 @@ def item_measure_meta(item: dict, unit_map: dict) -> dict:
     sell_by = item.get("sell_by")
     return {
         "sell_by": sell_by,
-        "allow_splitting": bool(item.get("allow_splitting")),
+        "allow_splitting": splitting_allowed(item),
         "quantity": item.get("quantity"),
         "weight": item.get("weight"),
         "weight_unit": item.get("weight_unit"),
@@ -156,7 +165,7 @@ def measure_locks(meta: dict, *, allow_split: bool | None = None) -> dict:
     A cell is locked when the parcel doesn't track that measure, when the
     quantity already IS that measure, or when splitting is disallowed.
     """
-    allow = allow_split if allow_split is not None else bool(meta.get("allow_splitting", True))
+    allow = allow_split if allow_split is not None else splitting_allowed(meta)
     return {
         "pcs_locked": meta.get("pieces") is None or bool(meta.get("qty_is_pieces")) or not allow,
         "weight_locked": meta.get("weight") is None or bool(meta.get("qty_is_weight")) or not allow,

--- a/celerp/services/pick.py
+++ b/celerp/services/pick.py
@@ -14,6 +14,8 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any
 
+from celerp.services.line_measures import splitting_allowed
+
 
 @dataclass
 class PickLine:
@@ -145,7 +147,7 @@ def compute_pick_plan(
                 cost_total = float(item.get("cost_total") or 0)
                 item_qty = float(item.get("quantity") or 1)
                 cost = cost_total / item_qty if item_qty else 0.0
-            allow_split = item.get("allow_splitting", True)
+            allow_split = splitting_allowed(item)
 
             if avail <= needed + 1e-9:
                 # Take entire item

--- a/celerp/services/pick.py
+++ b/celerp/services/pick.py
@@ -85,6 +85,35 @@ def _sorted_inventory(inventory: list[dict], strategy: str) -> list[dict]:
     return sorted(inventory, key=lambda it: it.get("created_at") or "")  # fifo
 
 
+def plan_lot_draws(
+    primary: dict,
+    needed: float,
+    siblings: list[dict],
+    method: str,
+) -> tuple[list[tuple[dict, float, bool]], float]:
+    """Allocate ``needed`` units across lots: the primary (bound) lot first, then
+    the siblings in the ``method`` draw order (fifo/fefo/lifo). Each draw is
+    ``(lot, take_qty, is_full_lot)``; the second element of the result is the
+    quantity no lot could cover (0.0 when stock suffices).
+
+    Pure allocation arithmetic - eligibility (SKU match, status, reservation
+    ownership) is the caller's job. Lots are dicts carrying entity_id, quantity,
+    created_at and expires_at, as _sorted_inventory reads them.
+    """
+    draws: list[tuple[dict, float, bool]] = []
+    remaining = float(needed)
+    for lot in [primary] + _sorted_inventory(siblings, method):
+        if remaining <= 1e-9:
+            break
+        avail = float(lot.get("quantity") or 0)
+        if avail <= 1e-9:
+            continue
+        take = min(remaining, avail)
+        draws.append((lot, take, abs(take - avail) <= 1e-9))
+        remaining -= take
+    return draws, max(0.0, remaining)
+
+
 def compute_pick_plan(
     line_items: list[dict],
     inventory: list[dict],

--- a/default_modules/celerp-admin/celerp_admin/routes.py
+++ b/default_modules/celerp-admin/celerp_admin/routes.py
@@ -381,33 +381,19 @@ async def _check_zero_amount_jes(
 async def _emit_finalize_je(
     session: AsyncSession, company_id, user_id, doc_id: str, state: dict,
 ) -> None:
-    total = float(state.get("total", 0) or 0)
-    subtotal = float(state.get("subtotal", total) or total)
-    tax = float(state.get("tax", 0) or 0)
-    ts = state.get("issue_date") or state.get("created_at") or state.get("finalized_at")
+    """Delegate to auto_je.create_for_doc_finalized for DRY compliance.
 
-    je_id = f"je:auto:{doc_id}:fin"
-    entries = [
-        {"account": "1120", "debit": total, "credit": 0.0},
-        {"account": "4100", "debit": 0.0, "credit": subtotal},
-    ]
-    if tax > 0:
-        entries.append({"account": "2120", "debit": 0.0, "credit": tax})
+    A repaired invoice gets the same JE a live finalize posts - revenue, tax,
+    and the COGS pair - in the company's base currency.
+    """
+    from celerp.models.company import Company
+    from celerp.services import auto_je as _auto_je
 
-    await emit_event(
-        session, company_id=company_id, entity_id=je_id,
-        entity_type="journal_entry", event_type="acc.journal_entry.created",
-        data={"memo": f"Auto JE for {doc_id} finalized", "entries": entries, "ts": ts},
-        actor_id=user_id, location_id=None, source="auto_je",
-        idempotency_key=je_idempotency_key(doc_id, "invoice.finalized", "c"),
-        metadata_={"trigger": "doc.finalized", "doc_id": doc_id},
-    )
-    await emit_event(
-        session, company_id=company_id, entity_id=je_id,
-        entity_type="journal_entry", event_type="acc.journal_entry.posted",
-        data={}, actor_id=user_id, location_id=None, source="auto_je",
-        idempotency_key=je_idempotency_key(doc_id, "invoice.finalized", "p"),
-        metadata_={"trigger": "doc.finalized", "doc_id": doc_id},
+    company = await session.get(Company, company_id)
+    base_currency = (company.settings.get("currency", "USD") if company else "USD")
+    await _auto_je.create_for_doc_finalized(
+        session, company_id=company_id, user_id=user_id, doc_id=doc_id,
+        doc=state, base_currency=base_currency,
     )
 
 

--- a/default_modules/celerp-docs/celerp_docs/routes.py
+++ b/default_modules/celerp-docs/celerp_docs/routes.py
@@ -1438,6 +1438,12 @@ async def void_doc(entity_id: str, payload: DocVoidBody, company_id: str = Depen
 
     event_data = payload.model_dump(exclude_none=True)
     event_data["pre_void_status"] = current_status
+    # Reverse the finalize JE before the doc goes void, symmetric with unvoid's
+    # re-posting: leaving it posted would double-count once unvoid re-posts. Voiding
+    # first also surfaces a locked-period refusal before anything else mutates,
+    # mirroring the revert-to-draft ordering.
+    current_revert_count = int(row.state.get("revert_count", 0))
+    await auto_je.void_for_doc_voided(session, company_id=company_id, user_id=user.id, doc_id=entity_id, revert_count=current_revert_count)
     entry = await emit_event(
         session, company_id=company_id, entity_id=entity_id, entity_type="doc", event_type="doc.voided",
         data=event_data, actor_id=user.id, location_id=None, source="api",

--- a/default_modules/celerp-docs/celerp_docs/routes.py
+++ b/default_modules/celerp-docs/celerp_docs/routes.py
@@ -1441,12 +1441,11 @@ async def void_doc(entity_id: str, payload: DocVoidBody, company_id: str = Depen
 
     event_data = payload.model_dump(exclude_none=True)
     event_data["pre_void_status"] = current_status
-    # Reverse the finalize JE before the doc goes void, symmetric with unvoid's
-    # re-posting: leaving it posted would double-count once unvoid re-posts. Voiding
-    # first also surfaces a locked-period refusal before anything else mutates,
-    # mirroring the revert-to-draft ordering.
-    current_revert_count = int(row.state.get("revert_count", 0))
-    await auto_je.void_for_doc_voided(session, company_id=company_id, user_id=user.id, doc_id=entity_id, revert_count=current_revert_count)
+    # Reverse the recognition JEs before the doc goes void, symmetric with unvoid's
+    # batch restore: leaving them posted would double-count once unvoid re-posts.
+    # Voiding first also surfaces a locked-period refusal before anything else
+    # mutates, mirroring the revert-to-draft ordering.
+    await auto_je.void_for_doc_voided(session, company_id=company_id, user_id=user.id, doc_id=entity_id)
     entry = await emit_event(
         session, company_id=company_id, entity_id=entity_id, entity_type="doc", event_type="doc.voided",
         data=event_data, actor_id=user.id, location_id=None, source="api",
@@ -1599,10 +1598,8 @@ async def unvoid_doc(entity_id: str, payload: DocUnvoidBody, company_id: str = D
         actor_id=user.id, location_id=None, source="api",
         idempotency_key=payload.idempotency_key or str(uuid.uuid4()), metadata_={},
     )
-    # Re-apply JEs for the restored status (idempotent - uses doc-scoped keys)
-    _unvoid_company = await session.get(Company, company_id)
-    _unvoid_base_currency = (_unvoid_company.settings.get("currency", "USD") if _unvoid_company else "USD")
-    await auto_je.create_for_doc_unvoided(session, company_id=company_id, user_id=user.id, doc_id=entity_id, doc=state, base_currency=_unvoid_base_currency)
+    # Restore the JEs the void reversed (idempotent - uses doc-scoped keys)
+    await auto_je.create_for_doc_unvoided(session, company_id=company_id, user_id=user.id, doc_id=entity_id)
 
     # TODO: actual re-fulfillment after unvoid would need inventory availability check.
     # For now, restore the fulfillment_status field so the UI reflects prior state.

--- a/default_modules/celerp-docs/celerp_docs/routes.py
+++ b/default_modules/celerp-docs/celerp_docs/routes.py
@@ -4111,7 +4111,7 @@ async def _plan_span_draws(session, company_id, primary_proj, needed: float, exc
     Returns ``[(lot_proj, take_qty, is_full)]`` covering ``needed``, or None when the
     SKU's total available stock (minus already-committed lots) is still short.
     """
-    from celerp.services.pick import resolve_pick_method, _sorted_inventory
+    from celerp.services.pick import plan_lot_draws, resolve_pick_method
     from celerp.models.company import Company
     sku = str(primary_proj.state.get("sku") or "").strip()
     company = await session.get(Company, company_id)
@@ -4128,26 +4128,17 @@ async def _plan_span_draws(session, company_id, primary_proj, needed: float, exc
     by_id = {l.entity_id: l for l in lots}
     if primary_proj.entity_id not in by_id:
         return None
-    if sum(float(l.state.get("quantity") or 0) for l in lots) + 1e-9 < needed:
-        return None  # truly short across all lots
 
     def _d(p):
         return {"entity_id": p.entity_id,
+                "quantity": float(p.state.get("quantity") or 0),
                 "created_at": p.created_at.isoformat() if p.created_at else "",
                 "expires_at": p.state.get("expires_at")}
-    others = [l for l in lots if l.entity_id != primary_proj.entity_id]
-    ordered_ids = [primary_proj.entity_id] + [d["entity_id"] for d in _sorted_inventory([_d(o) for o in others], method)]
-
-    draws, remaining = [], needed
-    for eid in ordered_ids:
-        if remaining <= 1e-9:
-            break
-        lot = by_id[eid]
-        avail = float(lot.state.get("quantity") or 0)
-        take = min(remaining, avail)
-        draws.append((lot, take, abs(take - avail) <= 1e-9))
-        remaining -= take
-    return draws
+    others = [_d(l) for l in lots if l.entity_id != primary_proj.entity_id]
+    draws, short_qty = plan_lot_draws(_d(primary_proj), needed, others, method)
+    if short_qty > 1e-9:
+        return None  # truly short across all lots
+    return [(by_id[lot["entity_id"]], take, is_full) for lot, take, is_full in draws]
 
 
 def _plan_line_carve(line: dict, parcel_state: dict, unit_map: dict) -> dict | None:

--- a/default_modules/celerp-docs/celerp_docs/routes.py
+++ b/default_modules/celerp-docs/celerp_docs/routes.py
@@ -1380,7 +1380,10 @@ async def finalize_doc(entity_id: str, company_id: str = Depends(get_current_com
     )
     # Auto-JE on finalize (invoices, direct bills, or convert to bill (POs))
     if doc_type == "invoice":
-        await auto_je.create_for_doc_finalized(session, company_id=company_id, user_id=_user_id, doc_id=entity_id, doc=_initial_doc_state, base_currency=_base_currency)
+        # span_lots: the interactive finalize recognizes a line exceeding its bound
+        # lot at the sibling lots that will actually be drawn; import/repair paths
+        # stay on exact bound-lot pricing.
+        await auto_je.create_for_doc_finalized(session, company_id=company_id, user_id=_user_id, doc_id=entity_id, doc=_initial_doc_state, base_currency=_base_currency, span_lots=True)
         # Promote memo_out items to sold: memo→invoice conversion leaves items in memo_out.
         # Finalizing the invoice is the point at which the sale is confirmed.
         _cid = uuid.UUID(str(company_id))

--- a/default_modules/celerp-docs/celerp_docs/routes.py
+++ b/default_modules/celerp-docs/celerp_docs/routes.py
@@ -4249,13 +4249,18 @@ async def fulfill_lines(
         raise HTTPException(status_code=422, detail="line_entity_ids must not be empty")
 
     # Each line keyed by the item parcel it references (for qty + split measures).
+    # Line indices are captured before any split remap: _apply_split_plan rewrites
+    # lines in place, so the index is the stable key the finalize JE's per-line
+    # COGS allocation snapshot is also keyed by.
     line_qty_by_eid: dict[str, float] = {}
     line_by_eid: dict[str, dict] = {}
-    for li in state.get("line_items", []):
+    line_index_by_eid: dict[str, int] = {}
+    for _idx, li in enumerate(state.get("line_items", [])):
         _eid = li.get("entity_id") or li.get("item_id") or ""
         if _eid:
             line_qty_by_eid[_eid] = float(li.get("quantity") or 0)
             line_by_eid[_eid] = li
+            line_index_by_eid[_eid] = _idx
 
     _unit_map = await _get_unit_map(session, company_id)
 
@@ -4266,6 +4271,7 @@ async def fulfill_lines(
     split_plan: dict[str, dict] = {}  # parent_eid -> child measures (partial draws)
     fetched: dict[str, Projection] = {}
     span_consumed: set[str] = set()  # extra lots pulled in by cross-lot spanning
+    fulfilled_line_eids: set[str] = set()  # accepted stock lines, by pre-remap line eid
     for item_eid in body.line_entity_ids:
         item_proj = await session.get(Projection, {"company_id": company_id, "entity_id": item_eid})
         if item_proj is None:
@@ -4302,6 +4308,7 @@ async def fulfill_lines(
                     owner_entity_id=entity_id,
                 )
                 if _draws is not None:
+                    fulfilled_line_eids.add(item_eid)
                     for _lot, _take, _full in _draws:
                         _leid = _lot.entity_id
                         fetched[_leid] = _lot
@@ -4347,6 +4354,7 @@ async def fulfill_lines(
                 continue
         fetched[item_eid] = item_proj
         to_fulfill.append(item_eid)
+        fulfilled_line_eids.add(item_eid)
         # Partial draw of a splittable parcel: split off the invoiced amount as a child
         # and fulfill that; the mother keeps the remainder. A full or over-invoiced line
         # takes the whole parcel and plans no carve.
@@ -4407,6 +4415,32 @@ async def fulfill_lines(
             idempotency_key=str(uuid.uuid4()),
             metadata_={"doc_id": entity_id},
         )
+
+    # True up recognized COGS against reality: the finalize JE recognized each line at
+    # the lots it expected to draw; the lots actually drawn just now can cost more or
+    # less (a sibling lot was sold in between, costs changed). The difference for the
+    # lines fulfilled here posts as one adjustment JE dated to this fulfillment. Docs
+    # whose finalize JE carries no allocation snapshot have no recognized basis and
+    # get no adjustment.
+    if doc_type == "invoice" and to_fulfill:
+        _recognized_allocs = await auto_je.recognized_cogs_allocations(session, company_id, entity_id)
+        if _recognized_allocs is not None:
+            _recognized = sum(
+                float((_recognized_allocs.get(str(line_index_by_eid[_eid])) or {}).get("amount") or 0)
+                for _eid in fulfilled_line_eids if _eid in line_index_by_eid
+            )
+            _delta = round(total_cogs - _recognized, 2)
+            if abs(_delta) > 0.005:
+                await auto_je.create_for_doc_cogs_adjustment(
+                    session,
+                    company_id=cid,
+                    user_id=uid,
+                    doc_id=entity_id,
+                    delta=_delta,
+                    cycle_tag=f"fulfill-{int(state.get('revert_count') or 0)}",
+                    doc_number=state.get("doc_number") or state.get("ref_id") or entity_id,
+                    ts=now,
+                )
 
     # Optimistically compute doc fulfillment_status. Service lines count as fulfilled (they are
     # rendered, not drawn from stock) so a service-only or mixed doc can reach "fulfilled".

--- a/default_modules/celerp-docs/celerp_docs/routes.py
+++ b/default_modules/celerp-docs/celerp_docs/routes.py
@@ -26,7 +26,7 @@ from celerp.models.projections import Projection
 from celerp_docs.taxes import TaxApplication, compute_tax_amounts
 from celerp.services import auto_je
 from celerp.services.landed_cost import compute_bill_landed_allocation
-from celerp.services.line_measures import line_label
+from celerp.services.line_measures import line_label, splitting_allowed
 from celerp.services.attachments import store_upload
 from ui.components.currency import CURRENCY_CODES
 from celerp.services.auth import get_current_company_id, get_current_role, get_current_user
@@ -4219,7 +4219,7 @@ async def fulfill_lines(
             # Cross-lot spanning: a splittable product can draw the shortfall from other
             # lots of the same SKU (bound lot first, then FIFO/FEFO/LIFO). Each drawn lot
             # is fulfilled at its own cost (specific identification by lot).
-            if item_proj.state.get("allow_splitting") is True:
+            if splitting_allowed(item_proj.state):
                 _draws = await _plan_span_draws(
                     session, company_id, item_proj, line_qty,
                     exclude=set(to_fulfill) | span_consumed,
@@ -4243,9 +4243,9 @@ async def fulfill_lines(
                 f"{sku}: insufficient stock — invoiced {line_qty:g}, available {available:g}"
             )
             continue
-        # Split-on-fulfill is allowed only when splitting is explicitly enabled.
-        # A missing/None allow_splitting (e.g. older imports) must NOT bypass this.
-        if line_qty + 1e-9 < available and item_proj.state.get("allow_splitting") is not True:
+        # Split-on-fulfill is blocked only when splitting is explicitly disabled.
+        # A missing/None allow_splitting (e.g. older imports) is treated as splittable.
+        if line_qty + 1e-9 < available and not splitting_allowed(item_proj.state):
             blocked.append(
                 f"{sku}: invoiced {line_qty:g} of {available:g} but 'Allow Splitting' is off — "
                 f"enable splitting or invoice the full quantity"

--- a/default_modules/celerp-docs/celerp_docs/routes.py
+++ b/default_modules/celerp-docs/celerp_docs/routes.py
@@ -4463,16 +4463,6 @@ async def fulfill_lines(
         metadata_={},
     )
 
-    # Create COGS JE only for invoices that reach fully-fulfilled status.
-    # Memos don't get a COGS JE here; that happens when the invoice is finalized.
-    if doc_type == "invoice" and doc_fulfillment_status == "fulfilled":
-        from datetime import date as _fdate
-        await auto_je.create_for_doc_fulfilled(
-            session, company_id=cid, user_id=uid, doc_id=entity_id, total_cogs=total_cogs,
-            cycle=state.get("fulfill_cycle", 0),
-            ts=_fdate.today().isoformat(),
-        )
-
     await session.commit()
     return {"fulfillment_status": doc_fulfillment_status, "fulfilled": to_fulfill}
 
@@ -4568,14 +4558,6 @@ async def _reverse_whole_lines(
         idempotency_key=str(uuid.uuid4()),
         metadata_={},
     )
-
-    # Void COGS JE for invoices when fulfillment is fully reversed.
-    # void_for_doc_fulfilled is a no-op if no JE exists (safe to call unconditionally).
-    if doc_type == "invoice" and doc_fulfillment_status == "unfulfilled":
-        await auto_je.void_for_doc_fulfilled(
-            session, company_id=cid, user_id=uid, doc_id=entity_id,
-            cycle=state.get("fulfill_cycle", 0),
-        )
 
     return doc_fulfillment_status
 

--- a/default_modules/celerp-docs/celerp_docs/routes.py
+++ b/default_modules/celerp-docs/celerp_docs/routes.py
@@ -4144,6 +4144,82 @@ async def _plan_span_draws(session, company_id, primary_proj, needed: float, exc
     return draws
 
 
+def _plan_line_carve(line: dict, parcel_state: dict, unit_map: dict) -> dict | None:
+    """Plan how to carve the invoiced portion off a parent parcel for an on-page split.
+
+    Returns the child's split measures (quantity plus the weight/pieces the parcel is
+    sold by), or None when the line takes the whole parcel (a full or over-invoiced
+    line needs no split). Pure computation shared by fulfill and reserve so the carve
+    rule lives once.
+    """
+    line_qty = float(line.get("quantity") or 0)
+    available = float(parcel_state.get("quantity", 0))
+    if not (line_qty + 1e-9 < available):
+        return None
+    sell_by = parcel_state.get("sell_by")
+    # An explicit line measure is authoritative and is validated by split_off_child (which
+    # rejects a weight/pieces that disagrees with child_qty). Only when the line omits it
+    # do we derive it: for a parcel sold BY that measure the quantity IS the measure.
+    line_weight = line.get("weight")
+    line_pieces = line.get("pieces")
+    return {
+        "child_qty": line_qty,
+        "child_weight": line_weight if line_weight is not None
+        else (line_qty if is_weight_unit(sell_by, unit_map) else None),
+        "child_pieces": line_pieces if line_pieces is not None
+        else (line_qty if is_pieces_unit(sell_by, unit_map) else None),
+    }
+
+
+async def _apply_split_plan(
+    session, *, company_id, cid, uid, entity_id: str, state: dict,
+    split_plan: dict[str, dict], fetched: dict[str, Projection], source: str,
+) -> dict[str, tuple[str, str]]:
+    """Carve each planned child off its parent, retarget the doc lines to the child, and
+    emit the doc.updated line-items change. Returns ``{parent_eid: (child_eid, child_sku)}``.
+
+    Emits no status/transition event - each caller applies its own transition afterward
+    (fulfill emits item.fulfilled; reserve retargets its item.status.set), so fulfill's
+    semantics never leak into reserve. The parent-projection FOR UPDATE lock that keeps
+    two concurrent carves of one parcel from losing an update lives in split_off_child,
+    the single carve primitive both paths share.
+    """
+    from celerp_inventory.routes import split_off_child
+
+    remap: dict[str, tuple[str, str]] = {}
+    new_line_items = [dict(li) for li in state.get("line_items", [])]
+    for parent_eid, plan in split_plan.items():
+        try:
+            child_eid, child_sku = await split_off_child(
+                session, company_id=cid, user_id=uid, parent_proj=fetched[parent_eid],
+                child_qty=plan["child_qty"], child_weight=plan.get("child_weight"),
+                child_pieces=plan.get("child_pieces"),
+            )
+        except ValueError as exc:
+            raise HTTPException(
+                status_code=409,
+                detail=f"Cannot split {fetched[parent_eid].state.get('sku', '')}: {exc}",
+            )
+        remap[parent_eid] = (child_eid, child_sku)
+        fetched[child_eid] = await session.get(
+            Projection, {"company_id": company_id, "entity_id": child_eid})
+        for nli in new_line_items:
+            if (nli.get("entity_id") or nli.get("item_id")) == parent_eid:
+                nli["entity_id"] = child_eid
+                nli["item_id"] = child_eid
+                nli["sku"] = child_sku
+                break
+    await emit_event(
+        session, company_id=cid, entity_id=entity_id, entity_type="doc",
+        event_type="doc.updated",
+        data={"fields_changed": {"line_items": {"old": state.get("line_items"), "new": new_line_items}}},
+        actor_id=uid, location_id=None, source=source,
+        idempotency_key=str(uuid.uuid4()), metadata_={},
+    )
+    state["line_items"] = new_line_items
+    return remap
+
+
 @router.post("/{entity_id}/fulfill-lines")
 async def fulfill_lines(
     entity_id: str,
@@ -4271,17 +4347,12 @@ async def fulfill_lines(
                 continue
         fetched[item_eid] = item_proj
         to_fulfill.append(item_eid)
-        if line_qty + 1e-9 < available:
-            # Partial draw of a splittable parcel: split off the invoiced amount as a
-            # child and fulfill that; the mother keeps the remainder. For a parcel sold
-            # BY pieces/weight the quantity IS that measure, so derive it (the line
-            # doesn't carry it separately); otherwise take the line's entered value
-            # (defaults to the parcel's, so by default the child takes all).
-            split_plan[item_eid] = {
-                "child_qty": line_qty,
-                "child_weight": line_qty if is_weight_unit(_sb, _unit_map) else _line.get("weight"),
-                "child_pieces": line_qty if is_pieces_unit(_sb, _unit_map) else _line.get("pieces"),
-            }
+        # Partial draw of a splittable parcel: split off the invoiced amount as a child
+        # and fulfill that; the mother keeps the remainder. A full or over-invoiced line
+        # takes the whole parcel and plans no carve.
+        _carve = _plan_line_carve(_line, item_proj.state, _unit_map)
+        if _carve is not None:
+            split_plan[item_eid] = _carve
 
     # A shortage or a non-splittable partial prohibits the whole fulfill.
     if blocked:
@@ -4300,37 +4371,13 @@ async def fulfill_lines(
     # Split partial draws: carve the invoiced amount off each parcel as a child,
     # retarget fulfillment to the child, and rewrite the doc line to reference it.
     if split_plan:
-        from celerp_inventory.routes import split_off_child
-        new_line_items = [dict(li) for li in state.get("line_items", [])]
-        for parent_eid, plan in split_plan.items():
-            try:
-                child_eid, child_sku = await split_off_child(
-                    session, company_id=cid, user_id=uid, parent_proj=fetched[parent_eid],
-                    child_qty=plan["child_qty"], child_weight=plan.get("child_weight"),
-                    child_pieces=plan.get("child_pieces"),
-                )
-            except ValueError as exc:
-                raise HTTPException(
-                    status_code=409,
-                    detail=f"Cannot split {fetched[parent_eid].state.get('sku', '')}: {exc}",
-                )
-            to_fulfill[to_fulfill.index(parent_eid)] = child_eid
-            fetched[child_eid] = await session.get(Projection, {"company_id": company_id, "entity_id": child_eid})
-            del fetched[parent_eid]
-            for nli in new_line_items:
-                if (nli.get("entity_id") or nli.get("item_id")) == parent_eid:
-                    nli["entity_id"] = child_eid
-                    nli["item_id"] = child_eid
-                    nli["sku"] = child_sku
-                    break
-        await emit_event(
-            session, company_id=cid, entity_id=entity_id, entity_type="doc",
-            event_type="doc.updated",
-            data={"fields_changed": {"line_items": {"old": state.get("line_items"), "new": new_line_items}}},
-            actor_id=uid, location_id=None, source="fulfillment",
-            idempotency_key=str(uuid.uuid4()), metadata_={},
+        remap = await _apply_split_plan(
+            session, company_id=company_id, cid=cid, uid=uid, entity_id=entity_id,
+            state=state, split_plan=split_plan, fetched=fetched, source="fulfillment",
         )
-        state["line_items"] = new_line_items
+        for parent_eid, (child_eid, _child_sku) in remap.items():
+            to_fulfill[to_fulfill.index(parent_eid)] = child_eid
+            del fetched[parent_eid]
 
     total_cogs = 0.0
     for item_eid in to_fulfill:
@@ -4678,7 +4725,20 @@ async def _reserve_lines_impl(row, entity_id, new_status, line_entity_ids, user,
     if not line_entity_ids:
         raise HTTPException(status_code=422, detail="line_entity_ids must not be empty")
 
+    # Each line keyed by the item parcel it references, so a partial reserve can carve
+    # only the invoiced portion (the same measures the fulfill split uses).
+    line_qty_by_eid: dict[str, float] = {}
+    line_by_eid: dict[str, dict] = {}
+    for li in state.get("line_items", []):
+        _eid = li.get("entity_id") or li.get("item_id") or ""
+        if _eid:
+            line_qty_by_eid[_eid] = float(li.get("quantity") or 0)
+            line_by_eid[_eid] = li
+    unit_map = await _get_unit_map(session, row.company_id)
+
     errors: list[str] = []
+    blocked: list[str] = []  # 409: partial reserve of a non-splittable parcel
+    split_plan: dict[str, dict] = {}  # parent_eid -> child measures (partial reserves)
     projs: dict[str, Projection] = {}
     to_unship: dict[str, Projection] = {}  # sold by THIS doc: reverse the sale, then reserve
     for eid in line_entity_ids:
@@ -4709,8 +4769,23 @@ async def _reserve_lines_impl(row, entity_id, new_status, line_entity_ids, user,
             if proj.state.get("status_doc_id") != entity_id:
                 errors.append(f"{eid} ({sku}): reserved by another document")
                 continue
+        # A partially-invoiced line reserves only the invoiced portion: carve a child and
+        # reserve that. A partial reserve of an explicitly non-splittable parcel is gated
+        # exactly as partial fulfillment is. A full or over-invoiced line reserves whole.
+        if new_status == "reserved" and eid not in to_unship:
+            _carve = _plan_line_carve(line_by_eid.get(eid, {}), proj.state, unit_map)
+            if _carve is not None:
+                if not splitting_allowed(proj.state):
+                    blocked.append(
+                        f"{sku}: invoiced {line_qty_by_eid.get(eid, 0):g} of "
+                        f"{float(proj.state.get('quantity', 0)):g} but 'Allow Splitting' is off; "
+                        f"enable splitting or reserve the full quantity")
+                    continue
+                split_plan[eid] = _carve
         projs[eid] = proj
 
+    if blocked:
+        raise HTTPException(status_code=409, detail="Cannot reserve: " + "; ".join(blocked))
     if errors:
         raise HTTPException(status_code=422, detail={"errors": errors})
 
@@ -4723,8 +4798,19 @@ async def _reserve_lines_impl(row, entity_id, new_status, line_entity_ids, user,
             state=state, doc_type=state.get("doc_type", ""), to_revert=list(to_unship),
             fetched=to_unship,
         )
+    # Carve the invoiced portion off each partial parcel and reserve the child instead of
+    # the mother; the mother keeps its remainder available.
+    remap: dict[str, tuple[str, str]] = {}
+    if split_plan:
+        remap = await _apply_split_plan(
+            session, company_id=row.company_id, cid=cid, uid=user.id, entity_id=entity_id,
+            state=state, split_plan=split_plan, fetched=projs, source="reservation",
+        )
     doc_number = state.get("doc_number") or state.get("ref_id") or ""
+    reserved_eids: list[str] = []
     for eid in line_entity_ids:
+        target_eid = remap[eid][0] if eid in remap else eid
+        reserved_eids.append(target_eid)
         # Reserve stamps this doc as owner (source_doc_id present); release omits it so
         # _stamp_status_doc clears the ownership stamp - a true handoff back to the pool.
         data: dict = {"new_status": new_status}
@@ -4732,14 +4818,14 @@ async def _reserve_lines_impl(row, entity_id, new_status, line_entity_ids, user,
             data["source_doc_id"] = entity_id
             data["doc_number"] = doc_number
         await emit_event(
-            session, company_id=cid, entity_id=eid, entity_type="item",
+            session, company_id=cid, entity_id=target_eid, entity_type="item",
             event_type="item.status.set", data=data,
             actor_id=user.id, location_id=None, source="reservation",
             idempotency_key=str(uuid.uuid4()), metadata_={"doc_id": entity_id},
         )
 
     await session.commit()
-    return {"new_status": new_status, "reserved": list(line_entity_ids)}
+    return {"new_status": new_status, "reserved": reserved_eids}
 
 
 @router.post("/{entity_id}/reserve-lines")

--- a/default_modules/celerp-docs/celerp_docs/routes.py
+++ b/default_modules/celerp-docs/celerp_docs/routes.py
@@ -4422,19 +4422,27 @@ async def fulfill_lines(
     if doc_type == "invoice" and to_fulfill:
         _recognized_allocs = await auto_je.recognized_cogs_allocations(session, company_id, entity_id)
         if _recognized_allocs is not None:
+            _batch_indices = sorted({
+                line_index_by_eid[_eid] for _eid in fulfilled_line_eids if _eid in line_index_by_eid
+            })
             _recognized = sum(
-                float((_recognized_allocs.get(str(line_index_by_eid[_eid])) or {}).get("amount") or 0)
-                for _eid in fulfilled_line_eids if _eid in line_index_by_eid
+                float((_recognized_allocs.get(str(_idx)) or {}).get("amount") or 0)
+                for _idx in _batch_indices
             )
             _delta = round(total_cogs - _recognized, 2)
             if abs(_delta) > 0.005:
+                # The JE identity carries the batch's line indexes: lines of one
+                # cycle can be fulfilled in separate calls, and each batch's delta
+                # must post on its own JE. Retrying the same batch dedups on the
+                # idempotency key; a different batch is a different key.
+                _batch_tag = "l" + "-".join(str(_idx) for _idx in _batch_indices)
                 await auto_je.create_for_doc_cogs_adjustment(
                     session,
                     company_id=cid,
                     user_id=uid,
                     doc_id=entity_id,
                     delta=_delta,
-                    cycle_tag=f"fulfill-{int(state.get('revert_count') or 0)}",
+                    cycle_tag=f"fulfill-{int(state.get('revert_count') or 0)}:{_batch_tag}",
                     doc_number=state.get("doc_number") or state.get("ref_id") or entity_id,
                     ts=now,
                 )

--- a/default_modules/celerp-docs/tests/test_fulfill_no_split.py
+++ b/default_modules/celerp-docs/tests/test_fulfill_no_split.py
@@ -1,11 +1,11 @@
 # Copyright (c) 2026 Noah Severs
 # SPDX-License-Identifier: MIT
-"""Fulfillment must respect 'no split' even when allow_splitting was never set.
+"""Fulfillment treats an unset allow_splitting as splittable.
 
-A partial draw on an invoice line splits the parcel (split-on-fulfill). The
-fulfillment guard must block that split for a parcel that isn't explicitly
-splittable — a missing/None allow_splitting (e.g. older imports) must not bypass
-the gate, the same as a manual split."""
+A partial draw on an invoice line splits the parcel (split-on-fulfill). A
+missing/None allow_splitting (e.g. older imports) is splittable by default, so a
+partial fulfillment carves a child and leaves the remainder on the mother; only
+an explicit False blocks the split."""
 from __future__ import annotations
 
 import uuid
@@ -28,7 +28,7 @@ def _h(t):
 
 
 @pytest.mark.asyncio
-async def test_partial_fulfillment_blocked_when_allow_splitting_missing(client, session):
+async def test_partial_fulfillment_allowed_when_allow_splitting_missing(client, session):
     token = await _register(client)
     h = _h(token)
 
@@ -43,18 +43,17 @@ async def test_partial_fulfillment_blocked_when_allow_splitting_missing(client, 
     row.state = new_state
     await session.commit()
 
-    # Invoice drawing a PARTIAL 3 of the 10 → fulfillment would split off a child.
+    # Invoice drawing a PARTIAL 3 of the 10 → fulfillment splits off a child.
     doc = (await client.post("/docs", headers=h, json={"doc_type": "invoice", "line_items": [
         {"entity_id": item, "sku": "PARCEL-NS", "name": "Parcel", "quantity": 3, "unit_price": 5, "sell_by": "piece"}],
     })).json()["id"]
     assert (await client.post(f"/docs/{doc}/finalize", headers=h)).status_code == 200
 
     r = await client.post(f"/docs/{doc}/fulfill-lines", headers=h, json={"line_entity_ids": [item]})
-    assert r.status_code == 409, (
-        f"partial fulfillment of a no-split parcel must be blocked, got {r.status_code}: {r.text}"
+    assert r.status_code == 200, (
+        f"partial fulfillment of an unset-split parcel must be allowed, got {r.status_code}: {r.text}"
     )
-    assert "Allow Splitting" in str(r.json().get("detail", ""))
 
-    # And the parcel must be untouched (not split).
+    # And the mother parcel keeps the un-drawn remainder (10 - 3 = 7).
     parcel = (await client.get(f"/items/{item}", headers=h)).json()
-    assert float(parcel.get("quantity") or 0) == 10.0, f"parcel was split: qty={parcel.get('quantity')}"
+    assert float(parcel.get("quantity") or 0) == 7.0, f"mother remainder wrong: qty={parcel.get('quantity')}"

--- a/default_modules/celerp-docs/tests/test_inventory_account_reconciliation.py
+++ b/default_modules/celerp-docs/tests/test_inventory_account_reconciliation.py
@@ -42,7 +42,8 @@ async def test_cogs_relieves_same_account_goods_are_capitalised_to(client):
     item = (await client.post("/items", headers=_h(t), json={
         "status": "available", "sku": "RECON-1", "name": "Widget", "quantity": 10, "sell_by": "piece", "cost_total": 100})).json()["id"]
 
-    # Sell 10 @ price 20 -> COGS 100. Fulfilling posts the COGS JE.
+    # Sell 10 @ price 20 -> COGS 100. Finalizing posts the COGS legs (Dr 5100 / Cr 1130-P)
+    # on the invoice JE, alongside revenue and AR; fulfillment no longer posts COGS.
     doc = (await client.post("/docs", headers=_h(t), json={"doc_type": "invoice", "line_items": [
         {"entity_id": item, "sku": "RECON-1", "name": "Widget", "quantity": 10, "unit_price": 20, "sell_by": "piece"}],
         "total": 200})).json()["id"]
@@ -51,11 +52,17 @@ async def test_cogs_relieves_same_account_goods_are_capitalised_to(client):
     assert r.status_code == 200, r.text
 
     ledger = (await client.get("/ledger?entity_type=journal_entry", headers=_h(t))).json()["items"]
-    # The COGS JE credits inventory at 1130-P (the canonical goods account), never the orphan 1300.
-    cogs_je = next(e for e in ledger if "fulfill" in (e.get("entity_id") or "") and e["data"].get("entries"))
-    accts = {x["account"] for x in cogs_je["data"]["entries"]}
-    assert accts == {"5100", "1130-P"}, accts
-    assert "1300" not in accts
+    # COGS relieves inventory at 1130-P (the canonical goods account), never the orphan 1300.
+    cogs_je = next(e for e in ledger
+                   if any(x.get("account") == "5100" for x in (e["data"].get("entries") or [])))
+    dr = {}
+    cr = {}
+    for x in cogs_je["data"]["entries"]:
+        dr[x["account"]] = dr.get(x["account"], 0.0) + float(x.get("debit", 0) or 0)
+        cr[x["account"]] = cr.get(x["account"], 0.0) + float(x.get("credit", 0) or 0)
+    assert round(dr.get("5100", 0.0), 2) == 100.0, dr
+    assert round(cr.get("1130-P", 0.0), 2) == 100.0, cr
+    assert "1300" not in dr and "1300" not in cr
 
     # No JE anywhere references the orphan 1300 account.
     for e in ledger:

--- a/default_modules/celerp-inventory/celerp_inventory/routes.py
+++ b/default_modules/celerp-inventory/celerp_inventory/routes.py
@@ -2317,7 +2317,18 @@ async def split_off_child(session: AsyncSession, *, company_id, user_id, parent_
 
     Does NOT commit — the caller owns the transaction.
     """
-    parent = parent_proj
+    # Lock and re-read the live parent projection before carving: split_off_child emits
+    # the mother's new quantity as an ABSOLUTE value, so two concurrent carves of one
+    # parcel must each base their decrement on the current committed quantity, not on a
+    # snapshot read earlier. FOR UPDATE serializes them so the second decrements from the
+    # first's result instead of overwriting it (lost update / phantom stock).
+    locked = (await session.execute(
+        select(Projection)
+        .where(Projection.company_id == company_id, Projection.entity_id == parent_proj.entity_id)
+        .with_for_update()
+        .execution_options(populate_existing=True)
+    )).scalar_one_or_none()
+    parent = locked if locked is not None else parent_proj
     entity_id = parent.entity_id
     parent_sku = parent.state.get("sku", "")
     parent_qty = float(parent.state.get("quantity") or 0)

--- a/default_modules/celerp-inventory/celerp_inventory/routes.py
+++ b/default_modules/celerp-inventory/celerp_inventory/routes.py
@@ -40,6 +40,7 @@ from celerp.services.pricing import (
     resolve_price,
 )
 from celerp.services.units import validate_quantity, build_unit_map, get_company_units, is_weight_unit, is_pieces_unit, LANDED_COST_KINDS
+from celerp.services.line_measures import splitting_allowed
 from celerp_inventory.projections import is_item_available
 
 router = APIRouter(dependencies=[Depends(get_current_user)])
@@ -1899,9 +1900,9 @@ async def split_item(entity_id: str, payload: SplitBody, company_id=Depends(get_
     if parent is None or not is_item_available(parent.state):
         raise HTTPException(status_code=404, detail="Item not found or unavailable")
 
-    # Allow splitting ONLY when explicitly enabled (== True). A missing/None value
-    # (e.g. older imports that never set the field) must NOT bypass this gate.
-    if parent.state.get("allow_splitting") is not True:
+    # Block splitting only when explicitly disabled. A missing/None value
+    # (e.g. older imports that never set the field) is treated as splittable.
+    if not splitting_allowed(parent.state):
         raise HTTPException(
             status_code=422,
             detail="Allow splitting is set to No for this item. Change Allow Splitting to Yes in the item details to enable splitting.",
@@ -2373,6 +2374,9 @@ async def split_off_child(session: AsyncSession, *, company_id, user_id, parent_
         "status": "available",
         "attributes": child_attrs,
         "barcode": str(next_barcode_seq).zfill(6),
+        # Resolve a possibly-unset parent default to a concrete bool: a None parent
+        # (splittable by default) must not emit a None the item.created schema rejects.
+        "allow_splitting": splitting_allowed(parent.state),
     })
     if child_weight is not None:
         child_data["weight"] = child_weight
@@ -2843,7 +2847,7 @@ async def merge_items(payload: MergeBody, company_id=Depends(get_current_company
         "quantity": resulting_qty,
         "sell_by": str(target_state.get("sell_by") or "piece"),
         "status": "available",
-        "allow_splitting": bool(target_state.get("allow_splitting", True)),
+        "allow_splitting": splitting_allowed(target_state),
         "attributes": resolved_attrs,
     }
     for field in ("category", "location_id", "barcode", "description", "unit", "tax_codes"):
@@ -3216,9 +3220,8 @@ async def batch_import_items(
         for _dk in _derived_keys:
             rec.data.pop(_dk, None)
         # Normalize allow_splitting to a real bool if the import provided one (CSV
-        # gives strings like "Yes"/"No", and None means "unset"). Imports that omit
-        # it default to no-split in the create branch below; the split guard
-        # requires an explicit True, so a string/None must never read as splittable.
+        # gives strings like "Yes"/"No"). Imports that omit it leave it unset, which
+        # reads as splittable via splitting_allowed; only an explicit False blocks.
         if "allow_splitting" in rec.data and not isinstance(rec.data["allow_splitting"], bool):
             rec.data["allow_splitting"] = str(rec.data["allow_splitting"]).strip().lower() in ("true", "yes", "1", "y", "t")
 
@@ -3315,10 +3318,6 @@ async def batch_import_items(
                 skipped += 1
             continue
         try:
-            # Imported items default to no-split until splitting is explicitly
-            # enabled per item (matches how they display; the split guard requires
-            # an explicit True).
-            rec.data.setdefault("allow_splitting", False)
             loc_id: uuid.UUID | None = None
             raw_loc = rec.data.get("location_id")
             if raw_loc:

--- a/default_modules/celerp-inventory/celerp_inventory/routes.py
+++ b/default_modules/celerp-inventory/celerp_inventory/routes.py
@@ -2308,6 +2308,7 @@ async def split_off_child(session: AsyncSession, *, company_id, user_id, parent_
     no auto-derivation; the mother keeps ``parent - child`` for each.
 
     Invariants (raise ValueError if violated):
+      - child_qty must not exceed the locked parent quantity
       - parcel has weight (weight-unit sell_by OR a weight attribute)
             -> child_weight is required
       - sell_by is a weight unit  -> child_weight must equal child_qty
@@ -2321,7 +2322,9 @@ async def split_off_child(session: AsyncSession, *, company_id, user_id, parent_
     # the mother's new quantity as an ABSOLUTE value, so two concurrent carves of one
     # parcel must each base their decrement on the current committed quantity, not on a
     # snapshot read earlier. FOR UPDATE serializes them so the second decrements from the
-    # first's result instead of overwriting it (lost update / phantom stock).
+    # first's result instead of overwriting it (lost update). Serializing the read alone
+    # only fixes ordering; the capacity check just below is what stops a carve larger than
+    # what is actually on hand, which is the other half of "no phantom stock".
     locked = (await session.execute(
         select(Projection)
         .where(Projection.company_id == company_id, Projection.entity_id == parent_proj.entity_id)
@@ -2333,6 +2336,10 @@ async def split_off_child(session: AsyncSession, *, company_id, user_id, parent_
     parent_sku = parent.state.get("sku", "")
     parent_qty = float(parent.state.get("quantity") or 0)
     parent_attrs = dict(parent.state.get("attributes") or {})
+
+    # --- validate against the locked quantity (no floor, no silent clamp) ---
+    if round(child_qty - parent_qty, 10) > 0:
+        raise ValueError(f"cannot split {child_qty:g} of {parent_qty:g} available")
 
     units = await _get_company_units(session, company_id)
     unit_map = {u["name"]: u for u in units}

--- a/default_modules/celerp-manufacturing/celerp_manufacturing/routes.py
+++ b/default_modules/celerp-manufacturing/celerp_manufacturing/routes.py
@@ -30,6 +30,7 @@ from celerp.models.company import Company, User, WorkCenter
 from celerp.models.projections import Projection
 from celerp.notifications import service as notif_svc
 from celerp.services import auto_je
+from celerp.services.line_measures import splitting_allowed
 from celerp.services.auth import get_current_company_id, get_current_user
 from celerp.services.permissions import require_permission
 
@@ -1432,7 +1433,7 @@ async def _receive(session: AsyncSession, company_id, user, order_id: str, run_s
                 "sku": product.get("sku"), "name": product.get("name"),
                 "sell_by": product.get("sell_by"), "category": product.get("category"),
                 "inventory_type": product.get("inventory_type"),
-                "allow_splitting": bool(product.get("allow_splitting", True)),
+                "allow_splitting": splitting_allowed(product),
                 "quantity": 0, "location_id": loc, "parent_item_id": out_id, "lot": True,
                 "manufacturing_order_id": order_id, "cost_total": round(unit_cost * qty, 2),
             },

--- a/default_modules/celerp-manufacturing/tests/test_run_records.py
+++ b/default_modules/celerp-manufacturing/tests/test_run_records.py
@@ -165,6 +165,32 @@ async def test_fungible_output_creates_lot_at_actual_cost(client):
 
 
 @pytest.mark.asyncio
+async def test_mfg_lot_none_product_splittable(client, session):
+    """A lot manufactured from a product whose allow_splitting is unset/None inherits
+    allow_splitting True (routed through splitting_allowed). At merge-base the lot's
+    item.created event stores bool(None) = False, so the lot is wrongly non-splittable."""
+    from celerp.models.projections import Projection
+    token = await _register(client)
+    gold = await _item(client, token, "GOLDN", quantity=1000, cost_total=80000)
+    ring = await _item(client, token, "RINGN", quantity=0)
+    # Force the product's allow_splitting to a present None (older imports left it unset).
+    row = (await session.execute(select(Projection).where(Projection.entity_id == ring))).scalar_one()
+    st = dict(row.state)
+    st["allow_splitting"] = None
+    row.state = st
+    await session.commit()
+
+    await _recipe(client, token, ring, [{"item_id": gold, "quantity": 5}])
+    run = await _build(client, token, ring, 2, complete=True)
+
+    lots = await _lots(client, token, run)
+    assert len(lots) == 1
+    lot = (await client.get(f"/items/{lots[0]['id']}", headers=_h(token))).json()
+    assert lot["allow_splitting"] is True, (
+        f"a lot from a None-allow_splitting product must be splittable, got {lot.get('allow_splitting')}")
+
+
+@pytest.mark.asyncio
 async def test_fungible_sale_cogs_actual_lot_cost(client):
     """Two fungible runs at different actual costs create two lots; a sale draws them FIFO so COGS
     is the real cost of the specific lots consumed, not a recipe-standard figure."""

--- a/default_modules/first_party.lock.json
+++ b/default_modules/first_party.lock.json
@@ -6,7 +6,7 @@
   "celerp-connectors": "50a4a7e40e5d667462b805c4993741edc4125d71be04bbf1abbdaba56ee710b9",
   "celerp-contacts": "899cf9febb388356290f6eb8c8ab6d67f1f92a9c9fa8377ebb6d46bf04cedbc3",
   "celerp-dashboard": "1b813cb8756ac600f06f0c061b7e7c507ad8ede0e49901e98df6231fdb28ec46",
-  "celerp-docs": "2c8ce39651ff09c4ae9651735f7b9abb9214870697fff2e302f35b8879c3e75a",
+  "celerp-docs": "eb64e8e274d5ebc778aa76f86a0b761034fba85efa30d1d67655c52c2ff77bcc",
   "celerp-inventory": "6e2f53313db2bed1247dba40e11517df1efbfbe28c63e008b20bcf236f9d08ba",
   "celerp-labels": "1175c234602fbc80e20a33a4d03bf7abcc9a7a78d6e83729c73106cb0af53832",
   "celerp-manufacturing": "62643ff7fe708ebe68fd0895a123af77d79c0951be82655c7f50b4d25b9c8956",

--- a/default_modules/first_party.lock.json
+++ b/default_modules/first_party.lock.json
@@ -6,10 +6,10 @@
   "celerp-connectors": "50a4a7e40e5d667462b805c4993741edc4125d71be04bbf1abbdaba56ee710b9",
   "celerp-contacts": "899cf9febb388356290f6eb8c8ab6d67f1f92a9c9fa8377ebb6d46bf04cedbc3",
   "celerp-dashboard": "1b813cb8756ac600f06f0c061b7e7c507ad8ede0e49901e98df6231fdb28ec46",
-  "celerp-docs": "16961730c1a82a429d12e249e2897933d23efb8f5a274626cc0b671e1af05ac2",
-  "celerp-inventory": "f0db69e80e5c9eb095a04ac7534d039085521f94785f63d411b9f18dffc27203",
+  "celerp-docs": "2c8ce39651ff09c4ae9651735f7b9abb9214870697fff2e302f35b8879c3e75a",
+  "celerp-inventory": "6e2f53313db2bed1247dba40e11517df1efbfbe28c63e008b20bcf236f9d08ba",
   "celerp-labels": "1175c234602fbc80e20a33a4d03bf7abcc9a7a78d6e83729c73106cb0af53832",
-  "celerp-manufacturing": "4bcf5d99d58bdf14b983b1442cafcbd5c95d9cdee369677ac1fe15b807be8987",
+  "celerp-manufacturing": "62643ff7fe708ebe68fd0895a123af77d79c0951be82655c7f50b4d25b9c8956",
   "celerp-reports": "f100f83b3fc3e4565685d3a0c8e62dcc724bb35d32238f051b05c5f97ae10d13",
   "celerp-subscriptions": "9c1797ebf9afab23fc834512b7265e7a1739eb1acd5ee70a7273e360453fbc68",
   "celerp-verticals": "f8b8c15e263eb8d61e16c0b8beadfbdfe8e91b76d73882551934c8751242d70d"

--- a/default_modules/first_party.lock.json
+++ b/default_modules/first_party.lock.json
@@ -6,7 +6,7 @@
   "celerp-connectors": "50a4a7e40e5d667462b805c4993741edc4125d71be04bbf1abbdaba56ee710b9",
   "celerp-contacts": "899cf9febb388356290f6eb8c8ab6d67f1f92a9c9fa8377ebb6d46bf04cedbc3",
   "celerp-dashboard": "1b813cb8756ac600f06f0c061b7e7c507ad8ede0e49901e98df6231fdb28ec46",
-  "celerp-docs": "eb64e8e274d5ebc778aa76f86a0b761034fba85efa30d1d67655c52c2ff77bcc",
+  "celerp-docs": "f48893b04813888a12ca1e6cf49acae0d9c4bb41789f611fe5d43eda6f1b8fbd",
   "celerp-inventory": "6e2f53313db2bed1247dba40e11517df1efbfbe28c63e008b20bcf236f9d08ba",
   "celerp-labels": "1175c234602fbc80e20a33a4d03bf7abcc9a7a78d6e83729c73106cb0af53832",
   "celerp-manufacturing": "62643ff7fe708ebe68fd0895a123af77d79c0951be82655c7f50b4d25b9c8956",

--- a/default_modules/first_party.lock.json
+++ b/default_modules/first_party.lock.json
@@ -7,7 +7,7 @@
   "celerp-contacts": "899cf9febb388356290f6eb8c8ab6d67f1f92a9c9fa8377ebb6d46bf04cedbc3",
   "celerp-dashboard": "1b813cb8756ac600f06f0c061b7e7c507ad8ede0e49901e98df6231fdb28ec46",
   "celerp-docs": "b968adb8c99c9ed016fb4d9ebdc09f0358953a7df4e68eac7daed14c7c01be3b",
-  "celerp-inventory": "6e2f53313db2bed1247dba40e11517df1efbfbe28c63e008b20bcf236f9d08ba",
+  "celerp-inventory": "5eba44cd752206ec19761846d38e9703cdef27dad0e2d0bf17fe030dfd91a33a",
   "celerp-labels": "1175c234602fbc80e20a33a4d03bf7abcc9a7a78d6e83729c73106cb0af53832",
   "celerp-manufacturing": "62643ff7fe708ebe68fd0895a123af77d79c0951be82655c7f50b4d25b9c8956",
   "celerp-reports": "f100f83b3fc3e4565685d3a0c8e62dcc724bb35d32238f051b05c5f97ae10d13",

--- a/default_modules/first_party.lock.json
+++ b/default_modules/first_party.lock.json
@@ -1,6 +1,6 @@
 {
   "celerp-accounting": "51e5b4ba7f854cd501fe6468959c3313791398ea3f64a89fb080946530c4784a",
-  "celerp-admin": "7ea2ccb71eec922eb083e0f7d6e66cfa9a9b73d12756a79ac3bcdc3ea1455ba1",
+  "celerp-admin": "8f582b383eea128a5b0a79ded89d685ded48a5400442c869a0b3680bbda42101",
   "celerp-ai": "c6b1c3739f1c7a7ce565a46e1cf47c269f4010ef6251a1936e16553a61d7ecd3",
   "celerp-backup": "890e9e8c1f34e55d6b218b29ce5556247ce7e129b310da9893af692a3a2d9d8a",
   "celerp-connectors": "50a4a7e40e5d667462b805c4993741edc4125d71be04bbf1abbdaba56ee710b9",

--- a/default_modules/first_party.lock.json
+++ b/default_modules/first_party.lock.json
@@ -6,7 +6,7 @@
   "celerp-connectors": "50a4a7e40e5d667462b805c4993741edc4125d71be04bbf1abbdaba56ee710b9",
   "celerp-contacts": "899cf9febb388356290f6eb8c8ab6d67f1f92a9c9fa8377ebb6d46bf04cedbc3",
   "celerp-dashboard": "1b813cb8756ac600f06f0c061b7e7c507ad8ede0e49901e98df6231fdb28ec46",
-  "celerp-docs": "f48893b04813888a12ca1e6cf49acae0d9c4bb41789f611fe5d43eda6f1b8fbd",
+  "celerp-docs": "b968adb8c99c9ed016fb4d9ebdc09f0358953a7df4e68eac7daed14c7c01be3b",
   "celerp-inventory": "6e2f53313db2bed1247dba40e11517df1efbfbe28c63e008b20bcf236f9d08ba",
   "celerp-labels": "1175c234602fbc80e20a33a4d03bf7abcc9a7a78d6e83729c73106cb0af53832",
   "celerp-manufacturing": "62643ff7fe708ebe68fd0895a123af77d79c0951be82655c7f50b4d25b9c8956",

--- a/tests/test_fulfillment.py
+++ b/tests/test_fulfillment.py
@@ -748,6 +748,19 @@ class TestPickAllowSplitting:
         assert len(result.picks) == 1
         assert result.picks[0].action == "split"
 
+    def test_pick_plan_none_item_splittable(self):
+        """An item whose stored allow_splitting is present but None is splittable
+        (routed through splitting_allowed), the same as an absent key. At merge-base pick
+        reads item.get('allow_splitting', True), which returns None (falsy) for a
+        present-None value, so the parcel is wrongly treated as non-splittable."""
+        line_items = [{"sku": "SP-N", "quantity": 3}]
+        inventory = [{"entity_id": "eN", "sku": "SP-N", "quantity": 10, "created_at": "2026-01-01",
+                      "expires_at": None, "cost_total": 10.0, "allow_splitting": None}]
+        result = compute_pick_plan(line_items, inventory)
+        assert len(result.picks) == 1
+        assert result.picks[0].action == "split"
+        assert result.unfulfilled == []
+
 
 # ---------------------------------------------------------------------------
 # consignment_in fulfillment: must NOT deduct inventory
@@ -1234,6 +1247,8 @@ async def test_fulfill_re_fulfill_after_revert(client, auth, _setup_ids):
     # Finalize
     fin_r = await client.post(f"/docs/{doc_id}/finalize", headers=auth["headers"])
     assert fin_r.status_code == 200, fin_r.text
+    # COGS is recognized at finalize (invoice date), before any physical fulfillment.
+    assert (await _je_net(client, auth["headers"])).get("5100") == 100.0, "COGS must post at finalize"
 
     # First fulfill
     r1 = await client.post(f"/docs/{doc_id}/fulfill-lines", headers=auth["headers"],
@@ -1243,6 +1258,8 @@ async def test_fulfill_re_fulfill_after_revert(client, auth, _setup_ids):
 
     item_state = (await client.get(f"/items/{item_id}", headers=auth["headers"])).json()
     assert item_state["status"] == "sold", f"Expected sold after first fulfill, got {item_state['status']}"
+    # Physically fulfilling posts no new COGS (already recognized at finalize).
+    assert (await _je_net(client, auth["headers"])).get("5100", 0.0) == 100.0, "fulfill must not post new COGS"
 
     # Revert lines
     rv_r = await client.post(f"/docs/{doc_id}/revert-lines", headers=auth["headers"],
@@ -1251,6 +1268,8 @@ async def test_fulfill_re_fulfill_after_revert(client, auth, _setup_ids):
 
     item_state = (await client.get(f"/items/{item_id}", headers=auth["headers"])).json()
     assert item_state["status"] == "available", f"Expected available after revert, got {item_state['status']}"
+    # Un-fulfilling (revert-lines) does not void the finalize COGS.
+    assert (await _je_net(client, auth["headers"])).get("5100", 0.0) == 100.0, "revert-lines must not void finalize COGS"
 
     # Re-fulfill — must succeed without idempotency key collision
     r2 = await client.post(f"/docs/{doc_id}/fulfill-lines", headers=auth["headers"],
@@ -1260,6 +1279,8 @@ async def test_fulfill_re_fulfill_after_revert(client, auth, _setup_ids):
 
     item_state = (await client.get(f"/items/{item_id}", headers=auth["headers"])).json()
     assert item_state["status"] == "sold", f"Expected sold after re-fulfill, got {item_state['status']}"
+    # Re-fulfill posts no new COGS either.
+    assert (await _je_net(client, auth["headers"])).get("5100", 0.0) == 100.0, "re-fulfill must not double-post COGS"
 
 
 @pytest.mark.asyncio
@@ -2435,3 +2456,365 @@ async def test_sold_view_attaches_realized_sale_price(client, session, auth, _se
     rows = {it["sku"]: it for it in r.json()["items"]}
     assert "SOLDPX-B" in rows
     assert "sold_price" not in rows["SOLDPX-B"]
+
+
+# ---------------------------------------------------------------------------
+# Reserve-side partial carve, split gates for unset/None parcels, COGS-at-finalize.
+# ---------------------------------------------------------------------------
+
+
+async def _je_net(client, headers) -> dict[str, float]:
+    """Net debit-credit per account across all non-voided posted journal entries."""
+    led = (await client.get("/ledger?entity_type=journal_entry", headers=headers)).json()["items"]
+    voided = {e["entity_id"] for e in led if str(e.get("event_type", "")).endswith(".voided")}
+    by_acct: dict[str, float] = {}
+    for e in led:
+        if not str(e.get("event_type", "")).endswith(".created") or e["entity_id"] in voided:
+            continue
+        for x in (e.get("data") or {}).get("entries", []):
+            by_acct[x["account"]] = round(
+                by_acct.get(x["account"], 0.0)
+                + float(x.get("debit", 0) or 0) - float(x.get("credit", 0) or 0), 2)
+    return {k: v for k, v in by_acct.items() if abs(v) > 1e-9}
+
+
+@pytest.mark.asyncio
+async def test_reserve_partial_carves_child(client, session, auth, _setup_ids):
+    """Reserving a partially-invoiced splittable line carves off only the invoiced
+    portion to a child parcel and reserves that child; the mother keeps the remainder
+    available. At merge-base reserve flips the whole row (no carve), so the mother stays
+    reserved at full quantity and no child exists."""
+    sku = f"RESCARVE-{uuid.uuid4().hex[:6]}"
+    mother_id = await _create_item(client, auth, sku, 10, cost_price=100.0)
+    doc_id = await _create_and_finalize_invoice(client, auth, [
+        {"sku": sku, "name": sku, "quantity": 3, "unit_price": 5.0, "entity_id": mother_id},
+    ])
+    r = await client.post(f"/docs/{doc_id}/reserve-lines", headers=auth["headers"],
+                          json={"line_entity_ids": [mother_id], "new_status": "reserved"})
+    assert r.status_code == 200, r.text
+
+    doc = (await client.get(f"/docs/{doc_id}", headers=auth["headers"])).json()
+    li = doc["line_items"][0]
+    child_eid = li.get("entity_id") or li.get("item_id")
+    assert child_eid and child_eid != mother_id, "reserve did not carve a child off the mother"
+
+    child = (await client.get(f"/items/{child_eid}", headers=auth["headers"])).json()
+    assert child["status"] == "reserved"
+    assert float(child["quantity"]) == 3.0
+
+    mother = (await client.get(f"/items/{mother_id}", headers=auth["headers"])).json()
+    assert mother["status"] == "available", f"mother should stay available, got {mother['status']}"
+    assert float(mother["quantity"]) == 7.0, f"mother should keep the remainder 7, got {mother['quantity']}"
+
+
+@pytest.mark.asyncio
+async def test_reserve_partial_nonsplittable_blocked(client, session, auth, _setup_ids):
+    """A partial reserve of an explicitly non-splittable parcel is rejected (4xx) and
+    commits nothing. At merge-base reserve ignores allow_splitting and flips the whole
+    row, so it wrongly succeeds."""
+    sku = f"RESNS-{uuid.uuid4().hex[:6]}"
+    mother_id = await _create_item(client, auth, sku, 10, cost_price=100.0)
+    pr = await client.patch(f"/items/{mother_id}", headers=auth["headers"],
+                            json={"fields_changed": {"allow_splitting": {"old": True, "new": False}}})
+    assert pr.status_code == 200, pr.text
+    doc_id = await _create_and_finalize_invoice(client, auth, [
+        {"sku": sku, "name": sku, "quantity": 3, "unit_price": 5.0, "entity_id": mother_id},
+    ])
+    r = await client.post(f"/docs/{doc_id}/reserve-lines", headers=auth["headers"],
+                          json={"line_entity_ids": [mother_id], "new_status": "reserved"})
+    assert r.status_code in (409, 422), (
+        f"partial reserve of a non-splittable parcel must be blocked, got {r.status_code}: {r.text}")
+
+    mother = (await client.get(f"/items/{mother_id}", headers=auth["headers"])).json()
+    assert mother["status"] == "available", f"nothing should commit, mother={mother['status']}"
+    assert float(mother["quantity"]) == 10.0
+
+
+@pytest.mark.asyncio
+async def test_reserve_split_valueerror_returns_409(client, session, auth, _setup_ids):
+    """A reserve carve whose split_off_child rejects the quantity surfaces a per-line
+    409 'Cannot split' and commits nothing. A piece-tracked parcel whose line pieces
+    disagree with its quantity makes split_off_child raise. At merge-base reserve never
+    carves (whole-row flip), so no split is attempted and no 409 occurs."""
+    sku = f"RESVE-{uuid.uuid4().hex[:6]}"
+    mother_id = await _create_item(client, auth, sku, 10, sell_by="piece", cost_price=100.0)
+    # pieces (5) != quantity (3) on a piece-sold parcel -> split_off_child invariant fails.
+    doc_id = await _create_and_finalize_invoice(client, auth, [
+        {"sku": sku, "name": sku, "quantity": 3, "pieces": 5, "unit_price": 5.0, "entity_id": mother_id},
+    ])
+    r = await client.post(f"/docs/{doc_id}/reserve-lines", headers=auth["headers"],
+                          json={"line_entity_ids": [mother_id], "new_status": "reserved"})
+    assert r.status_code == 409, f"a rejected carve must surface 409, got {r.status_code}: {r.text}"
+    assert "split" in r.text.lower()
+
+    mother = (await client.get(f"/items/{mother_id}", headers=auth["headers"])).json()
+    assert mother["status"] == "available"
+    assert float(mother["quantity"]) == 10.0
+
+
+@pytest.mark.asyncio
+async def test_reserve_carve_concurrent_no_lost_update(client, session, auth, _setup_ids):
+    """Two carves of one parcel that each start from the same (stale) parent snapshot
+    must conserve total quantity: mother remainder + both children == the original.
+    split_off_child emits the mother's NEW quantity as an ABSOLUTE value read from the
+    parent, so without a SELECT ... FOR UPDATE re-read under lock the second carve
+    overwrites the first and a unit of stock vanishes (lost update / phantom stock)."""
+    import copy
+    import types as _types
+    from celerp.models.projections import Projection
+    from celerp_inventory.routes import split_off_child
+
+    sku = f"RESCONC-{uuid.uuid4().hex[:6]}"
+    mother_id = await _create_item(client, auth, sku, 10, sell_by="piece", cost_price=100.0)
+    cid = _setup_ids["company_id"]
+    uid = str(_setup_ids["user_id"])
+
+    real = await session.get(Projection, {"company_id": cid, "entity_id": mother_id})
+    stale = copy.deepcopy(dict(real.state))  # quantity == 10 snapshot
+
+    def _snap():
+        return _types.SimpleNamespace(entity_id=mother_id, company_id=cid, state=copy.deepcopy(stale))
+
+    # Two carves, each from the same stale parent snapshot (concurrent readers).
+    await split_off_child(session, company_id=cid, user_id=uid, parent_proj=_snap(), child_qty=3, child_pieces=3)
+    await session.commit()
+    await split_off_child(session, company_id=cid, user_id=uid, parent_proj=_snap(), child_qty=3, child_pieces=3)
+    await session.commit()
+
+    items = (await client.get("/items", headers=auth["headers"])).json()["items"]
+    lots = [i for i in items if i.get("sku") == sku]
+    total = sum(float(i.get("quantity") or 0) for i in lots)
+    assert abs(total - 10.0) < 1e-6, (
+        f"stock not conserved across concurrent carves: total={total} "
+        f"(qtys={[i.get('quantity') for i in lots]})")
+    mother = (await client.get(f"/items/{mother_id}", headers=auth["headers"])).json()
+    assert abs(float(mother["quantity"]) - 4.0) < 1e-6, (
+        f"mother should decrement cumulatively to 4, got {mother['quantity']}")
+
+
+@pytest.mark.asyncio
+async def test_split_gate_allows_none_parcel(client, session, auth, _setup_ids):
+    """A partial draw of a parcel whose allow_splitting is unset/None is allowed: the
+    fulfill gate carves a child and the mother keeps the remainder. At merge-base the
+    gate uses `is not True`, so a None parcel is wrongly blocked (409)."""
+    from celerp.models.projections import Projection
+    sku = f"SPLITNONE-{uuid.uuid4().hex[:6]}"
+    item_id = await _create_item(client, auth, sku, 10, sell_by="liter")
+    row = await session.get(Projection, {"company_id": _setup_ids["company_id"], "entity_id": item_id})
+    new_state = dict(row.state)
+    new_state["allow_splitting"] = None
+    row.state = new_state
+    await session.commit()
+
+    doc_id = await _create_and_finalize_invoice(client, auth, [
+        {"sku": sku, "name": sku, "quantity": 3, "unit_price": 5.0, "entity_id": item_id},
+    ])
+    r = await client.post(f"/docs/{doc_id}/fulfill-lines", headers=auth["headers"],
+                          json={"line_entity_ids": [item_id]})
+    assert r.status_code == 200, f"a None parcel must be splittable, got {r.status_code}: {r.text}"
+    mother = (await client.get(f"/items/{item_id}", headers=auth["headers"])).json()
+    assert float(mother["quantity"]) == 7.0, f"mother should keep remainder 7, got {mother['quantity']}"
+
+
+@pytest.mark.asyncio
+async def test_span_gate_allows_none_parcel(client, session, auth, _setup_ids):
+    """Cross-lot span of a None-allow_splitting item draws the shortfall from a sibling
+    lot instead of blocking. At merge-base the span gate uses `is True`, so a None parcel
+    fails the gate and the request is rejected as insufficient stock."""
+    from celerp.models.projections import Projection
+    h = auth["headers"]
+    sku = f"SPANNONE-{uuid.uuid4().hex[:6]}"
+    ra = await client.post("/items", headers=h, json={"status": "available", "sku": sku, "name": sku,
+                           "quantity": 60, "sell_by": "piece", "cost_total": 60.0})
+    assert ra.status_code == 200, ra.text
+    lot_a = ra.json()["id"]
+    rb = await client.post("/items", headers=h, json={"status": "available", "sku": sku, "name": sku,
+                           "quantity": 40, "sell_by": "piece", "cost_total": 80.0})
+    assert rb.status_code == 200, rb.text
+    lot_b = rb.json()["id"]
+    for eid in (lot_a, lot_b):
+        row = await session.get(Projection, {"company_id": _setup_ids["company_id"], "entity_id": eid})
+        st = dict(row.state)
+        st["allow_splitting"] = None
+        row.state = st
+    await session.commit()
+
+    doc_id = await _create_and_finalize_invoice(client, auth, [
+        {"sku": sku, "name": sku, "quantity": 100, "unit_price": 5.0, "entity_id": lot_a},
+    ])
+    r = await client.post(f"/docs/{doc_id}/fulfill-lines", headers=h, json={"line_entity_ids": [lot_a]})
+    assert r.status_code == 200, f"a None parcel must span across lots, got {r.status_code}: {r.text}"
+    assert r.json()["fulfillment_status"] == "fulfilled"
+    assert (await client.get(f"/items/{lot_a}", headers=h)).json()["status"] == "sold"
+    assert (await client.get(f"/items/{lot_b}", headers=h)).json()["status"] == "sold"
+
+
+@pytest.mark.asyncio
+async def test_invoice_line_legacy_item_splittable():
+    """A draft invoice line for an item whose allow_splitting is unset/None renders the
+    hidden allow_splitting field truthy and item_quantity as the parcel quantity. At
+    merge-base the hidden fields render allow_splitting='' and item_quantity=drawn qty."""
+    import re
+    from fasthtml.common import to_xml
+    from celerp.services.line_measures import item_measure_meta
+    from ui.routes.documents import _doc_detail
+
+    item = {"sku": "LEGACY-P", "name": "Legacy parcel", "quantity": 10, "sell_by": "piece",
+            "allow_splitting": None}
+    eid = "item:legacy-1"
+    meta = {eid: item_measure_meta(item, {})}
+    doc = {"id": "doc:leg", "entity_id": "doc:leg", "doc_type": "invoice", "status": "draft",
+           "line_items": [{"item_id": eid, "entity_id": eid, "sku": "LEGACY-P", "name": "Legacy parcel",
+                           "quantity": 3.0, "unit_price": 5.0, "sell_by": "piece"}]}
+    html = to_xml(_doc_detail(doc, item_meta_map=meta))
+    allow = re.findall(r'<input[^>]*data-name="allow_splitting"[^>]*>', html)
+    iq = re.findall(r'<input[^>]*data-name="item_quantity"[^>]*>', html)
+    assert allow, "no allow_splitting hidden input rendered"
+    assert all('value=""' not in tag for tag in allow), (
+        f"a legacy None item must render allow_splitting truthy, got {allow}")
+    assert any('value="10' in tag for tag in iq), (
+        f"item_quantity must render the parcel qty 10, not the drawn qty, got {iq}")
+
+
+@pytest.mark.asyncio
+async def test_cogs_posts_at_finalize(client, session, auth, _setup_ids):
+    """Finalizing an invoice posts COGS (Dr 5100 / Cr 1130-P), not only revenue. At
+    merge-base finalize posts revenue only; COGS waits until fulfillment."""
+    sku = f"COGSFIN-{uuid.uuid4().hex[:6]}"
+    item_id = await _create_item(client, auth, sku, 10, cost_price=5.0)  # unit cost 5
+    await _create_and_finalize_invoice(client, auth, [
+        {"sku": sku, "name": sku, "quantity": 2, "unit_price": 9.0, "entity_id": item_id},
+    ])
+    nets = await _je_net(client, auth["headers"])
+    assert nets.get("5100") == 10.0, f"finalize must debit COGS 5100 = 2*5, got {nets.get('5100')} (nets={nets})"
+    assert nets.get("1130-P") == -10.0, f"finalize must credit inventory 1130-P, got {nets.get('1130-P')} (nets={nets})"
+
+
+@pytest.mark.asyncio
+async def test_cogs_not_double_posted_on_fulfill(client, session, auth, _setup_ids):
+    """COGS is recognized once, at finalize. Physically fulfilling the issued invoice
+    posts no NEW 5100 entry. At merge-base COGS posts at fulfill instead, so the 5100
+    balance jumps when the line is fulfilled."""
+    sku = f"COGSDBL-{uuid.uuid4().hex[:6]}"
+    item_id = await _create_item(client, auth, sku, 1, cost_price=100.0)
+    doc_id = await _create_and_finalize_invoice(client, auth, [
+        {"sku": sku, "name": sku, "quantity": 1, "unit_price": 200.0, "entity_id": item_id},
+    ])
+    net_fin = await _je_net(client, auth["headers"])
+    r = await client.post(f"/docs/{doc_id}/fulfill-lines", headers=auth["headers"],
+                          json={"line_entity_ids": [item_id]})
+    assert r.status_code == 200, r.text
+    net_ful = await _je_net(client, auth["headers"])
+    assert net_ful.get("5100", 0.0) == net_fin.get("5100", 0.0), (
+        f"fulfill must not post new COGS; 5100 changed from {net_fin.get('5100')} to {net_ful.get('5100')}")
+    assert net_fin.get("5100") == 100.0, f"COGS must already post at finalize, got {net_fin.get('5100')}"
+
+
+@pytest.mark.asyncio
+async def test_cogs_partial_line_uses_line_qty(client, session, auth, _setup_ids):
+    """COGS at finalize for a partial line is line_qty * unit_cost, not the whole
+    parcel's cost. Parcel: 10 units at cost_total 50 (unit cost 5); line draws 3, so
+    COGS = 15, not 50. At merge-base finalize posts no COGS at all."""
+    sku = f"COGSPART-{uuid.uuid4().hex[:6]}"
+    item_id = await _create_item(client, auth, sku, 10, cost_price=5.0)  # cost_total 50
+    await _create_and_finalize_invoice(client, auth, [
+        {"sku": sku, "name": sku, "quantity": 3, "unit_price": 9.0, "entity_id": item_id},
+    ])
+    nets = await _je_net(client, auth["headers"])
+    assert nets.get("5100") == 15.0, f"partial-line COGS must be 3*5=15, got {nets.get('5100')} (nets={nets})"
+
+
+@pytest.mark.asyncio
+async def test_cogs_zero_cost_line_contributes_zero(client, session, auth, _setup_ids):
+    """A finalize line whose parcel cost is unknown contributes 0 COGS while a sibling
+    costed line posts its full amount, with no crash. At merge-base finalize posts no
+    COGS at all."""
+    sku_u = f"COGSU-{uuid.uuid4().hex[:6]}"   # unknown cost
+    sku_c = f"COGSC-{uuid.uuid4().hex[:6]}"   # costed
+    item_u = await _create_item(client, auth, sku_u, 5)                   # no cost set
+    item_c = await _create_item(client, auth, sku_c, 5, cost_price=4.0)   # unit cost 4
+    await _create_and_finalize_invoice(client, auth, [
+        {"sku": sku_u, "name": sku_u, "quantity": 2, "unit_price": 9.0, "entity_id": item_u},
+        {"sku": sku_c, "name": sku_c, "quantity": 2, "unit_price": 9.0, "entity_id": item_c},
+    ])
+    nets = await _je_net(client, auth["headers"])
+    assert nets.get("5100") == 8.0, (
+        f"COGS must be 0 (unknown) + 2*4 (costed) = 8, got {nets.get('5100')} (nets={nets})")
+
+
+@pytest.mark.asyncio
+async def test_cogs_parcel_qty_zero_falls_back(client, session, auth, _setup_ids):
+    """A line whose parcel has quantity <= 0 falls back to the parcel's cost_price for
+    the per-unit cost and posts no division error. Parcel: quantity 0, cost_price 7; line
+    draws 2, so COGS = 14. At merge-base finalize posts no COGS and never divides."""
+    sku = f"COGSZQ-{uuid.uuid4().hex[:6]}"
+    r = await client.post("/items", headers=auth["headers"], json={
+        "status": "available", "sku": sku, "name": sku, "quantity": 0,
+        "cost_price": 7.0, "sell_by": "piece"})
+    assert r.status_code == 200, r.text
+    item_id = r.json()["id"]
+    await _create_and_finalize_invoice(client, auth, [
+        {"sku": sku, "name": sku, "quantity": 2, "unit_price": 9.0, "entity_id": item_id},
+    ])
+    nets = await _je_net(client, auth["headers"])
+    assert nets.get("5100") == 14.0, (
+        f"parcel_qty<=0 must fall back to cost_price: 2*7=14, got {nets.get('5100')} (nets={nets})")
+
+
+@pytest.mark.asyncio
+async def test_cogs_negative_line_clamped(client, session, auth, _setup_ids):
+    """A negative per-line cost contributes 0, not a negative that cancels a correctly
+    costed sibling. Parcel A: cost_total -20 over 5 (unit -4) -> clamped to 0; Parcel B:
+    unit cost 4. Two units each: COGS = 0 + 8 = 8, not 8 + (-8) = 0. At merge-base
+    finalize posts no COGS at all."""
+    sku_n = f"COGSNEG-{uuid.uuid4().hex[:6]}"
+    sku_p = f"COGSPOS-{uuid.uuid4().hex[:6]}"
+    rn = await client.post("/items", headers=auth["headers"], json={
+        "status": "available", "sku": sku_n, "name": sku_n, "quantity": 5,
+        "cost_total": -20.0, "sell_by": "piece"})
+    assert rn.status_code == 200, rn.text
+    item_n = rn.json()["id"]
+    item_p = await _create_item(client, auth, sku_p, 5, cost_price=4.0)
+    await _create_and_finalize_invoice(client, auth, [
+        {"sku": sku_n, "name": sku_n, "quantity": 2, "unit_price": 9.0, "entity_id": item_n},
+        {"sku": sku_p, "name": sku_p, "quantity": 2, "unit_price": 9.0, "entity_id": item_p},
+    ])
+    nets = await _je_net(client, auth["headers"])
+    assert nets.get("5100") == 8.0, (
+        f"negative line must clamp to 0; COGS = 8, got {nets.get('5100')} (nets={nets})")
+
+
+@pytest.mark.asyncio
+async def test_cogs_reverses_on_revert(client, session, auth, _setup_ids):
+    """Revert-to-draft voids the finalize JE including its COGS; re-finalizing restores
+    it. At merge-base finalize carries no COGS, so there is nothing to void or restore."""
+    sku = f"COGSREV-{uuid.uuid4().hex[:6]}"
+    item_id = await _create_item(client, auth, sku, 1, cost_price=100.0)
+    doc_id = await _create_and_finalize_invoice(client, auth, [
+        {"sku": sku, "name": sku, "quantity": 1, "unit_price": 200.0, "entity_id": item_id},
+    ])
+    assert (await _je_net(client, auth["headers"])).get("5100") == 100.0, "COGS must post at finalize"
+
+    rv = await client.post(f"/docs/{doc_id}/revert-to-draft", headers=auth["headers"], json={})
+    assert rv.status_code == 200, rv.text
+    assert (await _je_net(client, auth["headers"])).get("5100", 0.0) == 0.0, "revert-to-draft must void COGS"
+
+    rf = await client.post(f"/docs/{doc_id}/finalize", headers=auth["headers"])
+    assert rf.status_code == 200, rf.text
+    assert (await _je_net(client, auth["headers"])).get("5100") == 100.0, "re-finalize must restore COGS"
+
+
+@pytest.mark.asyncio
+async def test_cogs_nonstock_or_zero_qty_line_skipped(client, session, auth, _setup_ids):
+    """A finalize line that is non-stock (no inventory parcel) contributes 0 COGS and is
+    skipped, while a sibling costed stock line still posts, with no crash. At merge-base
+    finalize posts no COGS at all."""
+    sku_c = f"COGSSTK-{uuid.uuid4().hex[:6]}"
+    item_c = await _create_item(client, auth, sku_c, 5, cost_price=4.0)
+    await _create_and_finalize_invoice(client, auth, [
+        {"sku": f"SVC-{uuid.uuid4().hex[:6]}", "name": "Service", "quantity": 2, "unit_price": 9.0},
+        {"sku": sku_c, "name": sku_c, "quantity": 2, "unit_price": 9.0, "entity_id": item_c},
+    ])
+    nets = await _je_net(client, auth["headers"])
+    assert nets.get("5100") == 8.0, (
+        f"non-stock line skipped (0), costed sibling posts 2*4=8, got {nets.get('5100')} (nets={nets})")

--- a/tests/test_fulfillment.py
+++ b/tests/test_fulfillment.py
@@ -2593,6 +2593,81 @@ async def test_reserve_carve_concurrent_no_lost_update(client, session, auth, _s
 
 
 @pytest.mark.asyncio
+async def test_split_off_child_rejects_over_capacity(client, session, auth, _setup_ids):
+    """A single carve larger than the locked parent quantity is rejected outright: no
+    child is created and the parent keeps its full quantity. At merge-base split_off_child
+    never checks child_qty against the locked read, so the carve wrongly succeeds in
+    full and the parent is floored to 0 instead of being left at its actual 4."""
+    from celerp.models.projections import Projection
+    from celerp_inventory.routes import split_off_child
+
+    sku = f"CAPCHK-{uuid.uuid4().hex[:6]}"
+    mother_id = await _create_item(client, auth, sku, 4, sell_by="piece", cost_price=100.0)
+    cid = _setup_ids["company_id"]
+    uid = str(_setup_ids["user_id"])
+
+    parent = await session.get(Projection, {"company_id": cid, "entity_id": mother_id})
+    with pytest.raises(ValueError, match="6 of 4"):
+        await split_off_child(session, company_id=cid, user_id=uid, parent_proj=parent,
+                              child_qty=6, child_pieces=6)
+    await session.rollback()
+
+    mother = (await client.get(f"/items/{mother_id}", headers=auth["headers"])).json()
+    assert float(mother["quantity"]) == 4.0, (
+        f"parent quantity must be unchanged after a rejected carve, got {mother['quantity']}")
+
+    items = (await client.get("/items", headers=auth["headers"])).json()["items"]
+    lots = [i for i in items if i.get("sku") == sku]
+    assert len(lots) == 1, f"a rejected carve must not create a child, got lots={lots}"
+
+
+@pytest.mark.asyncio
+async def test_split_off_child_concurrent_over_capacity_rejects_second(client, session, auth, _setup_ids):
+    """Two carves that each ask for more than half of one parcel must not both succeed:
+    the first consumes the parcel down to a remainder smaller than the second request, so
+    the second's own locked re-read must reject it. Total carved off the parcel must never
+    exceed what it actually held. At merge-base split_off_child never validates child_qty
+    against the locked quantity, so both 6-unit carves against the 10-unit parcel succeed
+    and 12 units come off a 10-unit parcel (phantom stock)."""
+    import copy
+    import types as _types
+    from celerp.models.projections import Projection
+    from celerp_inventory.routes import split_off_child
+
+    sku = f"CAPCONC-{uuid.uuid4().hex[:6]}"
+    mother_id = await _create_item(client, auth, sku, 10, sell_by="piece", cost_price=100.0)
+    cid = _setup_ids["company_id"]
+    uid = str(_setup_ids["user_id"])
+
+    real = await session.get(Projection, {"company_id": cid, "entity_id": mother_id})
+    stale = copy.deepcopy(dict(real.state))  # quantity == 10 snapshot
+
+    def _snap():
+        return _types.SimpleNamespace(entity_id=mother_id, company_id=cid, state=copy.deepcopy(stale))
+
+    # First carve: 6 of 10, succeeds, leaves the locked parent at 4.
+    await split_off_child(session, company_id=cid, user_id=uid, parent_proj=_snap(), child_qty=6, child_pieces=6)
+    await session.commit()
+
+    # Second carve, from the same stale (quantity == 10) snapshot: 6 of the now-locked 4
+    # must be rejected, not silently floored.
+    with pytest.raises(ValueError, match="6 of 4"):
+        await split_off_child(session, company_id=cid, user_id=uid, parent_proj=_snap(), child_qty=6, child_pieces=6)
+    await session.rollback()
+
+    items = (await client.get("/items", headers=auth["headers"])).json()["items"]
+    lots = [i for i in items if i.get("sku") == sku]
+    assert len(lots) == 2, f"only the first carve should have created a child, got lots={lots}"
+    total = sum(float(i.get("quantity") or 0) for i in lots)
+    assert total <= 10.0 + 1e-6, (
+        f"stock must never exceed the parcel's original quantity: total={total} "
+        f"(qtys={[i.get('quantity') for i in lots]})")
+    mother = (await client.get(f"/items/{mother_id}", headers=auth["headers"])).json()
+    assert abs(float(mother["quantity"]) - 4.0) < 1e-6, (
+        f"mother should hold the true remainder 4, got {mother['quantity']}")
+
+
+@pytest.mark.asyncio
 async def test_split_gate_allows_none_parcel(client, session, auth, _setup_ids):
     """A partial draw of a parcel whose allow_splitting is unset/None is allowed: the
     fulfill gate carves a child and the mother keeps the remainder. At merge-base the

--- a/tests/test_fulfillment.py
+++ b/tests/test_fulfillment.py
@@ -2848,3 +2848,231 @@ async def test_cogs_nonstock_or_zero_qty_line_skipped(client, session, auth, _se
     nets = await _je_net(client, auth["headers"])
     assert nets.get("5100") == 8.0, (
         f"non-stock line skipped (0), costed sibling posts 2*4=8, got {nets.get('5100')} (nets={nets})")
+
+
+# ---------------------------------------------------------------------------
+# Ledger correctness: cross-lot COGS at finalize, fulfill true-up, non-stock
+# lines, and void/unvoid restore fidelity.
+# ---------------------------------------------------------------------------
+
+
+async def _posted_doc_jes(session, company_id, doc_id: str) -> dict[str, dict]:
+    """entity_id -> state for every posted JE projection belonging to the doc."""
+    from sqlalchemy import select
+    from celerp.models.projections import Projection
+    rows = (await session.execute(select(Projection).where(
+        Projection.company_id == company_id,
+        Projection.entity_type == "journal_entry",
+    ))).scalars().all()
+    prefix = f"je:auto:{doc_id}:"
+    return {r.entity_id: r.state for r in rows
+            if r.entity_id.startswith(prefix) and (r.state or {}).get("status") == "posted"}
+
+
+@pytest.mark.asyncio
+async def test_cogs_finalize_spans_sibling_lots(client, session, auth, _setup_ids):
+    """Finalizing an invoice line that draws more than its bound lot holds recognizes
+    COGS across the sibling lots that will actually be drawn: bound lot first, then
+    siblings in pick order, each at its own cost. Lots: A 2 units at 10, B 3 units at
+    30, same splittable SKU; line qty 5 bound to A must post COGS 2*10 + 3*30 = 110,
+    not 5 units extrapolated at A's unit cost (50)."""
+    sku = f"SPANFIN-{uuid.uuid4().hex[:6]}"
+    lot_a = await _create_item(client, auth, sku, 2, cost_price=10.0)
+    await _create_item(client, auth, sku, 3, cost_price=30.0)
+    await _create_and_finalize_invoice(client, auth, [
+        {"sku": sku, "name": sku, "quantity": 5, "unit_price": 50.0, "entity_id": lot_a},
+    ])
+    nets = await _je_net(client, auth["headers"])
+    assert nets.get("5100") == 110.0, (
+        f"cross-lot finalize COGS must be 2*10 + 3*30 = 110, got {nets.get('5100')} (nets={nets})")
+    assert nets.get("1130-P") == -110.0, (
+        f"inventory relief must match at -110, got {nets.get('1130-P')} (nets={nets})")
+
+
+@pytest.mark.asyncio
+async def test_cogs_finalize_oversell_prices_shortfall_at_bound_cost(client, session, auth, _setup_ids):
+    """When the whole SKU is short of the invoiced quantity, finalize still succeeds:
+    the allocatable units price at their own lots' costs and the unallocatable
+    remainder prices provisionally at the bound lot's unit cost. Lots: A 2 at 10,
+    B 2 at 30 (total 4); line qty 5 bound to A posts 2*10 + 2*30 + 1*10 = 90."""
+    sku = f"SPANSHORT-{uuid.uuid4().hex[:6]}"
+    lot_a = await _create_item(client, auth, sku, 2, cost_price=10.0)
+    await _create_item(client, auth, sku, 2, cost_price=30.0)
+    await _create_and_finalize_invoice(client, auth, [
+        {"sku": sku, "name": sku, "quantity": 5, "unit_price": 50.0, "entity_id": lot_a},
+    ])
+    nets = await _je_net(client, auth["headers"])
+    assert nets.get("5100") == 90.0, (
+        f"oversold line must post 2*10 + 2*30 + 1*10 = 90, got {nets.get('5100')} (nets={nets})")
+    assert nets.get("1130-P") == -90.0, (
+        f"inventory relief must match at -90, got {nets.get('1130-P')} (nets={nets})")
+
+
+@pytest.mark.asyncio
+async def test_fulfill_true_up_posts_adjustment_je(client, session, auth, _setup_ids):
+    """Fulfillment compares the actual cost of the lots drawn with the COGS recognized
+    at finalize and posts one adjustment JE for the difference; a fulfill whose actual
+    cost equals the recognized amount posts no adjustment; re-running the adjustment
+    is idempotent.
+
+    Setup: lots A 2 at 10, B 3 at 30, C 3 at 50. doc1 line qty 5 bound to A
+    recognizes 2*10 + 3*30 = 110 at finalize. doc2 then sells lot B outright
+    (recognized 90, fulfilled at exactly 90: no adjustment). Fulfilling doc1
+    afterwards draws A and C (B is sold), actual 2*10 + 3*50 = 170, so doc1 gets one
+    adjustment JE of +60."""
+    from celerp.models.projections import Projection
+
+    cid = _setup_ids["company_id"]
+    sku = f"TRUEUP-{uuid.uuid4().hex[:6]}"
+    lot_a = await _create_item(client, auth, sku, 2, cost_price=10.0)
+    lot_b = await _create_item(client, auth, sku, 3, cost_price=30.0)
+    await _create_item(client, auth, sku, 3, cost_price=50.0)
+
+    doc1 = await _create_and_finalize_invoice(client, auth, [
+        {"sku": sku, "name": sku, "quantity": 5, "unit_price": 50.0, "entity_id": lot_a},
+    ])
+    doc2 = await _create_and_finalize_invoice(client, auth, [
+        {"sku": sku, "name": sku, "quantity": 3, "unit_price": 50.0, "entity_id": lot_b},
+    ])
+
+    r = await client.post(f"/docs/{doc2}/fulfill-lines", headers=auth["headers"],
+                          json={"line_entity_ids": [lot_b]})
+    assert r.status_code == 200, r.text
+    session.expire_all()
+    doc2_adj = await session.get(
+        Projection, {"company_id": cid, "entity_id": f"je:auto:{doc2}:cogs-adj:fulfill-0"})
+    assert doc2_adj is None, (
+        "a fulfill whose actual cost equals the recognized COGS must post no adjustment JE")
+
+    r = await client.post(f"/docs/{doc1}/fulfill-lines", headers=auth["headers"],
+                          json={"line_entity_ids": [lot_a]})
+    assert r.status_code == 200, r.text
+    session.expire_all()
+    adj_id = f"je:auto:{doc1}:cogs-adj:fulfill-0"
+    adj = await session.get(Projection, {"company_id": cid, "entity_id": adj_id})
+    assert adj is not None and adj.state.get("status") == "posted", (
+        f"fulfillment must post the COGS adjustment JE {adj_id} (actual 170 vs recognized 110)")
+    by_acct = {e["account"]: (float(e.get("debit") or 0), float(e.get("credit") or 0))
+               for e in adj.state.get("entries", [])}
+    assert by_acct.get("5100") == (60.0, 0.0), (
+        f"adjustment must debit 5100 by exactly 60, got {by_acct.get('5100')}")
+    assert by_acct.get("1130-P") == (0.0, 60.0), (
+        f"adjustment must credit 1130-P by exactly 60, got {by_acct.get('1130-P')}")
+
+    nets = await _je_net(client, auth["headers"])
+    assert nets.get("5100") == 260.0, (
+        f"total COGS must be 110 + 90 + 60 = 260, got {nets.get('5100')} (nets={nets})")
+
+    # Idempotency: replaying the same adjustment must not double-post.
+    from sqlalchemy import func, select
+    from celerp.models.ledger import LedgerEntry
+    from celerp.services import auto_je as auto_je_service
+    rows_before = (await session.execute(
+        select(func.count()).select_from(LedgerEntry)
+        .where(LedgerEntry.company_id == cid, LedgerEntry.entity_id == adj_id))).scalar()
+    await auto_je_service.create_for_doc_cogs_adjustment(
+        session, company_id=cid, user_id=None, doc_id=doc1, delta=60.0,
+        cycle_tag="fulfill-0", doc_number="RETRY", ts="2026-01-01")
+    await session.commit()
+    rows_after = (await session.execute(
+        select(func.count()).select_from(LedgerEntry)
+        .where(LedgerEntry.company_id == cid, LedgerEntry.entity_id == adj_id))).scalar()
+    assert rows_after == rows_before, (
+        f"re-running the adjustment must be a no-op, ledger rows went {rows_before} -> {rows_after}")
+
+
+@pytest.mark.asyncio
+async def test_cogs_finalize_skips_service_and_freight_lines(client, session, auth, _setup_ids):
+    """Non-stock lines (service and freight catalog items) carry a cost for margin
+    display but hold no goods, so finalize must post no 5100/1130-P movement for them.
+    Only the stock sibling's 2*4 = 8 may post."""
+    sku_s = f"SVCLINE-{uuid.uuid4().hex[:6]}"
+    sku_f = f"FRTLINE-{uuid.uuid4().hex[:6]}"
+    sku_c = f"STKLINE-{uuid.uuid4().hex[:6]}"
+    rs = await client.post("/items", headers=auth["headers"], json={
+        "status": "available", "sku": sku_s, "name": sku_s, "quantity": 1,
+        "sell_by": "piece", "inventory_type": "service", "cost_total": 30.0})
+    assert rs.status_code == 200, rs.text
+    item_s = rs.json()["id"]
+    rf = await client.post("/items", headers=auth["headers"], json={
+        "status": "available", "sku": sku_f, "name": sku_f, "quantity": 1,
+        "sell_by": "piece", "inventory_type": "freight", "cost_total": 25.0})
+    assert rf.status_code == 200, rf.text
+    item_f = rf.json()["id"]
+    item_c = await _create_item(client, auth, sku_c, 5, cost_price=4.0)
+    await _create_and_finalize_invoice(client, auth, [
+        {"sku": sku_s, "name": sku_s, "quantity": 1, "unit_price": 90.0, "entity_id": item_s},
+        {"sku": sku_f, "name": sku_f, "quantity": 1, "unit_price": 40.0, "entity_id": item_f},
+        {"sku": sku_c, "name": sku_c, "quantity": 2, "unit_price": 9.0, "entity_id": item_c},
+    ])
+    nets = await _je_net(client, auth["headers"])
+    assert nets.get("5100") == 8.0, (
+        f"service/freight lines must post no COGS; only stock 2*4=8, got {nets.get('5100')} (nets={nets})")
+    assert nets.get("1130-P") == -8.0, (
+        f"service/freight lines must not relieve inventory; expected -8, got {nets.get('1130-P')} (nets={nets})")
+
+
+@pytest.mark.asyncio
+async def test_double_void_unvoid_cycle_restores_original_economics(client, session, auth, _setup_ids):
+    """Unvoid restores exactly what the immediately preceding void removed, never a
+    recomputation. Finalize -> void -> unvoid -> void -> unvoid, with a sibling lot's
+    cost changed between the cycles, must end with exactly one live posted recognition
+    JE whose economics equal the original finalize, and the trial balance back to the
+    post-finalize snapshot."""
+    from celerp.models.projections import Projection
+
+    cid = _setup_ids["company_id"]
+    sku = f"DBLVOID-{uuid.uuid4().hex[:6]}"
+    lot_a = await _create_item(client, auth, sku, 2, cost_price=10.0)
+    lot_b = await _create_item(client, auth, sku, 3, cost_price=30.0)
+    doc_id = await _create_and_finalize_invoice(client, auth, [
+        {"sku": sku, "name": sku, "quantity": 5, "unit_price": 100.0, "entity_id": lot_a},
+    ])
+    snapshot = await _je_net(client, auth["headers"])
+    assert snapshot.get("5100") == 110.0, (
+        f"finalize must recognize 2*10 + 3*30 = 110, got {snapshot.get('5100')}")
+    assert snapshot.get("4100") == -500.0, f"revenue must post at -500, got {snapshot.get('4100')}"
+
+    r = await client.post(f"/docs/{doc_id}/void", headers=auth["headers"], json={"reason": "cycle one"})
+    assert r.status_code == 200, r.text
+    after_void = await _je_net(client, auth["headers"])
+    assert after_void.get("5100", 0.0) == 0.0 and after_void.get("4100", 0.0) == 0.0, (
+        f"first void must reverse the recognition, got {after_void}")
+
+    r = await client.post(f"/docs/{doc_id}/unvoid", headers=auth["headers"], json={})
+    assert r.status_code == 200, r.text
+    assert await _je_net(client, auth["headers"]) == snapshot, (
+        "first unvoid must restore the exact post-finalize trial balance")
+
+    # A sibling cost change between the cycles: a recomputing unvoid would now
+    # produce different numbers, a restoring one must not.
+    session.expire_all()
+    lot_b_row = await session.get(Projection, {"company_id": cid, "entity_id": lot_b})
+    lot_b_row.state = {**lot_b_row.state, "cost_total": 300.0}
+    session.add(lot_b_row)
+    await session.commit()
+
+    r = await client.post(f"/docs/{doc_id}/void", headers=auth["headers"], json={"reason": "cycle two"})
+    assert r.status_code == 200, r.text
+    after_void2 = await _je_net(client, auth["headers"])
+    assert after_void2.get("5100", 0.0) == 0.0 and after_void2.get("4100", 0.0) == 0.0, (
+        f"second void must reverse the restored recognition, got {after_void2}")
+
+    r = await client.post(f"/docs/{doc_id}/unvoid", headers=auth["headers"], json={})
+    assert r.status_code == 200, r.text
+    final_nets = await _je_net(client, auth["headers"])
+    assert final_nets == snapshot, (
+        f"second unvoid must restore the original finalize economics {snapshot}, got {final_nets}")
+
+    session.expire_all()
+    posted = await _posted_doc_jes(session, cid, doc_id)
+    cogs_posted = [eid for eid, st in posted.items()
+                   if any(e.get("account") == "5100" and float(e.get("debit") or 0) > 0
+                          for e in st.get("entries", []))]
+    assert len(cogs_posted) == 1, (
+        f"exactly one live recognition JE may carry COGS after the cycles, got {cogs_posted}")
+    live = posted[cogs_posted[0]]
+    by_acct = {e["account"]: (float(e.get("debit") or 0), float(e.get("credit") or 0))
+               for e in live.get("entries", [])}
+    assert by_acct.get("5100") == (110.0, 0.0), (
+        f"the live JE must carry the ORIGINAL COGS of 110, got {by_acct.get('5100')}")

--- a/tests/test_fulfillment.py
+++ b/tests/test_fulfillment.py
@@ -2940,7 +2940,7 @@ async def test_fulfill_true_up_posts_adjustment_je(client, session, auth, _setup
     assert r.status_code == 200, r.text
     session.expire_all()
     doc2_adj = await session.get(
-        Projection, {"company_id": cid, "entity_id": f"je:auto:{doc2}:cogs-adj:fulfill-0"})
+        Projection, {"company_id": cid, "entity_id": f"je:auto:{doc2}:cogs-adj:fulfill-0:l0"})
     assert doc2_adj is None, (
         "a fulfill whose actual cost equals the recognized COGS must post no adjustment JE")
 
@@ -2948,7 +2948,7 @@ async def test_fulfill_true_up_posts_adjustment_je(client, session, auth, _setup
                           json={"line_entity_ids": [lot_a]})
     assert r.status_code == 200, r.text
     session.expire_all()
-    adj_id = f"je:auto:{doc1}:cogs-adj:fulfill-0"
+    adj_id = f"je:auto:{doc1}:cogs-adj:fulfill-0:l0"
     adj = await session.get(Projection, {"company_id": cid, "entity_id": adj_id})
     assert adj is not None and adj.state.get("status") == "posted", (
         f"fulfillment must post the COGS adjustment JE {adj_id} (actual 170 vs recognized 110)")
@@ -2972,13 +2972,103 @@ async def test_fulfill_true_up_posts_adjustment_je(client, session, auth, _setup
         .where(LedgerEntry.company_id == cid, LedgerEntry.entity_id == adj_id))).scalar()
     await auto_je_service.create_for_doc_cogs_adjustment(
         session, company_id=cid, user_id=None, doc_id=doc1, delta=60.0,
-        cycle_tag="fulfill-0", doc_number="RETRY", ts="2026-01-01")
+        cycle_tag="fulfill-0:l0", doc_number="RETRY", ts="2026-01-01")
     await session.commit()
     rows_after = (await session.execute(
         select(func.count()).select_from(LedgerEntry)
         .where(LedgerEntry.company_id == cid, LedgerEntry.entity_id == adj_id))).scalar()
     assert rows_after == rows_before, (
         f"re-running the adjustment must be a no-op, ledger rows went {rows_before} -> {rows_after}")
+
+
+@pytest.mark.asyncio
+async def test_fulfill_true_up_per_batch_posts_separate_adjustments(client, session, auth, _setup_ids):
+    """Lines of one cycle fulfilled in separate calls each true up on their own
+    batch-keyed JE: the JE id carries the batch's line indexes, so a second batch
+    with a different delta posts its own adjustment instead of deduping away on
+    the first batch's idempotency key, and each batch's delta compares only that
+    batch's lines. Replaying a batch stays a no-op.
+
+    Setup: two SKUs. SKU1 lots A1 2 at 10, B1 3 at 30, C1 3 at 50; SKU2 lots
+    A2 2 at 20, B2 3 at 40, C2 3 at 70. doc1 line 0 (SKU1 qty 5 bound A1)
+    recognizes 110; line 1 (SKU2 qty 5 bound A2) recognizes 160. doc2 sells B1
+    and B2 outright, so batch 1 (line 0) draws A1+C1 = 170, delta +60, and
+    batch 2 (line 1) draws A2+C2 = 250, delta +90."""
+    from celerp.models.projections import Projection
+
+    cid = _setup_ids["company_id"]
+    sku1 = f"BATCH1-{uuid.uuid4().hex[:6]}"
+    sku2 = f"BATCH2-{uuid.uuid4().hex[:6]}"
+    lot_a1 = await _create_item(client, auth, sku1, 2, cost_price=10.0)
+    lot_b1 = await _create_item(client, auth, sku1, 3, cost_price=30.0)
+    await _create_item(client, auth, sku1, 3, cost_price=50.0)
+    lot_a2 = await _create_item(client, auth, sku2, 2, cost_price=20.0)
+    lot_b2 = await _create_item(client, auth, sku2, 3, cost_price=40.0)
+    await _create_item(client, auth, sku2, 3, cost_price=70.0)
+
+    doc1 = await _create_and_finalize_invoice(client, auth, [
+        {"sku": sku1, "name": sku1, "quantity": 5, "unit_price": 60.0, "entity_id": lot_a1},
+        {"sku": sku2, "name": sku2, "quantity": 5, "unit_price": 80.0, "entity_id": lot_a2},
+    ])
+    doc2 = await _create_and_finalize_invoice(client, auth, [
+        {"sku": sku1, "name": sku1, "quantity": 3, "unit_price": 60.0, "entity_id": lot_b1},
+        {"sku": sku2, "name": sku2, "quantity": 3, "unit_price": 80.0, "entity_id": lot_b2},
+    ])
+    r = await client.post(f"/docs/{doc2}/fulfill-lines", headers=auth["headers"],
+                          json={"line_entity_ids": [lot_b1, lot_b2]})
+    assert r.status_code == 200, r.text
+
+    def _adj_amount(adj):
+        by_acct = {e["account"]: (float(e.get("debit") or 0), float(e.get("credit") or 0))
+                   for e in adj.state.get("entries", [])}
+        return by_acct.get("5100")
+
+    # Batch 1: line 0 only.
+    r = await client.post(f"/docs/{doc1}/fulfill-lines", headers=auth["headers"],
+                          json={"line_entity_ids": [lot_a1]})
+    assert r.status_code == 200, r.text
+    session.expire_all()
+    adj_l0_id = f"je:auto:{doc1}:cogs-adj:fulfill-0:l0"
+    adj_l0 = await session.get(Projection, {"company_id": cid, "entity_id": adj_l0_id})
+    assert adj_l0 is not None and adj_l0.state.get("status") == "posted", (
+        f"batch 1 must post its own adjustment JE {adj_l0_id} (actual 170 vs recognized 110)")
+    assert _adj_amount(adj_l0) == (60.0, 0.0), (
+        f"batch 1 delta must be +60 for its own line only, got {_adj_amount(adj_l0)}")
+
+    # Batch 2: line 1, same cycle, different delta. Must post a second JE, not
+    # dedup away on batch 1's key.
+    r = await client.post(f"/docs/{doc1}/fulfill-lines", headers=auth["headers"],
+                          json={"line_entity_ids": [lot_a2]})
+    assert r.status_code == 200, r.text
+    session.expire_all()
+    adj_l1_id = f"je:auto:{doc1}:cogs-adj:fulfill-0:l1"
+    adj_l1 = await session.get(Projection, {"company_id": cid, "entity_id": adj_l1_id})
+    assert adj_l1 is not None and adj_l1.state.get("status") == "posted", (
+        f"batch 2 must post its own adjustment JE {adj_l1_id} (actual 250 vs recognized 160)")
+    assert _adj_amount(adj_l1) == (90.0, 0.0), (
+        f"batch 2 delta must be +90 for its own line only, got {_adj_amount(adj_l1)}")
+    adj_l0 = await session.get(Projection, {"company_id": cid, "entity_id": adj_l0_id})
+    assert _adj_amount(adj_l0) == (60.0, 0.0), "batch 2 must not disturb batch 1's JE"
+
+    # Replaying batch 2 posts nothing new, even with a different computed delta.
+    from sqlalchemy import func, select
+    from celerp.models.ledger import LedgerEntry
+    from celerp.services import auto_je as auto_je_service
+    rows_before = (await session.execute(
+        select(func.count()).select_from(LedgerEntry)
+        .where(LedgerEntry.company_id == cid, LedgerEntry.entity_id == adj_l1_id))).scalar()
+    await auto_je_service.create_for_doc_cogs_adjustment(
+        session, company_id=cid, user_id=None, doc_id=doc1, delta=42.0,
+        cycle_tag="fulfill-0:l1", doc_number="RETRY", ts="2026-01-01")
+    await session.commit()
+    rows_after = (await session.execute(
+        select(func.count()).select_from(LedgerEntry)
+        .where(LedgerEntry.company_id == cid, LedgerEntry.entity_id == adj_l1_id))).scalar()
+    assert rows_after == rows_before, (
+        f"replaying batch 2 must be a no-op, ledger rows went {rows_before} -> {rows_after}")
+    session.expire_all()
+    adj_l1 = await session.get(Projection, {"company_id": cid, "entity_id": adj_l1_id})
+    assert _adj_amount(adj_l1) == (90.0, 0.0), "replay must not change batch 2's posted entries"
 
 
 @pytest.mark.asyncio

--- a/tests/test_fulfillment.py
+++ b/tests/test_fulfillment.py
@@ -2805,6 +2805,36 @@ async def test_cogs_reverses_on_revert(client, session, auth, _setup_ids):
 
 
 @pytest.mark.asyncio
+async def test_void_unvoid_does_not_double_post_ledger(client, session, auth, _setup_ids):
+    """Void then unvoid a finalized invoice nets revenue and COGS back to a single
+    posting, never double. Voiding reverses the finalize JE (revenue + COGS); unvoiding
+    re-posts it once. At merge-base void reverses nothing while unvoid re-posts, so the
+    round trip leaves 5100 and 4100 at double their finalize values."""
+    sku = f"VOIDCYC-{uuid.uuid4().hex[:6]}"
+    item_id = await _create_item(client, auth, sku, 1, cost_price=100.0)
+    doc_id = await _create_and_finalize_invoice(client, auth, [
+        {"sku": sku, "name": sku, "quantity": 1, "unit_price": 200.0, "entity_id": item_id},
+    ])
+    after_finalize = await _je_net(client, auth["headers"])
+    assert after_finalize.get("5100") == 100.0, f"COGS posts at finalize, got {after_finalize.get('5100')}"
+    assert after_finalize.get("4100") == -200.0, f"revenue posts at finalize, got {after_finalize.get('4100')}"
+
+    # Void reverses the finalize JE: no finalize-related posting stays live.
+    r = await client.post(f"/docs/{doc_id}/void", headers=auth["headers"], json={"reason": "test void"})
+    assert r.status_code == 200, r.text
+    after_void = await _je_net(client, auth["headers"])
+    assert after_void.get("5100", 0.0) == 0.0, f"void must reverse COGS, got {after_void.get('5100')}"
+    assert after_void.get("4100", 0.0) == 0.0, f"void must reverse revenue, got {after_void.get('4100')}"
+
+    # Unvoid re-posts the finalize JE exactly once: back to the finalize state, not double.
+    r = await client.post(f"/docs/{doc_id}/unvoid", headers=auth["headers"], json={})
+    assert r.status_code == 200, r.text
+    after_unvoid = await _je_net(client, auth["headers"])
+    assert after_unvoid.get("5100") == 100.0, f"unvoid restores COGS to 100 (not 200), got {after_unvoid.get('5100')}"
+    assert after_unvoid.get("4100") == -200.0, f"unvoid restores revenue to -200 (not -400), got {after_unvoid.get('4100')}"
+
+
+@pytest.mark.asyncio
 async def test_cogs_nonstock_or_zero_qty_line_skipped(client, session, auth, _setup_ids):
     """A finalize line that is non-stock (no inventory parcel) contributes 0 COGS and is
     skipped, while a sibling costed stock line still posts, with no crash. At merge-base

--- a/tests/test_line_measures.py
+++ b/tests/test_line_measures.py
@@ -136,3 +136,18 @@ def test_measure_locks():
     # non-splittable: everything locked.
     locks2 = measure_locks({**meta, "allow_splitting": False})
     assert locks2 == {"pcs_locked": True, "weight_locked": True, "qty_locked": True}
+
+
+def test_splitting_allowed_default_unset_true():
+    """splitting_allowed treats an unset/None allow_splitting as True (only an explicit
+    False blocks), and item_measure_meta reflects that. At merge-base item_measure_meta
+    returns allow_splitting False for a None item, and there is no splitting_allowed
+    helper to import."""
+    from celerp.services.line_measures import splitting_allowed
+    assert splitting_allowed({}) is True
+    assert splitting_allowed({"allow_splitting": None}) is True
+    assert splitting_allowed({"allow_splitting": True}) is True
+    assert splitting_allowed({"allow_splitting": False}) is False
+
+    none_item = {"sell_by": "piece", "quantity": 10, "allow_splitting": None}
+    assert item_measure_meta(none_item, UM)["allow_splitting"] is True

--- a/tests/test_projections/test_cogs_backfill.py
+++ b/tests/test_projections/test_cogs_backfill.py
@@ -636,3 +636,62 @@ async def test_backfill_ledger_invariant_and_idempotent_rowcount(session):
     await session.commit()
     assert second == {"changed": False}
     assert await _rowcount(session) == rows_after_first
+
+
+@pytest.mark.asyncio
+async def test_backfill_skips_ambiguous_multi_lot_invoice(session, caplog):
+    """A historical invoice whose line quantity exceeds its bound splittable lot
+    cannot be costed from that lot alone (the remainder came from sibling lots at
+    unknown costs), so the backfill posts nothing for it, counts it as skipped,
+    says so in the notification, and warns in the log. The skip is terminal: the
+    completion marker still sets and the next boot is a no-op."""
+    import logging
+
+    await _clear_marker(session)
+    company_id = await _seed_company(session)
+    _seed_parcel(session, company_id, "item:amb1", cost_total=40.0, quantity=2.0)
+    _seed_parcel(session, company_id, "item:amb2", cost_total=40.0, quantity=2.0)
+    doc_ok = "doc:INV-AMB1"
+    doc_amb = "doc:INV-AMB2"
+    _seed_doc(session, company_id, doc_ok,
+              line_items=[{"quantity": 1, "item_id": "item:amb1", "line_total": 100.0}],
+              finalized_at="2024-04-05")
+    _seed_doc(session, company_id, doc_amb,
+              line_items=[{"quantity": 5, "item_id": "item:amb2", "line_total": 500.0}],
+              finalized_at="2024-04-06")
+    await _emit_je(session, company_id, f"je:auto:{doc_ok}:fin",
+                   entries=_fin_entries(), ts="2024-04-05")
+    await _emit_je(session, company_id, f"je:auto:{doc_amb}:fin",
+                   entries=_fin_entries(total=550.0, revenue=500.0, tax=50.0), ts="2024-04-06")
+    await session.commit()
+
+    with caplog.at_level(logging.WARNING, logger="celerp.services.cogs_backfill"):
+        result = await run_cogs_backfill(session)
+    await session.commit()
+
+    assert result["posted"] == 1, f"only the unambiguous invoice may post, got {result}"
+    assert result["skipped"] == 1, f"the ambiguous invoice must count as skipped, got {result}"
+
+    jes_ok = await _doc_jes(session, company_id, doc_ok)
+    assert _posted_5100_debits(jes_ok) == [20.0], (
+        f"unambiguous invoice must get its 1*20 backfill, got {_posted_5100_debits(jes_ok)}")
+    jes_amb = await _doc_jes(session, company_id, doc_amb)
+    assert f"je:auto:{doc_amb}:cogs-backfill" not in jes_amb, (
+        "ambiguous invoice must receive no backfill JE at all")
+
+    assert any(doc_amb in rec.getMessage() for rec in caplog.records), (
+        f"skip must be warned with the doc id, got {[r.getMessage() for r in caplog.records]}")
+
+    notes = await _notifications(session, company_id)
+    assert len(notes) == 1
+    assert "1 skipped: cost spans multiple lots, post manually." in notes[0].body, (
+        f"notification must carry the skip, got: {notes[0].body}")
+
+    assert await _marker_value(session) == "done", (
+        "ambiguous skips are terminal and must not hold the completion marker open")
+
+    rows_after_first = await _rowcount(session)
+    second = await run_cogs_backfill(session)
+    await session.commit()
+    assert second == {"changed": False}
+    assert await _rowcount(session) == rows_after_first

--- a/tests/test_projections/test_cogs_backfill.py
+++ b/tests/test_projections/test_cogs_backfill.py
@@ -157,8 +157,8 @@ async def test_backfill_posts_cogs_for_unfulfilled_invoice(session):
     await session.commit()
     assert result["posted"] == 1
 
-    expected = await compute_doc_cogs(
-        session, company_id, {"line_items": lines})
+    expected = (await compute_doc_cogs(
+        session, company_id, {"line_items": lines})).total
     assert expected > 0
 
     jes = await _doc_jes(session, company_id, doc_id)
@@ -224,7 +224,7 @@ async def test_backfill_full_cogs_for_partially_fulfilled_invoice(session):
     await run_cogs_backfill(session)
     await session.commit()
 
-    expected = await compute_doc_cogs(session, company_id, {"line_items": lines})
+    expected = (await compute_doc_cogs(session, company_id, {"line_items": lines})).total
     assert expected == 50.0  # 40/2 * 1 + 15 * 2
     jes = await _doc_jes(session, company_id, doc_id)
     assert _posted_5100_debits(jes) == [expected]
@@ -618,7 +618,7 @@ async def test_backfill_ledger_invariant_and_idempotent_rowcount(session):
             and any(e.get("account") == "4100" and float(e.get("credit") or 0) > 0
                     for e in st.get("entries", []))
             for st in jes.values())
-        cogs = await compute_doc_cogs(session, company_id, doc.state)
+        cogs = (await compute_doc_cogs(session, company_id, doc.state)).total
         debits = _posted_5100_debits(jes)
         if has_posted_revenue and cogs > 0:
             assert len(debits) == 1, f"{doc.entity_id}: expected exactly one 5100 debit, got {debits}"

--- a/tests/test_projections/test_cogs_backfill.py
+++ b/tests/test_projections/test_cogs_backfill.py
@@ -1,0 +1,638 @@
+# Copyright (c) 2026 Noah Severs. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-Proprietary
+"""One-time COGS backfill for finalized invoices missing their COGS journal entry."""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+from sqlalchemy import func, select, text
+
+from celerp.events.engine import emit_event
+from celerp.migrations._data_reconcile import get_meta
+from celerp.models.company import Company
+from celerp.models.ledger import LedgerEntry
+from celerp.models.notification import Notification
+from celerp.models.projections import Projection
+from celerp.services.auto_je import compute_doc_cogs
+from celerp.services.cogs_backfill import COGS_BACKFILL_KEY, run_cogs_backfill
+
+
+async def _clear_marker(session) -> None:
+    """The backfill is once-per-database: any app boot against this DB sets the
+    marker, so each test resets it to the unset state its scenario assumes."""
+    conn = await session.connection()
+    await conn.run_sync(lambda c: get_meta(c, COGS_BACKFILL_KEY))
+    await session.execute(
+        text("DELETE FROM instance_meta WHERE key = :k"), {"k": COGS_BACKFILL_KEY})
+
+
+async def _marker_value(session) -> str | None:
+    conn = await session.connection()
+    return await conn.run_sync(lambda c: get_meta(c, COGS_BACKFILL_KEY))
+
+
+async def _seed_company(session, name: str = "CogsCo") -> uuid.UUID:
+    company_id = uuid.uuid4()
+    session.add(Company(id=company_id, name=name, slug=f"cogs-{company_id.hex[:8]}"))
+    await session.flush()
+    return company_id
+
+
+def _seed_parcel(session, company_id, entity_id: str, *, cost_total=None,
+                 quantity=0.0, cost_price=None) -> None:
+    """A parcel projection as compute_doc_cogs reads it."""
+    state: dict = {"quantity": quantity}
+    if cost_total is not None:
+        state["cost_total"] = cost_total
+    if cost_price is not None:
+        state["cost_price"] = cost_price
+    session.add(Projection(
+        company_id=company_id, entity_id=entity_id, entity_type="item",
+        state=state, version=1, updated_at=datetime.now(timezone.utc)))
+
+
+def _seed_doc(session, company_id, doc_id: str, *, line_items, doc_type="invoice",
+              status="finalized", finalized_at=None, issue_date=None,
+              revert_count=0, total=110.0, tax=10.0) -> None:
+    """A doc projection in the shape the legacy population carries."""
+    state: dict = {
+        "doc_type": doc_type, "status": status, "line_items": line_items,
+        "total": total, "tax": tax, "revert_count": revert_count,
+    }
+    if finalized_at:
+        state["finalized_at"] = finalized_at
+    if issue_date:
+        state["issue_date"] = issue_date
+    session.add(Projection(
+        company_id=company_id, entity_id=doc_id, entity_type="doc",
+        state=state, version=1, updated_at=datetime.now(timezone.utc)))
+
+
+def _fin_entries(total=110.0, revenue=100.0, tax=10.0, cogs=None) -> list[dict]:
+    entries = [
+        {"account": "1120", "debit": total, "credit": 0.0},
+        {"account": "4100", "debit": 0.0, "credit": revenue},
+        {"account": "2120", "debit": 0.0, "credit": tax},
+    ]
+    if cogs:
+        entries.append({"account": "5100", "debit": cogs, "credit": 0.0})
+        entries.append({"account": "1130-P", "debit": 0.0, "credit": cogs})
+    return entries
+
+
+async def _emit_je(session, company_id, je_id: str, *, entries, ts=None,
+                   memo="Auto JE", void=False) -> None:
+    data: dict = {"memo": memo, "entries": entries}
+    if ts:
+        data["ts"] = ts
+    await emit_event(
+        session, company_id=company_id, entity_id=je_id,
+        entity_type="journal_entry", event_type="acc.journal_entry.created",
+        data=data, actor_id=None, location_id=None, source="test",
+        idempotency_key=str(uuid.uuid4()), metadata_={})
+    if void:
+        await emit_event(
+            session, company_id=company_id, entity_id=je_id,
+            entity_type="journal_entry", event_type="acc.journal_entry.voided",
+            data={"reason": "test", "ts": ts}, actor_id=None, location_id=None,
+            source="test", idempotency_key=str(uuid.uuid4()), metadata_={})
+
+
+async def _doc_jes(session, company_id, doc_id: str) -> dict[str, dict]:
+    """entity_id -> state for every JE projection belonging to the doc."""
+    rows = (await session.execute(select(Projection).where(
+        Projection.company_id == company_id,
+        Projection.entity_type == "journal_entry",
+    ))).scalars().all()
+    prefix = f"je:auto:{doc_id}:"
+    return {r.entity_id: r.state for r in rows if r.entity_id.startswith(prefix)}
+
+
+def _posted_5100_debits(jes: dict[str, dict]) -> list[float]:
+    return [float(e.get("debit") or 0)
+            for st in jes.values() if st.get("status") == "posted"
+            for e in st.get("entries", [])
+            if e.get("account") == "5100" and float(e.get("debit") or 0) > 0]
+
+
+def _posted_ids(jes: dict[str, dict]) -> set[str]:
+    return {eid for eid, st in jes.items() if st.get("status") == "posted"}
+
+
+async def _rowcount(session) -> int:
+    return (await session.execute(
+        select(func.count()).select_from(LedgerEntry))).scalar()
+
+
+async def _notifications(session, company_id) -> list[Notification]:
+    return list((await session.execute(select(Notification).where(
+        Notification.company_id == company_id))).scalars().all())
+
+
+async def _lock_period(session, company_id, lock_date: str) -> None:
+    company = await session.get(Company, company_id)
+    company.settings = {**(company.settings or {}), "lock_date": lock_date}
+    session.add(company)
+    await session.flush()
+
+
+@pytest.mark.asyncio
+async def test_backfill_posts_cogs_for_unfulfilled_invoice(session):
+    """A never-fulfilled old-style invoice gets exactly one posted cogs-backfill
+    JE, amount matching compute_doc_cogs, dated to its finalize JE."""
+    await _clear_marker(session)
+    company_id = await _seed_company(session)
+    _seed_parcel(session, company_id, "item:p1", cost_total=40.0, quantity=2.0)
+    doc_id = "doc:INV-0001"
+    lines = [{"quantity": 1, "item_id": "item:p1", "line_total": 100.0}]
+    _seed_doc(session, company_id, doc_id, line_items=lines,
+              finalized_at="2024-03-05", issue_date="2024-03-01")
+    await _emit_je(session, company_id, f"je:auto:{doc_id}:fin",
+                   entries=_fin_entries(), ts="2024-03-02")
+    await session.commit()
+
+    result = await run_cogs_backfill(session)
+    await session.commit()
+    assert result["posted"] == 1
+
+    expected = await compute_doc_cogs(
+        session, company_id, {"line_items": lines})
+    assert expected > 0
+
+    jes = await _doc_jes(session, company_id, doc_id)
+    backfill = jes.get(f"je:auto:{doc_id}:cogs-backfill")
+    assert backfill is not None, "backfill JE was not posted"
+    assert backfill["status"] == "posted"
+    assert backfill["ts"] == "2024-03-02", "ts must copy the finalize JE's ts"
+    assert backfill["memo"] == f"Auto JE for {doc_id} COGS backfill"
+    assert backfill["entries"] == [
+        {"account": "5100", "debit": expected, "credit": 0.0},
+        {"account": "1130-P", "debit": 0.0, "credit": expected},
+    ]
+    assert _posted_5100_debits(jes) == [expected]
+    assert await _marker_value(session) == "done"
+
+
+@pytest.mark.asyncio
+async def test_backfill_skips_invoice_with_fulfill_cogs(session):
+    """An old invoice whose COGS was posted at fulfillment keeps its exact
+    posted-JE id set and ledger row count."""
+    await _clear_marker(session)
+    company_id = await _seed_company(session)
+    _seed_parcel(session, company_id, "item:p2", cost_total=40.0, quantity=2.0)
+    doc_id = "doc:INV-0002"
+    _seed_doc(session, company_id, doc_id,
+              line_items=[{"quantity": 1, "item_id": "item:p2", "line_total": 100.0}])
+    await _emit_je(session, company_id, f"je:auto:{doc_id}:fin",
+                   entries=_fin_entries(), ts="2024-03-02")
+    await _emit_je(session, company_id, f"je:auto:{doc_id}:fulfill",
+                   entries=[{"account": "5100", "debit": 20.0, "credit": 0.0},
+                            {"account": "1130-P", "debit": 0.0, "credit": 20.0}],
+                   ts="2024-03-09")
+    await session.commit()
+
+    before_ids = _posted_ids(await _doc_jes(session, company_id, doc_id))
+    before_rows = await _rowcount(session)
+
+    await run_cogs_backfill(session)
+    await session.commit()
+
+    assert _posted_ids(await _doc_jes(session, company_id, doc_id)) == before_ids
+    assert await _rowcount(session) == before_rows
+
+
+@pytest.mark.asyncio
+async def test_backfill_full_cogs_for_partially_fulfilled_invoice(session):
+    """The old path posted COGS only at full fulfillment, so a partially
+    fulfilled invoice has none anywhere and gets the full amount."""
+    await _clear_marker(session)
+    company_id = await _seed_company(session)
+    _seed_parcel(session, company_id, "item:p3a", cost_total=40.0, quantity=2.0)
+    _seed_parcel(session, company_id, "item:p3b", cost_price=15.0)
+    doc_id = "doc:INV-0003"
+    lines = [
+        {"quantity": 1, "item_id": "item:p3a", "line_total": 50.0},
+        {"quantity": 2, "item_id": "item:p3b", "line_total": 50.0},
+    ]
+    _seed_doc(session, company_id, doc_id, line_items=lines)
+    await _emit_je(session, company_id, f"je:auto:{doc_id}:fin",
+                   entries=_fin_entries(), ts="2024-04-01")
+    await session.commit()
+
+    await run_cogs_backfill(session)
+    await session.commit()
+
+    expected = await compute_doc_cogs(session, company_id, {"line_items": lines})
+    assert expected == 50.0  # 40/2 * 1 + 15 * 2
+    jes = await _doc_jes(session, company_id, doc_id)
+    assert _posted_5100_debits(jes) == [expected]
+
+
+@pytest.mark.asyncio
+async def test_backfill_covers_prefix_unvoid_restored_invoice(session):
+    """A doc restored by a pre-fix unvoid (voided fin JE, posted fin:unvoid JE
+    with no COGS) gets exactly one backfill JE, dated to the fin:unvoid JE."""
+    await _clear_marker(session)
+    company_id = await _seed_company(session)
+    _seed_parcel(session, company_id, "item:p4", cost_total=40.0, quantity=2.0)
+    doc_id = "doc:INV-0004"
+    _seed_doc(session, company_id, doc_id,
+              line_items=[{"quantity": 1, "item_id": "item:p4", "line_total": 100.0}])
+    await _emit_je(session, company_id, f"je:auto:{doc_id}:fin",
+                   entries=_fin_entries(), ts="2024-04-01", void=True)
+    await _emit_je(session, company_id, f"je:auto:{doc_id}:fin:unvoid",
+                   entries=_fin_entries(), ts="2024-04-02")
+    await session.commit()
+
+    await run_cogs_backfill(session)
+    await session.commit()
+
+    jes = await _doc_jes(session, company_id, doc_id)
+    backfill = jes.get(f"je:auto:{doc_id}:cogs-backfill")
+    assert backfill is not None and backfill["status"] == "posted"
+    assert backfill["ts"] == "2024-04-02"
+    assert _posted_5100_debits(jes) == [20.0]
+
+
+@pytest.mark.asyncio
+async def test_backfill_skips_new_code_invoice(session):
+    """An invoice whose finalize JE already carries the 5100 leg keeps its exact
+    posted-JE id set and ledger row count."""
+    await _clear_marker(session)
+    company_id = await _seed_company(session)
+    _seed_parcel(session, company_id, "item:p5", cost_total=40.0, quantity=2.0)
+    doc_id = "doc:INV-0005"
+    _seed_doc(session, company_id, doc_id,
+              line_items=[{"quantity": 1, "item_id": "item:p5", "line_total": 100.0}])
+    await _emit_je(session, company_id, f"je:auto:{doc_id}:fin",
+                   entries=_fin_entries(cogs=20.0), ts="2026-01-05")
+    await session.commit()
+
+    before_ids = _posted_ids(await _doc_jes(session, company_id, doc_id))
+    before_rows = await _rowcount(session)
+
+    await run_cogs_backfill(session)
+    await session.commit()
+
+    assert _posted_ids(await _doc_jes(session, company_id, doc_id)) == before_ids
+    assert await _rowcount(session) == before_rows
+
+
+@pytest.mark.asyncio
+async def test_backfill_rerun_without_marker_posts_nothing_new(session):
+    """With the marker wiped, a second run finds nothing to do: the universe
+    predicate and the emit idempotency keys are each sufficient on their own."""
+    await _clear_marker(session)
+    company_id = await _seed_company(session)
+    _seed_parcel(session, company_id, "item:p6", cost_total=40.0, quantity=2.0)
+    doc_id = "doc:INV-0006"
+    _seed_doc(session, company_id, doc_id,
+              line_items=[{"quantity": 1, "item_id": "item:p6", "line_total": 100.0}])
+    await _emit_je(session, company_id, f"je:auto:{doc_id}:fin",
+                   entries=_fin_entries(), ts="2024-05-01")
+    await session.commit()
+
+    first = await run_cogs_backfill(session)
+    await session.commit()
+    assert first["posted"] == 1
+    rows_after_first = await _rowcount(session)
+    ids_after_first = _posted_ids(await _doc_jes(session, company_id, doc_id))
+
+    await _clear_marker(session)
+    second = await run_cogs_backfill(session)
+    await session.commit()
+
+    assert second["posted"] == 0
+    assert await _rowcount(session) == rows_after_first
+    assert _posted_ids(await _doc_jes(session, company_id, doc_id)) == ids_after_first
+
+
+@pytest.mark.asyncio
+async def test_backfill_defers_on_locked_period_keeps_marker_unset(session):
+    """A doc dated inside a locked period posts nothing, raises nothing, is
+    counted deferred, and leaves the marker unset for the next boot."""
+    await _clear_marker(session)
+    company_id = await _seed_company(session)
+    _seed_parcel(session, company_id, "item:p7", cost_total=40.0, quantity=2.0)
+    doc_id = "doc:INV-0007"
+    _seed_doc(session, company_id, doc_id,
+              line_items=[{"quantity": 1, "item_id": "item:p7", "line_total": 100.0}])
+    await _emit_je(session, company_id, f"je:auto:{doc_id}:fin",
+                   entries=_fin_entries(), ts="2024-03-02")
+    await _lock_period(session, company_id, "2024-12-31")
+    await session.commit()
+
+    result = await run_cogs_backfill(session)
+    await session.commit()
+
+    assert result["deferred"] == 1
+    jes = await _doc_jes(session, company_id, doc_id)
+    assert f"je:auto:{doc_id}:cogs-backfill" not in jes
+    assert await _marker_value(session) is None
+    notifs = await _notifications(session, company_id)
+    assert len(notifs) == 1
+    assert "1 deferred: accounting period locked" in notifs[0].body
+
+
+@pytest.mark.asyncio
+async def test_backfill_zero_cost_doc_posts_nothing_and_counts(session):
+    """A doc computing zero COGS posts no JE and is reported as a count, never
+    a fabricated amount; zero-cost alone does not hold the marker open."""
+    await _clear_marker(session)
+    company_id = await _seed_company(session)
+    _seed_parcel(session, company_id, "item:p8", cost_price=0.0)
+    doc_id = "doc:INV-0008"
+    _seed_doc(session, company_id, doc_id,
+              line_items=[{"quantity": 1, "item_id": "item:p8", "line_total": 100.0}])
+    await _emit_je(session, company_id, f"je:auto:{doc_id}:fin",
+                   entries=_fin_entries(), ts="2024-05-01")
+    await session.commit()
+
+    result = await run_cogs_backfill(session)
+    await session.commit()
+
+    assert result["zero_cost"] == 1
+    assert result["posted"] == 0
+    jes = await _doc_jes(session, company_id, doc_id)
+    assert f"je:auto:{doc_id}:cogs-backfill" not in jes
+    assert await _marker_value(session) == "done"
+    notifs = await _notifications(session, company_id)
+    assert len(notifs) == 1
+    assert "1 zero cost" in notifs[0].body
+
+
+@pytest.mark.asyncio
+async def test_backfill_ignores_non_invoice_doc_types(session):
+    """bill, memo, consignment_in, and credit_note docs keep their exact
+    posted-JE id sets even when they hold finalize-family JEs."""
+    await _clear_marker(session)
+    company_id = await _seed_company(session)
+    _seed_parcel(session, company_id, "item:p9", cost_total=40.0, quantity=2.0)
+    lines = [{"quantity": 1, "item_id": "item:p9", "line_total": 100.0}]
+
+    _seed_doc(session, company_id, "doc:BILL-1", line_items=lines, doc_type="bill")
+    await _emit_je(session, company_id, "je:auto:doc:BILL-1:bill",
+                   entries=[{"account": "1130-P", "debit": 110.0, "credit": 0.0},
+                            {"account": "2110", "debit": 0.0, "credit": 110.0}],
+                   ts="2024-05-01")
+    _seed_doc(session, company_id, "doc:MEMO-1", line_items=lines, doc_type="memo")
+    _seed_doc(session, company_id, "doc:CI-1", line_items=lines,
+              doc_type="consignment_in")
+    _seed_doc(session, company_id, "doc:CN-1", line_items=lines,
+              doc_type="credit_note")
+    await _emit_je(session, company_id, "je:auto:doc:CN-1:fin",
+                   entries=_fin_entries(), ts="2024-05-01")
+    await session.commit()
+
+    before = {d: _posted_ids(await _doc_jes(session, company_id, d))
+              for d in ("doc:BILL-1", "doc:MEMO-1", "doc:CI-1", "doc:CN-1")}
+    before_rows = await _rowcount(session)
+
+    result = await run_cogs_backfill(session)
+    await session.commit()
+
+    assert result["posted"] == 0
+    after = {d: _posted_ids(await _doc_jes(session, company_id, d))
+             for d in ("doc:BILL-1", "doc:MEMO-1", "doc:CI-1", "doc:CN-1")}
+    assert after == before
+    assert await _rowcount(session) == before_rows
+
+
+@pytest.mark.asyncio
+async def test_backfill_notifies_per_company_with_counts(session):
+    """One bell notification per affected company carrying the invoice count,
+    total, and the zero-cost, deferred, and errored counts."""
+    await _clear_marker(session)
+    company_a = await _seed_company(session, "CogsA")
+    company_b = await _seed_company(session, "CogsB")
+
+    # Company A: one posted, one zero-cost, one deferred, one errored.
+    _seed_parcel(session, company_a, "item:a1", cost_total=40.0, quantity=2.0)
+    _seed_parcel(session, company_a, "item:a2", cost_price=0.0)
+    _seed_doc(session, company_a, "doc:INV-A1",
+              line_items=[{"quantity": 1, "item_id": "item:a1", "line_total": 100.0}])
+    await _emit_je(session, company_a, "je:auto:doc:INV-A1:fin",
+                   entries=_fin_entries(), ts="2026-01-15")
+    _seed_doc(session, company_a, "doc:INV-A2",
+              line_items=[{"quantity": 1, "item_id": "item:a2", "line_total": 100.0}])
+    await _emit_je(session, company_a, "je:auto:doc:INV-A2:fin",
+                   entries=_fin_entries(), ts="2026-01-16")
+    _seed_doc(session, company_a, "doc:INV-A3",
+              line_items=[{"quantity": 1, "item_id": "item:a1", "line_total": 100.0}])
+    await _emit_je(session, company_a, "je:auto:doc:INV-A3:fin",
+                   entries=_fin_entries(), ts="2024-06-01")
+    _seed_doc(session, company_a, "doc:INV-A4",
+              line_items=[{"quantity": "not-a-number", "item_id": "item:a1",
+                           "line_total": 100.0}])
+    await _emit_je(session, company_a, "je:auto:doc:INV-A4:fin",
+                   entries=_fin_entries(), ts="2026-01-17")
+    await _lock_period(session, company_a, "2024-12-31")
+
+    # Company B: one posted only.
+    _seed_parcel(session, company_b, "item:b1", cost_total=60.0, quantity=2.0)
+    _seed_doc(session, company_b, "doc:INV-B1",
+              line_items=[{"quantity": 1, "item_id": "item:b1", "line_total": 100.0}])
+    await _emit_je(session, company_b, "je:auto:doc:INV-B1:fin",
+                   entries=_fin_entries(), ts="2026-02-01")
+    await session.commit()
+
+    await run_cogs_backfill(session)
+    await session.commit()
+
+    notifs_a = await _notifications(session, company_a)
+    assert len(notifs_a) == 1
+    a = notifs_a[0]
+    assert a.title == "Cost of goods posted for past invoices"
+    assert "1 invoice, total 20.00." in a.body
+    assert "1 zero cost" in a.body
+    assert "1 deferred: accounting period locked" in a.body
+    assert "1 could not be computed" in a.body
+    assert a.action_url.startswith("/accounting?q=COGS%20backfill")
+
+    notifs_b = await _notifications(session, company_b)
+    assert len(notifs_b) == 1
+    b = notifs_b[0]
+    assert "1 invoice, total 30.00." in b.body
+    assert b.action_url == "/accounting?q=COGS%20backfill&from=2026-02-01&to=2026-02-01"
+
+
+@pytest.mark.asyncio
+async def test_backfill_scopes_per_company(session):
+    """Two companies each hold doc:INV-0001; only the company whose doc lacks
+    COGS gets a backfill JE, so lookups must be keyed by company."""
+    await _clear_marker(session)
+    company_a = await _seed_company(session, "ScopeA")
+    company_b = await _seed_company(session, "ScopeB")
+    doc_id = "doc:INV-0001"
+    for cid in (company_a, company_b):
+        _seed_parcel(session, cid, "item:s1", cost_total=40.0, quantity=2.0)
+        _seed_doc(session, cid, doc_id,
+                  line_items=[{"quantity": 1, "item_id": "item:s1", "line_total": 100.0}])
+        await _emit_je(session, cid, f"je:auto:{doc_id}:fin",
+                       entries=_fin_entries(), ts="2024-05-01")
+    await _emit_je(session, company_a, f"je:auto:{doc_id}:fulfill",
+                   entries=[{"account": "5100", "debit": 20.0, "credit": 0.0},
+                            {"account": "1130-P", "debit": 0.0, "credit": 20.0}],
+                   ts="2024-05-02")
+    await session.commit()
+
+    result = await run_cogs_backfill(session)
+    await session.commit()
+
+    assert result["posted"] == 1
+    jes_a = await _doc_jes(session, company_a, doc_id)
+    jes_b = await _doc_jes(session, company_b, doc_id)
+    assert f"je:auto:{doc_id}:cogs-backfill" not in jes_a
+    backfill_b = jes_b.get(f"je:auto:{doc_id}:cogs-backfill")
+    assert backfill_b is not None and backfill_b["status"] == "posted"
+
+
+@pytest.mark.asyncio
+async def test_backfill_second_boot_while_locked_does_not_duplicate_notification(session):
+    """A still-locked period leaves the marker unset, so every boot rescans;
+    the unread notice dedups on its stable title so exactly one accumulates."""
+    await _clear_marker(session)
+    company_id = await _seed_company(session)
+    _seed_parcel(session, company_id, "item:p10", cost_total=40.0, quantity=2.0)
+    doc_id = "doc:INV-0010"
+    _seed_doc(session, company_id, doc_id,
+              line_items=[{"quantity": 1, "item_id": "item:p10", "line_total": 100.0}])
+    await _emit_je(session, company_id, f"je:auto:{doc_id}:fin",
+                   entries=_fin_entries(), ts="2024-03-02")
+    await _lock_period(session, company_id, "2024-12-31")
+    await session.commit()
+
+    first = await run_cogs_backfill(session)
+    await session.commit()
+    assert first["deferred"] == 1
+    assert await _marker_value(session) is None
+
+    second = await run_cogs_backfill(session)
+    await session.commit()
+    assert second["deferred"] == 1
+
+    notifs = await _notifications(session, company_id)
+    unread = [n for n in notifs if not n.read]
+    assert len(unread) == 1
+    assert unread[0].title == "Cost of goods posted for past invoices"
+
+
+@pytest.mark.asyncio
+async def test_backfill_malformed_doc_errors_and_continues(session):
+    """Legacy state that raises inside the cost computation marks that doc
+    errored; the sibling doc still gets its JE and the marker stays unset."""
+    await _clear_marker(session)
+    company_id = await _seed_company(session)
+    _seed_parcel(session, company_id, "item:p11", cost_total=40.0, quantity=2.0)
+    _seed_doc(session, company_id, "doc:INV-0011",
+              line_items=[{"quantity": "not-a-number", "item_id": "item:p11",
+                           "line_total": 100.0}])
+    await _emit_je(session, company_id, "je:auto:doc:INV-0011:fin",
+                   entries=_fin_entries(), ts="2024-05-01")
+    _seed_doc(session, company_id, "doc:INV-0012",
+              line_items=[{"quantity": 1, "item_id": "item:p11", "line_total": 100.0}])
+    await _emit_je(session, company_id, "je:auto:doc:INV-0012:fin",
+                   entries=_fin_entries(), ts="2024-05-02")
+    await session.commit()
+
+    result = await run_cogs_backfill(session)
+    await session.commit()
+
+    assert result["errored"] == 1
+    assert result["posted"] == 1
+    jes_bad = await _doc_jes(session, company_id, "doc:INV-0011")
+    assert "je:auto:doc:INV-0011:cogs-backfill" not in jes_bad
+    jes_ok = await _doc_jes(session, company_id, "doc:INV-0012")
+    backfill = jes_ok.get("je:auto:doc:INV-0012:cogs-backfill")
+    assert backfill is not None and backfill["status"] == "posted"
+    assert await _marker_value(session) is None
+
+
+@pytest.mark.asyncio
+async def test_backfill_ledger_invariant_and_idempotent_rowcount(session):
+    """Seeded matrix: after one run every doc holding a posted finalize-family
+    JE with a 4100 credit and computed COGS > 0 has exactly one posted 5100
+    debit, every posted JE balances, and a second run changes nothing."""
+    await _clear_marker(session)
+    company_id = await _seed_company(session)
+    _seed_parcel(session, company_id, "item:m1", cost_total=40.0, quantity=2.0)
+    _seed_parcel(session, company_id, "item:m0", cost_price=0.0)
+    lines = [{"quantity": 1, "item_id": "item:m1", "line_total": 100.0}]
+    zero_lines = [{"quantity": 1, "item_id": "item:m0", "line_total": 100.0}]
+    nonstock_lines = [{"quantity": 1, "line_total": 100.0}]
+
+    # Never fulfilled: affected.
+    _seed_doc(session, company_id, "doc:M-1", line_items=lines)
+    await _emit_je(session, company_id, "je:auto:doc:M-1:fin",
+                   entries=_fin_entries(), ts="2024-01-10")
+    # Fulfilled under the old path: COGS already posted at fulfillment.
+    _seed_doc(session, company_id, "doc:M-2", line_items=lines)
+    await _emit_je(session, company_id, "je:auto:doc:M-2:fin",
+                   entries=_fin_entries(), ts="2024-01-11")
+    await _emit_je(session, company_id, "je:auto:doc:M-2:fulfill",
+                   entries=[{"account": "5100", "debit": 20.0, "credit": 0.0},
+                            {"account": "1130-P", "debit": 0.0, "credit": 20.0}],
+                   ts="2024-01-12")
+    # Partially fulfilled under the old path: no COGS anywhere.
+    _seed_doc(session, company_id, "doc:M-3", line_items=lines)
+    await _emit_je(session, company_id, "je:auto:doc:M-3:fin",
+                   entries=_fin_entries(), ts="2024-01-13")
+    # Voided: no posted finalize-family JE.
+    _seed_doc(session, company_id, "doc:M-4", line_items=lines, status="void")
+    await _emit_je(session, company_id, "je:auto:doc:M-4:fin",
+                   entries=_fin_entries(), ts="2024-01-14", void=True)
+    # Reverted to draft: finalize JE voided.
+    _seed_doc(session, company_id, "doc:M-5", line_items=lines, status="draft",
+              revert_count=1)
+    await _emit_je(session, company_id, "je:auto:doc:M-5:fin",
+                   entries=_fin_entries(), ts="2024-01-15", void=True)
+    # Unvoided by pre-fix code: fin voided, fin:unvoid posted, no COGS.
+    _seed_doc(session, company_id, "doc:M-6", line_items=lines)
+    await _emit_je(session, company_id, "je:auto:doc:M-6:fin",
+                   entries=_fin_entries(), ts="2024-01-16", void=True)
+    await _emit_je(session, company_id, "je:auto:doc:M-6:fin:unvoid",
+                   entries=_fin_entries(), ts="2024-01-17")
+    # Zero cost and non-stock: counted, never posted.
+    _seed_doc(session, company_id, "doc:M-7", line_items=zero_lines)
+    await _emit_je(session, company_id, "je:auto:doc:M-7:fin",
+                   entries=_fin_entries(), ts="2024-01-18")
+    _seed_doc(session, company_id, "doc:M-8", line_items=nonstock_lines)
+    await _emit_je(session, company_id, "je:auto:doc:M-8:fin",
+                   entries=_fin_entries(), ts="2024-01-19")
+    await session.commit()
+
+    result = await run_cogs_backfill(session)
+    await session.commit()
+    assert result["posted"] == 3  # M-1, M-3, M-6
+    assert result["zero_cost"] == 2  # M-7, M-8
+
+    docs = (await session.execute(select(Projection).where(
+        Projection.company_id == company_id,
+        Projection.entity_type == "doc"))).scalars().all()
+    for doc in docs:
+        jes = await _doc_jes(session, company_id, doc.entity_id)
+        has_posted_revenue = any(
+            st.get("status") == "posted"
+            and any(e.get("account") == "4100" and float(e.get("credit") or 0) > 0
+                    for e in st.get("entries", []))
+            for st in jes.values())
+        cogs = await compute_doc_cogs(session, company_id, doc.state)
+        debits = _posted_5100_debits(jes)
+        if has_posted_revenue and cogs > 0:
+            assert len(debits) == 1, f"{doc.entity_id}: expected exactly one 5100 debit, got {debits}"
+        # Every posted JE balances.
+        for eid, st in jes.items():
+            if st.get("status") != "posted":
+                continue
+            entries = st.get("entries", [])
+            total_debit = sum(float(e.get("debit") or 0) for e in entries)
+            total_credit = sum(float(e.get("credit") or 0) for e in entries)
+            assert abs(total_debit - total_credit) < 0.01, f"{eid} does not balance"
+
+    rows_after_first = await _rowcount(session)
+    second = await run_cogs_backfill(session)
+    await session.commit()
+    assert second == {"changed": False}
+    assert await _rowcount(session) == rows_after_first

--- a/tests/test_projections/test_cogs_backfill.py
+++ b/tests/test_projections/test_cogs_backfill.py
@@ -210,7 +210,7 @@ async def test_backfill_full_cogs_for_partially_fulfilled_invoice(session):
     await _clear_marker(session)
     company_id = await _seed_company(session)
     _seed_parcel(session, company_id, "item:p3a", cost_total=40.0, quantity=2.0)
-    _seed_parcel(session, company_id, "item:p3b", cost_price=15.0)
+    _seed_parcel(session, company_id, "item:p3b", cost_price=15.0, quantity=2.0)
     doc_id = "doc:INV-0003"
     lines = [
         {"quantity": 1, "item_id": "item:p3a", "line_total": 50.0},
@@ -342,7 +342,7 @@ async def test_backfill_zero_cost_doc_posts_nothing_and_counts(session):
     a fabricated amount; zero-cost alone does not hold the marker open."""
     await _clear_marker(session)
     company_id = await _seed_company(session)
-    _seed_parcel(session, company_id, "item:p8", cost_price=0.0)
+    _seed_parcel(session, company_id, "item:p8", cost_price=0.0, quantity=1.0)
     doc_id = "doc:INV-0008"
     _seed_doc(session, company_id, doc_id,
               line_items=[{"quantity": 1, "item_id": "item:p8", "line_total": 100.0}])
@@ -410,7 +410,7 @@ async def test_backfill_notifies_per_company_with_counts(session):
 
     # Company A: one posted, one zero-cost, one deferred, one errored.
     _seed_parcel(session, company_a, "item:a1", cost_total=40.0, quantity=2.0)
-    _seed_parcel(session, company_a, "item:a2", cost_price=0.0)
+    _seed_parcel(session, company_a, "item:a2", cost_price=0.0, quantity=1.0)
     _seed_doc(session, company_a, "doc:INV-A1",
               line_items=[{"quantity": 1, "item_id": "item:a1", "line_total": 100.0}])
     await _emit_je(session, company_a, "je:auto:doc:INV-A1:fin",
@@ -558,7 +558,7 @@ async def test_backfill_ledger_invariant_and_idempotent_rowcount(session):
     await _clear_marker(session)
     company_id = await _seed_company(session)
     _seed_parcel(session, company_id, "item:m1", cost_total=40.0, quantity=2.0)
-    _seed_parcel(session, company_id, "item:m0", cost_price=0.0)
+    _seed_parcel(session, company_id, "item:m0", cost_price=0.0, quantity=1.0)
     lines = [{"quantity": 1, "item_id": "item:m1", "line_total": 100.0}]
     zero_lines = [{"quantity": 1, "item_id": "item:m0", "line_total": 100.0}]
     nonstock_lines = [{"quantity": 1, "line_total": 100.0}]

--- a/tests/test_routers/test_doctor_cogs_repair.py
+++ b/tests/test_routers/test_doctor_cogs_repair.py
@@ -1,0 +1,88 @@
+# Copyright (c) 2026 Noah Severs
+# SPDX-License-Identifier: LicenseRef-Proprietary
+
+"""Doctor's missing-JE repair posts the full finalize JE, COGS legs included."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+from sqlalchemy import select
+
+from celerp.models.projections import Projection
+
+
+async def _register(client) -> str:
+    r = await client.post("/auth/register", json={
+        "company_name": "Doctor Co", "email": f"doc-{uuid.uuid4().hex[:8]}@test.test",
+        "name": "Admin", "password": "pw",
+    })
+    assert r.status_code == 200
+    return r.json()["access_token"]
+
+
+def _h(token: str) -> dict:
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.mark.asyncio
+async def test_doctor_finalize_repair_includes_cogs(client, session):
+    """An imported old-style invoice repaired by the doctor gets one finalize JE
+    carrying revenue AND the COGS pair, identical to a live finalize."""
+    token = await _register(client)
+    entity_id = f"doc:doctor-cogs-{uuid.uuid4().hex[:8]}"
+
+    r = await client.post("/docs/import", headers=_h(token), json={
+        "entity_id": entity_id, "event_type": "doc.created",
+        "data": {"doc_type": "invoice", "total": 110, "subtotal": 100, "tax": 10,
+                 "status": "draft",
+                 "line_items": [{"description": "Parcel", "quantity": 1,
+                                 "item_id": "item:doctor-parcel",
+                                 "unit_price": 100, "line_total": 100}]},
+        "source": "import:test", "idempotency_key": f"idem-dc-{uuid.uuid4().hex[:8]}",
+    })
+    assert r.status_code == 200
+
+    r = await client.post("/docs/import", headers=_h(token), json={
+        "entity_id": entity_id, "event_type": "doc.finalized", "data": {},
+        "source": "import:test", "idempotency_key": f"idem-df-{uuid.uuid4().hex[:8]}",
+    })
+    assert r.status_code == 200
+
+    doc_proj = (await session.execute(select(Projection).where(
+        Projection.entity_id == entity_id,
+        Projection.entity_type == "doc"))).scalar_one()
+    company_id = doc_proj.company_id
+
+    # The stock parcel behind the line item: unit cost 20 (40 total over qty 2).
+    session.add(Projection(
+        company_id=company_id, entity_id="item:doctor-parcel", entity_type="item",
+        state={"cost_total": 40.0, "quantity": 2.0}, version=1,
+        updated_at=datetime.now(timezone.utc)))
+    await session.flush()
+
+    r = await client.post("/admin/doctor?checks=missing_jes&fix=true", headers=_h(token))
+    data = r.json()
+    missing = next(c for c in data["results"] if c["check"] == "missing_jes")
+    assert missing["found"] == 1
+    assert missing["fixed"] == 1
+
+    jes = (await session.execute(select(Projection).where(
+        Projection.company_id == company_id,
+        Projection.entity_type == "journal_entry"))).scalars().all()
+    prefix = f"je:auto:{entity_id}:"
+    posted = {p.entity_id: p.state for p in jes
+              if p.entity_id.startswith(prefix) and p.state.get("status") == "posted"}
+    assert posted, "doctor fix posted no JE"
+
+    entries = [e for st in posted.values() for e in st.get("entries", [])]
+    cogs_debits = [float(e.get("debit") or 0) for e in entries
+                   if e.get("account") == "5100" and float(e.get("debit") or 0) > 0]
+    inv_credits = [float(e.get("credit") or 0) for e in entries
+                   if e.get("account") == "1130-P" and float(e.get("credit") or 0) > 0]
+    assert cogs_debits == [20.0], (
+        f"repaired JE is missing the 5100 COGS debit: {entries}")
+    assert inv_credits == [20.0], (
+        f"repaired JE is missing the 1130-P credit: {entries}")

--- a/tests/test_routers/test_items.py
+++ b/tests/test_routers/test_items.py
@@ -641,10 +641,10 @@ async def test_split_blocked_when_allow_splitting_false(client):
 
 
 @pytest.mark.asyncio
-async def test_split_blocked_when_allow_splitting_field_missing(client, session):
-    """A missing/None allow_splitting must NOT bypass the split guard — only an
-    explicit True allows splitting. Simulate an item whose projection state lacks
-    the field (as older imports produced) by removing it before splitting.
+async def test_split_allowed_when_allow_splitting_field_missing(client, session):
+    """A missing/None allow_splitting is splittable: only an explicit False blocks.
+    Simulate an item whose projection state lacks the field (as older imports produced)
+    and confirm the split now succeeds.
     """
     from celerp.models.projections import Projection
     from sqlalchemy import select
@@ -668,18 +668,18 @@ async def test_split_blocked_when_allow_splitting_field_missing(client, session)
     rs = await client.post(f"/items/{item_id}/split", json={
         "children": [{"sku": "MISSING-SPLIT-1", "quantity": 3}]
     }, headers=h)
-    assert rs.status_code == 422, f"missing allow_splitting must block split, got {rs.status_code}: {rs.text}"
-    assert "Allow Splitting" in rs.json()["detail"]
+    assert rs.status_code == 200, f"missing allow_splitting must be splittable, got {rs.status_code}: {rs.text}"
 
 
 @pytest.mark.asyncio
-async def test_import_defaults_no_split_and_coerces_present_value(client):
-    """Imported items default to no-split (allow_splitting=False) when the field is
-    absent, and a present CSV value ("Yes"/"No") is coerced to a real bool."""
+async def test_import_defaults_unset_split_and_coerces_present_value(client):
+    """Imported items leave allow_splitting unset (None) when the field is absent, so
+    they stay splittable by default; a present CSV value ("Yes"/"No") is coerced to a
+    real bool."""
     token = await _token(client)
     h = {"Authorization": f"Bearer {token}"}
 
-    # (1) Import WITHOUT allow_splitting → defaults to False → split blocked.
+    # (1) Import WITHOUT allow_splitting → stays unset (None) → splittable.
     eid1 = "item:imp-nofield"
     r = await client.post("/items/import/batch", json={"records": [{
         "entity_id": eid1, "event_type": "item.created", "source": "csv",
@@ -689,9 +689,9 @@ async def test_import_defaults_no_split_and_coerces_present_value(client):
     assert r.status_code == 200, r.text
     assert r.json()["created"] == 1, r.json()
     item1 = (await client.get(f"/items/{eid1}", headers=h)).json()
-    assert item1.get("allow_splitting") is False, item1.get("allow_splitting")
+    assert item1.get("allow_splitting") is None, item1.get("allow_splitting")
     rs1 = await client.post(f"/items/{eid1}/split", json={"children": [{"sku": "IMP-NF-001-1", "quantity": 3}]}, headers=h)
-    assert rs1.status_code == 422, rs1.text
+    assert rs1.status_code == 200, rs1.text
 
     # (2) Import WITH allow_splitting="Yes" → coerced to True → splittable.
     eid2 = "item:imp-yes"

--- a/tests/test_services/test_auto_je_void_sweep.py
+++ b/tests/test_services/test_auto_je_void_sweep.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 import uuid
-from datetime import datetime, timezone
 
 import pytest
 from sqlalchemy import select
@@ -24,13 +23,6 @@ async def _seed_company(session) -> uuid.UUID:
     session.add(Company(id=company_id, name="SweepCo", slug=f"sw-{company_id.hex[:8]}"))
     await session.flush()
     return company_id
-
-
-def _seed_parcel(session, company_id, entity_id: str) -> None:
-    session.add(Projection(
-        company_id=company_id, entity_id=entity_id, entity_type="item",
-        state={"cost_total": 40.0, "quantity": 2.0}, version=1,
-        updated_at=datetime.now(timezone.utc)))
 
 
 def _fin_entries() -> list[dict]:
@@ -75,21 +67,12 @@ async def _je_states(session, company_id, doc_id: str) -> dict[str, dict]:
     return {r.entity_id: r.state for r in rows if r.entity_id.startswith(prefix)}
 
 
-def _doc_state(line_items) -> dict:
-    return {
-        "doc_type": "invoice", "status": "finalized", "total": 110.0,
-        "tax": 10.0, "line_items": line_items, "finalized_at": "2024-06-01",
-    }
-
-
 @pytest.mark.asyncio
 async def test_void_after_backfill_voids_backfill_je(session):
     """Voiding a backfilled invoice voids the backfill JE alongside the finalize
     JE, and a later unvoid restores exactly one COGS leg."""
     company_id = await _seed_company(session)
-    _seed_parcel(session, company_id, "item:v1")
     doc_id = "doc:INV-V1"
-    lines = [{"quantity": 1, "item_id": "item:v1", "line_total": 100.0}]
     await _emit_je(session, company_id, f"je:auto:{doc_id}:fin",
                    entries=_fin_entries(), ts="2024-06-01")
     await _emit_je(session, company_id, f"je:auto:{doc_id}:cogs-backfill",
@@ -106,8 +89,7 @@ async def test_void_after_backfill_voids_backfill_je(session):
         "void sweep left the backfill JE posted")
 
     await create_for_doc_unvoided(
-        session, company_id=company_id, user_id=None, doc_id=doc_id,
-        doc=_doc_state(lines))
+        session, company_id=company_id, user_id=None, doc_id=doc_id)
     await session.commit()
 
     jes = await _je_states(session, company_id, doc_id)

--- a/tests/test_services/test_auto_je_void_sweep.py
+++ b/tests/test_services/test_auto_je_void_sweep.py
@@ -1,0 +1,164 @@
+# Copyright (c) 2026 Noah Severs. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-Proprietary
+"""Void sweeps cover every live auto-JE a doc can carry, backfill JEs included."""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+from sqlalchemy import select
+
+from celerp.events.engine import emit_event
+from celerp.models.company import Company
+from celerp.models.projections import Projection
+from celerp.services.auto_je import (
+    create_for_doc_unvoided,
+    void_for_doc_finalized,
+    void_for_doc_voided,
+)
+
+
+async def _seed_company(session) -> uuid.UUID:
+    company_id = uuid.uuid4()
+    session.add(Company(id=company_id, name="SweepCo", slug=f"sw-{company_id.hex[:8]}"))
+    await session.flush()
+    return company_id
+
+
+def _seed_parcel(session, company_id, entity_id: str) -> None:
+    session.add(Projection(
+        company_id=company_id, entity_id=entity_id, entity_type="item",
+        state={"cost_total": 40.0, "quantity": 2.0}, version=1,
+        updated_at=datetime.now(timezone.utc)))
+
+
+def _fin_entries() -> list[dict]:
+    return [
+        {"account": "1120", "debit": 110.0, "credit": 0.0},
+        {"account": "4100", "debit": 0.0, "credit": 100.0},
+        {"account": "2120", "debit": 0.0, "credit": 10.0},
+    ]
+
+
+def _cogs_entries() -> list[dict]:
+    return [
+        {"account": "5100", "debit": 20.0, "credit": 0.0},
+        {"account": "1130-P", "debit": 0.0, "credit": 20.0},
+    ]
+
+
+async def _emit_je(session, company_id, je_id: str, *, entries, ts=None,
+                   void=False) -> None:
+    data: dict = {"memo": "Auto JE", "entries": entries}
+    if ts:
+        data["ts"] = ts
+    await emit_event(
+        session, company_id=company_id, entity_id=je_id,
+        entity_type="journal_entry", event_type="acc.journal_entry.created",
+        data=data, actor_id=None, location_id=None, source="test",
+        idempotency_key=str(uuid.uuid4()), metadata_={})
+    if void:
+        await emit_event(
+            session, company_id=company_id, entity_id=je_id,
+            entity_type="journal_entry", event_type="acc.journal_entry.voided",
+            data={"reason": "test", "ts": ts}, actor_id=None, location_id=None,
+            source="test", idempotency_key=str(uuid.uuid4()), metadata_={})
+
+
+async def _je_states(session, company_id, doc_id: str) -> dict[str, dict]:
+    rows = (await session.execute(select(Projection).where(
+        Projection.company_id == company_id,
+        Projection.entity_type == "journal_entry",
+    ))).scalars().all()
+    prefix = f"je:auto:{doc_id}:"
+    return {r.entity_id: r.state for r in rows if r.entity_id.startswith(prefix)}
+
+
+def _doc_state(line_items) -> dict:
+    return {
+        "doc_type": "invoice", "status": "finalized", "total": 110.0,
+        "tax": 10.0, "line_items": line_items, "finalized_at": "2024-06-01",
+    }
+
+
+@pytest.mark.asyncio
+async def test_void_after_backfill_voids_backfill_je(session):
+    """Voiding a backfilled invoice voids the backfill JE alongside the finalize
+    JE, and a later unvoid restores exactly one COGS leg."""
+    company_id = await _seed_company(session)
+    _seed_parcel(session, company_id, "item:v1")
+    doc_id = "doc:INV-V1"
+    lines = [{"quantity": 1, "item_id": "item:v1", "line_total": 100.0}]
+    await _emit_je(session, company_id, f"je:auto:{doc_id}:fin",
+                   entries=_fin_entries(), ts="2024-06-01")
+    await _emit_je(session, company_id, f"je:auto:{doc_id}:cogs-backfill",
+                   entries=_cogs_entries(), ts="2024-06-01")
+    await session.commit()
+
+    await void_for_doc_voided(
+        session, company_id=company_id, user_id=None, doc_id=doc_id)
+    await session.commit()
+
+    jes = await _je_states(session, company_id, doc_id)
+    assert jes[f"je:auto:{doc_id}:fin"]["status"] == "void"
+    assert jes[f"je:auto:{doc_id}:cogs-backfill"]["status"] == "void", (
+        "void sweep left the backfill JE posted")
+
+    await create_for_doc_unvoided(
+        session, company_id=company_id, user_id=None, doc_id=doc_id,
+        doc=_doc_state(lines))
+    await session.commit()
+
+    jes = await _je_states(session, company_id, doc_id)
+    posted_5100 = [
+        float(e.get("debit") or 0)
+        for st in jes.values() if st.get("status") == "posted"
+        for e in st.get("entries", [])
+        if e.get("account") == "5100" and float(e.get("debit") or 0) > 0]
+    assert posted_5100 == [20.0], (
+        f"expected exactly one posted 5100 debit after unvoid, got {posted_5100}")
+
+
+@pytest.mark.asyncio
+async def test_revert_after_backfill_voids_both_jes(session):
+    """Reverting a backfilled invoice to draft voids the finalize JE and the
+    backfill JE; the sweep must not stop at the first hit."""
+    company_id = await _seed_company(session)
+    doc_id = "doc:INV-V2"
+    await _emit_je(session, company_id, f"je:auto:{doc_id}:fin",
+                   entries=_fin_entries(), ts="2024-06-01")
+    await _emit_je(session, company_id, f"je:auto:{doc_id}:cogs-backfill",
+                   entries=_cogs_entries(), ts="2024-06-01")
+    await session.commit()
+
+    await void_for_doc_finalized(
+        session, company_id=company_id, user_id=None, doc_id=doc_id)
+    await session.commit()
+
+    jes = await _je_states(session, company_id, doc_id)
+    assert jes[f"je:auto:{doc_id}:fin"]["status"] == "void"
+    assert jes[f"je:auto:{doc_id}:cogs-backfill"]["status"] == "void", (
+        "revert sweep stopped after the finalize JE")
+
+
+@pytest.mark.asyncio
+async def test_revert_after_unvoid_voids_the_restored_je(session):
+    """Reverting a doc whose live finalize JE is the fin:unvoid restore leaves
+    no posted finalize-family JE behind."""
+    company_id = await _seed_company(session)
+    doc_id = "doc:INV-V3"
+    await _emit_je(session, company_id, f"je:auto:{doc_id}:fin",
+                   entries=_fin_entries(), ts="2024-06-01", void=True)
+    await _emit_je(session, company_id, f"je:auto:{doc_id}:fin:unvoid",
+                   entries=_fin_entries(), ts="2024-06-02")
+    await session.commit()
+
+    await void_for_doc_finalized(
+        session, company_id=company_id, user_id=None, doc_id=doc_id)
+    await session.commit()
+
+    jes = await _je_states(session, company_id, doc_id)
+    posted = [eid for eid, st in jes.items() if st.get("status") == "posted"]
+    assert posted == [], (
+        f"revert left posted finalize-family JEs behind: {posted}")

--- a/ui/routes/documents.py
+++ b/ui/routes/documents.py
@@ -14,7 +14,7 @@ from urllib.parse import quote_plus, urlencode
 
 import ui.api_client as api
 from ui.api_client import APIError
-from celerp.services.line_measures import identifier_backfill, item_measure_meta, line_identifier, measure_locks, measure_sublines, qty_label, resolve_line_measures
+from celerp.services.line_measures import identifier_backfill, item_measure_meta, line_identifier, measure_locks, measure_sublines, qty_label, resolve_line_measures, splitting_allowed
 from ui.components.shell import base_shell, page_header, toast_header
 from ui.components.table import search_bar, EMPTY, pagination, searchable_select, breadcrumbs, status_cards, empty_state_cta, fmt_money, fmt_rate, format_value, currency_symbol, unwrap_address, col_resize_script, bank_account_options as _bank_account_options, display_cell, editable_cell
 from celerp.services.money import to_decimal, to_stored_float, round_money, currency_dp, rate_dp
@@ -224,7 +224,7 @@ def _consolidate_sales_lots(items: list[dict], company_settings: dict) -> list[d
     out: list[dict] = []
     for sku in order:
         group = by_sku[sku]
-        if len(group) == 1 or not all(g.get("allow_splitting") for g in group):
+        if len(group) == 1 or not all(splitting_allowed(g) for g in group):
             out.extend(group)  # unique / non-splittable -> keep each lot (labeled)
             continue
         method = resolve_pick_method(group[0], company_settings)
@@ -683,7 +683,8 @@ async def _line_items_from_inventory(token: str, entity_ids: list[str], price_li
             "hs_code": item.get("hs_code") or None,
             "country_of_origin": item.get("country_of_origin") or None,
             "entity_id": eid,
-            "allow_splitting": bool(item.get("allow_splitting")),
+            "allow_splitting": splitting_allowed(item),
+            "item_quantity": item.get("quantity"),
         })
     return line_items
 
@@ -1637,7 +1638,8 @@ def setup_routes(app):
                 "hs_code": hs_code or catalog_item.get("hs_code") or "",
                 "account_code": account_code,
                 "entity_id": catalog_item.get("entity_id") or "",
-                "allow_splitting": bool(catalog_item.get("allow_splitting")),
+                "allow_splitting": splitting_allowed(catalog_item),
+                "item_quantity": catalog_item.get("quantity"),
                 "ambiguous": row_ambiguous,
             }
             new_lines.append(line)
@@ -6589,7 +6591,9 @@ def _doc_detail(doc: dict, locations: list | None = None, ledger: list | None = 
             discounted = float(qty or 0) * float(price or 0) * (1 - discount_pct / 100)
             line_tot = discounted
             li_entity_id = li.get("entity_id") or li.get("item_id") or ""
-            li_allow_splitting = "1" if li.get("allow_splitting") else ""
+            _meta = (item_meta_map or {}).get(li_entity_id) or {}
+            _allow_split = splitting_allowed(_meta) if "allow_splitting" in _meta else splitting_allowed(li)
+            li_allow_splitting = "1" if _allow_split else ""
             account_cell = None
             if doc_type in ("purchase_order", "bill"):
                 _acct_list = chart_accounts or []
@@ -6649,8 +6653,6 @@ def _doc_detail(doc: dict, locations: list | None = None, ledger: list | None = 
                 # PCS / WEIGHT are editable inputs inline in the description cell. Show
                 # only the secondary measure (the one qty is NOT) — same skip rule as the
                 # print/finalized view; locks + values come from the shared helper.
-                _meta = (item_meta_map or {}).get(li_entity_id) or {}
-                _allow_split = _meta.get("allow_splitting", bool(li.get("allow_splitting")))
                 _locks = measure_locks(_meta, allow_split=_allow_split)
                 _qty_disabled = _locks["qty_locked"]
                 _qty_measure = "weight" if _meta.get("qty_is_weight") else ("pieces" if _meta.get("qty_is_pieces") else "")
@@ -6761,7 +6763,7 @@ def _doc_detail(doc: dict, locations: list | None = None, ledger: list | None = 
                    None if pol["customs"] else Input(type="hidden", value=li.get("hs_code", "") or "", data_name="hs_code"),
                    Input(type="hidden", value=li_entity_id, data_name="entity_id"),
                    Input(type="hidden", value=li_allow_splitting, data_name="allow_splitting"),
-                   Input(type="hidden", value=str(li.get("item_quantity") or qty), data_name="item_quantity"),
+                   Input(type="hidden", value=str(li.get("item_quantity") or _meta.get("quantity") or qty), data_name="item_quantity"),
                    cls="cell--number col-total"),
             ])
             if pol["show_onhand"]:
@@ -6878,7 +6880,7 @@ def _doc_detail(doc: dict, locations: list | None = None, ledger: list | None = 
                          data_name="line_total"),
                    None if pol["customs"] else Input(type="hidden", value="", data_name="hs_code"),
                    Input(type="hidden", value="", data_name="entity_id"),
-                   Input(type="hidden", value="", data_name="allow_splitting"),
+                   Input(type="hidden", value="1", data_name="allow_splitting"),
                    Input(type="hidden", value="", data_name="item_quantity"),
                    cls="cell--number col-total"),
             ])

--- a/ui/routes/inventory.py
+++ b/ui/routes/inventory.py
@@ -30,6 +30,7 @@ from celerp.events.schemas import _WORKFLOW_TIME_UNITS
 from ui.routes.documents import _ICON_PRINT as _ICON_PRINT_SVG
 from ui.i18n import t, get_lang, is_rtl
 from celerp.services.units import is_weight_unit, is_pieces_unit
+from celerp.services.line_measures import splitting_allowed
 
 _DEFAULT_PER_PAGE = 50
 
@@ -7642,7 +7643,7 @@ def _advanced_panel(entity_id: str, item: dict, split_preview: dict | None = Non
     safe_id = re.sub(r"[^a-zA-Z0-9]", "_", entity_id)
 
     # 2x2 compact action cards
-    allow_splitting = item.get("allow_splitting", True)
+    allow_splitting = splitting_allowed(item)
     sell_by = item.get("sell_by") or "piece"
     # Splittable only when the server preview resolved and the parcel can be carved.
     can_split = bool(allow_splitting and split_preview and not split_preview.get("cannot_split"))


### PR DESCRIPTION
Four fixes to invoicing, reservation, and cost accounting.

Reserve only the invoiced quantity. Reserving a stock line that was invoiced for part of a parcel now carves off just the invoiced portion and reserves that, instead of reserving the whole parcel. A full-quantity invoice still reserves the whole line. A partial reserve of a parcel whose Allow Splitting is off is blocked with the same message used at fulfillment.

Consistent Allow Splitting default. An item whose Allow Splitting has never been set is now treated as splittable everywhere, matching what the item page already showed. This clears the spurious "Allow splitting is set to false" warning on the invoice screen for those items, and the warning now shows the parcel's full quantity rather than the quantity being drawn. Imported items keep this behavior instead of being forced to non-splittable.

Post cost of goods sold when an invoice is issued. COGS now posts to the profit and loss on the invoice date, at finalize, rather than at fulfillment. Cost is computed per lot: a line that draws on several lots is costed at each lot's own cost, and service or freight lines never post cost of goods. If the goods actually shipped later cost more or less than what was recognized at issue, fulfillment posts the difference as an adjustment entry dated to the shipment. Reverting an invoice reverses the COGS with it, and unvoiding a voided invoice restores exactly the entries the void reversed, through any number of void and unvoid cycles. This fixes issued-but-unfulfilled invoices that were showing revenue without the matching cost.

Backfill cost of goods for previously issued invoices. Invoices issued before this fix are missing their cost entries, so on the first start after updating, the system posts the missing cost of goods for every affected invoice automatically, dated to the original invoice dates. A notification in the bell menu reports what was posted, with a link to the new journal entries. Invoices that cannot be updated, for example because their period is locked, are skipped and retried on the next start. Invoices whose historical cost can no longer be determined unambiguously, because the invoiced lot has since been split or sold across several lots, are left untouched and listed in the notification for manual posting. Voiding or reverting an invoice sweeps these entries along with the rest of its automatic journal entries, and the repair tool now posts the cost line too when it rebuilds a finalize entry.