### PR TITLE
Let modules ship UI translation catalogs

### DIFF
--- a/celerp/modules/loader.py
+++ b/celerp/modules/loader.py
@@ -873,7 +873,7 @@ def _load_one(pkg_path: Path, pkg_name: str, *, trusted: bool = False) -> dict |
             rtl = False
         cat_path = pkg_path / entry["file"]
         try:
-            catalog = json.loads(cat_path.read_text())
+            catalog = json.loads(cat_path.read_text(encoding="utf-8"))
         except (OSError, ValueError) as exc:
             log.error(
                 "Module %r locale %r skipped: cannot read %s (%s: %s)",

--- a/celerp/modules/loader.py
+++ b/celerp/modules/loader.py
@@ -827,6 +827,31 @@ def _load_one(pkg_path: Path, pkg_name: str, *, trusted: bool = False) -> dict |
             for item in contribution:
                 register_slot(slot_name, {**item, "_module": pkg_name})
 
+    # Register module-contributed UI translation catalogs (the `locales`
+    # manifest key, mirroring `slots` above). Each entry maps a language code to
+    # {"file": <path>, "rtl": <bool>}. Pushed into ui.i18n through a lazy import
+    # so the i18n leaf never imports the module subsystem. A malformed or
+    # unreadable entry is logged and skipped; the module and its other locales
+    # still load.
+    for lang, entry in (manifest.get("locales") or {}).items():
+        if not isinstance(entry, dict) or "file" not in entry:
+            log.error(
+                "Module %r locale %r skipped: entry must be a dict with a 'file' key",
+                pkg_name, lang,
+            )
+            continue
+        cat_path = pkg_path / entry["file"]
+        try:
+            catalog = json.loads(cat_path.read_text())
+        except (OSError, ValueError) as exc:
+            log.error(
+                "Module %r locale %r skipped: cannot read %s (%s: %s)",
+                pkg_name, lang, entry["file"], type(exc).__name__, exc,
+            )
+            continue
+        from ui.i18n import register_catalog
+        register_catalog(lang, catalog, rtl=bool(entry.get("rtl")))
+
     log.info(
         "Module %r loaded (v%s, slots: %s)",
         manifest["name"],

--- a/celerp/modules/loader.py
+++ b/celerp/modules/loader.py
@@ -549,6 +549,12 @@ def load_all(module_dir: str | Path, enabled: set[str]) -> list[dict]:
     """
     _loaded.clear()
     _load_errors.clear()
+    # Module-contributed i18n catalogs are rebuilt from scratch on every pass,
+    # exactly like _loaded above, so a re-scan (a module toggled off, or a
+    # catalog changed) never leaves a stale or orphaned catalog behind. Lazy
+    # import keeps ui.i18n the lowest leaf (it must not import this module).
+    from ui.i18n import clear_registry
+    clear_registry()
 
     # Support comma-separated module directories
     raw = str(module_dir)
@@ -581,8 +587,12 @@ def load_all(module_dir: str | Path, enabled: set[str]) -> list[dict]:
                 sys.path.insert(0, p_str)
             candidate_paths.append(p)
 
-    # Sort by dependency order (skip reasons land in _load_errors)
-    ordered = _topo_sort(candidate_paths, enabled, errors=_load_errors)
+    # Sort by dependency order (skip reasons land in _load_errors). Discovery is
+    # name-sorted first so load order - and therefore every first-registered-wins
+    # tie-break (slots and module i18n catalogs alike) - is deterministic, not
+    # dependent on the filesystem's iterdir() order.
+    ordered = _topo_sort(
+        sorted(candidate_paths, key=lambda p: p.name), enabled, errors=_load_errors)
 
     # Relay credentials for the premium-license gate, resolved lazily and ONCE
     # per load pass: the JWT is the same for every module, and there must be no
@@ -833,13 +843,34 @@ def _load_one(pkg_path: Path, pkg_name: str, *, trusted: bool = False) -> dict |
     # so the i18n leaf never imports the module subsystem. A malformed or
     # unreadable entry is logged and skipped; the module and its other locales
     # still load.
-    for lang, entry in (manifest.get("locales") or {}).items():
-        if not isinstance(entry, dict) or "file" not in entry:
+    locales = manifest.get("locales") or {}
+    if not isinstance(locales, dict):
+        log.error(
+            "Module %r 'locales' skipped: must be a dict, got %s",
+            pkg_name, type(locales).__name__,
+        )
+        locales = {}
+    for lang, entry in locales.items():
+        if not isinstance(lang, str) or not lang.strip():
             log.error(
-                "Module %r locale %r skipped: entry must be a dict with a 'file' key",
+                "Module %r locale skipped: language code must be a non-empty string (got %r)",
                 pkg_name, lang,
             )
             continue
+        if (not isinstance(entry, dict)
+                or not isinstance(entry.get("file"), str) or not entry["file"].strip()):
+            log.error(
+                "Module %r locale %r skipped: entry must be a dict with a non-empty string 'file'",
+                pkg_name, lang,
+            )
+            continue
+        rtl = entry.get("rtl", False)
+        if not isinstance(rtl, bool):
+            log.error(
+                "Module %r locale %r: 'rtl' must be a bool, got %s - treating as false",
+                pkg_name, lang, type(rtl).__name__,
+            )
+            rtl = False
         cat_path = pkg_path / entry["file"]
         try:
             catalog = json.loads(cat_path.read_text())
@@ -850,7 +881,7 @@ def _load_one(pkg_path: Path, pkg_name: str, *, trusted: bool = False) -> dict |
             )
             continue
         from ui.i18n import register_catalog
-        register_catalog(lang, catalog, rtl=bool(entry.get("rtl")))
+        register_catalog(lang, catalog, rtl=rtl)
 
     log.info(
         "Module %r loaded (v%s, slots: %s)",

--- a/tests/fixtures/modules/celerp-testlang/__init__.py
+++ b/tests/fixtures/modules/celerp-testlang/__init__.py
@@ -1,0 +1,18 @@
+# Copyright (c) 2026 Noah Severs
+# SPDX-License-Identifier: LicenseRef-Proprietary
+"""Test fixture module: exercises the i18n `locales` manifest seam.
+
+Declares one new language ("xx") and one right-to-left language ("xr") so the
+loader push path (manifest -> register_catalog -> _load) can be tested end to
+end. Strings are ASCII test placeholders only, never shipped copy.
+"""
+
+PLUGIN_MANIFEST = {
+    "name": "celerp-testlang",
+    "version": "1.0.0",
+    "display_name": "Test Language Module",
+    "locales": {
+        "xx": {"file": "locales/xx.json", "rtl": False},
+        "xr": {"file": "locales/xr.json", "rtl": True},
+    },
+}

--- a/tests/fixtures/modules/celerp-testlang/locales/xr.json
+++ b/tests/fixtures/modules/celerp-testlang/locales/xr.json
@@ -1,0 +1,3 @@
+{
+  "testlang.greeting": "Salaam Testish"
+}

--- a/tests/fixtures/modules/celerp-testlang/locales/xx.json
+++ b/tests/fixtures/modules/celerp-testlang/locales/xx.json
@@ -1,0 +1,4 @@
+{
+  "testlang.greeting": "Hi from Testish",
+  "action.delete_file": "\"><img src=x onerror=alert(1)>"
+}

--- a/tests/test_browser/test_i18n_ui.py
+++ b/tests/test_browser/test_i18n_ui.py
@@ -59,6 +59,8 @@ def test_select_module_language_sets_cookie_and_renders(page, ui_server):
     the running ui_server process (the same thing the module loader does on boot),
     then removed afterwards so no other browser test sees the synthetic 'xx'
     language."""
+    from playwright.sync_api import expect
+
     from ui import i18n
 
     i18n.register_catalog(
@@ -67,21 +69,20 @@ def test_select_module_language_sets_cookie_and_renders(page, ui_server):
     try:
         page.goto(f"{ui_server}/dashboard", wait_until="domcontentloaded")
         switcher = page.locator("#lang-switcher")
-        assert switcher.count() == 1, "language switcher not rendered with >1 locale"
+        expect(switcher).to_have_count(1)
 
+        # The switcher writes the celerp_lang cookie and reloads the page. Use
+        # auto-retrying assertions that ride out the reload rather than reading
+        # page.content() mid-navigation. The header text 'Testish Dashboard' is
+        # rendered server-side from t('page.dashboard') under the xx cookie, so it
+        # only appears AFTER the reload - proving the full cookie -> get_lang ->
+        # t() -> production component -> browser chain, not just the picker state.
         switcher.select_option("xx")
-        page.wait_for_load_state("domcontentloaded")
+        expect(page.locator("body")).to_contain_text("Testish Dashboard")
+        expect(page.locator("#lang-switcher")).to_have_value("xx")
 
         cookies = {c["name"]: c["value"] for c in page.context.cookies()}
         assert cookies.get("celerp_lang") == "xx", f"cookie not set: {cookies}"
-
-        body = page.content()
-        assert "Internal Server Error" not in body
-        assert "Traceback" not in body
-        # After reload, get_lang reads the cookie and the switcher marks xx active.
-        assert page.locator("#lang-switcher").input_value() == "xx"
-        # The contributed catalog value actually renders in the page header.
-        assert "Testish Dashboard" in body
     finally:
         i18n._registry.pop("xx", None)
         getattr(getattr(i18n, "_cached_load", None), "cache_clear", lambda: None)()

--- a/tests/test_browser/test_i18n_ui.py
+++ b/tests/test_browser/test_i18n_ui.py
@@ -53,12 +53,17 @@ def test_select_module_language_sets_cookie_and_renders(page, ui_server):
     sets the celerp_lang cookie, reloads, and the reloaded page renders that
     language as selected - the real end-to-end contributed-language flow.
 
-    The catalog is pushed straight into the running ui_server process (the same
-    thing the module loader does on boot), then removed afterwards so no other
-    browser test sees the synthetic 'xx' language."""
+    The catalog overrides page.dashboard, a key the dashboard header actually
+    renders, so the assertion proves the full chain: module catalog -> request
+    language -> t() -> production component -> browser. It is pushed straight into
+    the running ui_server process (the same thing the module loader does on boot),
+    then removed afterwards so no other browser test sees the synthetic 'xx'
+    language."""
     from ui import i18n
 
-    i18n.register_catalog("xx", {"testlang.greeting": "Hi from Testish"})
+    i18n.register_catalog(
+        "xx", {"testlang.greeting": "Hi from Testish", "page.dashboard": "Testish Dashboard"}
+    )
     try:
         page.goto(f"{ui_server}/dashboard", wait_until="domcontentloaded")
         switcher = page.locator("#lang-switcher")
@@ -75,6 +80,8 @@ def test_select_module_language_sets_cookie_and_renders(page, ui_server):
         assert "Traceback" not in body
         # After reload, get_lang reads the cookie and the switcher marks xx active.
         assert page.locator("#lang-switcher").input_value() == "xx"
+        # The contributed catalog value actually renders in the page header.
+        assert "Testish Dashboard" in body
     finally:
         i18n._registry.pop("xx", None)
         getattr(getattr(i18n, "_cached_load", None), "cache_clear", lambda: None)()

--- a/tests/test_browser/test_i18n_ui.py
+++ b/tests/test_browser/test_i18n_ui.py
@@ -46,18 +46,3 @@ def test_lang_switcher_in_topbar(page, ui_server):
     # With only en.json, it won't render. Just verify no crash.
     assert "Internal Server Error" not in body
     assert "Traceback" not in body
-
-
-def test_language_change_endpoint_no_crash(page, ui_server):
-    """I18N-04: POST /settings/company/language → no 500, renders updated picker."""
-    # Use HTMX-style POST (form data)
-    resp = page.request.post(
-        f"{ui_server}/settings/company/language",
-        form={"language": "en"},
-    )
-    assert resp.status != 500, \
-        f"POST /settings/company/language returned {resp.status}"
-    # Response should be a valid HTML fragment (not a full traceback)
-    body = resp.text()
-    assert "Internal Server Error" not in body
-    assert "Traceback" not in body

--- a/tests/test_browser/test_i18n_ui.py
+++ b/tests/test_browser/test_i18n_ui.py
@@ -46,3 +46,35 @@ def test_lang_switcher_in_topbar(page, ui_server):
     # With only en.json, it won't render. Just verify no crash.
     assert "Internal Server Error" not in body
     assert "Traceback" not in body
+
+
+def test_select_module_language_sets_cookie_and_renders(page, ui_server):
+    """I18N-04: selecting a module-contributed language in the topbar switcher
+    sets the celerp_lang cookie, reloads, and the reloaded page renders that
+    language as selected - the real end-to-end contributed-language flow.
+
+    The catalog is pushed straight into the running ui_server process (the same
+    thing the module loader does on boot), then removed afterwards so no other
+    browser test sees the synthetic 'xx' language."""
+    from ui import i18n
+
+    i18n.register_catalog("xx", {"testlang.greeting": "Hi from Testish"})
+    try:
+        page.goto(f"{ui_server}/dashboard", wait_until="domcontentloaded")
+        switcher = page.locator("#lang-switcher")
+        assert switcher.count() == 1, "language switcher not rendered with >1 locale"
+
+        switcher.select_option("xx")
+        page.wait_for_load_state("domcontentloaded")
+
+        cookies = {c["name"]: c["value"] for c in page.context.cookies()}
+        assert cookies.get("celerp_lang") == "xx", f"cookie not set: {cookies}"
+
+        body = page.content()
+        assert "Internal Server Error" not in body
+        assert "Traceback" not in body
+        # After reload, get_lang reads the cookie and the switcher marks xx active.
+        assert page.locator("#lang-switcher").input_value() == "xx"
+    finally:
+        i18n._registry.pop("xx", None)
+        getattr(getattr(i18n, "_cached_load", None), "cache_clear", lambda: None)()

--- a/tests/test_module_i18n_seam.py
+++ b/tests/test_module_i18n_seam.py
@@ -190,25 +190,233 @@ def test_switcher_lists_module_language():
 
 def test_module_catalog_value_escaped_in_attribute_sink():
     """A module catalog value carrying an attribute-breakout payload is
-    neutralized when rendered into an f-string attribute sink (the files delete
-    button's hx_confirm), exactly as the central catalog would be."""
-    from fasthtml.common import Button, to_xml
+    neutralized when rendered by the REAL production component (the files
+    section's delete-button hx_confirm sink at ui/components/files.py), not a
+    hand-mirrored stand-in. The active language is set to 'xx' so files_section's
+    own t('action.delete_file') call picks up the module payload."""
+    from fasthtml.common import to_xml
 
-    from ui.components.attrs import esc_attr
+    from ui.components.files import files_section
 
     payload = '"><img src=x onerror=alert(1)>'
     i18n.register_catalog("xx", {"action.delete_file": payload})
 
-    # Mirror the ui/components/files.py delete-button sink verbatim: the t()
-    # value is interpolated into hx_confirm without a manual esc_attr, relying
-    # on FastHTML's to_xml attribute escaping.
-    btn = Button(
-        "×",
-        hx_confirm=f"{i18n.t('action.delete_file', 'xx')}: {esc_attr('file.txt')}?",
-        cls="btn btn--ghost btn--xs",
-    )
-    xml = to_xml(btn)
+    token = i18n._current_lang.set("xx")
+    try:
+        section = files_section(
+            "doc",
+            "doc-1",
+            [{"id": "f1", "filename": "file.txt", "size": 12, "uploaded_at": "2026-08-23"}],
+        )
+        xml = to_xml(section)
+    finally:
+        i18n._current_lang.reset(token)
 
     assert i18n.t("action.delete_file", "xx") == payload  # stored raw
-    assert "<img src=x" not in xml                        # no raw breakout tag
+    assert payload not in xml                              # not present verbatim
+    assert "<img src=x" not in xml                         # no raw breakout tag
     assert "&lt;img src=x" in xml                          # escaped instead
+
+
+# ---------------------------------------------------------------------------
+# Malformed-input robustness (the module-supplied trust boundary must degrade,
+# never crash the loader / boot)
+# ---------------------------------------------------------------------------
+
+def test_malformed_locales_container_skipped(tmp_path):
+    """A `locales` value that is not a dict (here a list) is logged and skipped;
+    the module still loads with no exception escaping the loader."""
+    from celerp.modules.loader import load_all
+
+    _write_module(
+        tmp_path,
+        "celerp-badcontainer",
+        {"name": "celerp-badcontainer", "version": "1.0.0", "locales": ["xx"]},
+        {},
+    )
+    loaded = load_all(tmp_path, {"celerp-badcontainer"})
+    assert any(m["name"] == "celerp-badcontainer" for m in loaded)
+    assert "xx" not in i18n.available_langs()
+
+
+def test_non_string_file_value_skipped(tmp_path):
+    """An entry whose `file` is not a string is skipped (no Path / non-string),
+    the module still loads, and a valid sibling locale registers."""
+    from celerp.modules.loader import load_all
+
+    _write_module(
+        tmp_path,
+        "celerp-badfile",
+        {
+            "name": "celerp-badfile",
+            "version": "1.0.0",
+            "locales": {
+                "xg": {"file": "locales/xg.json"},
+                "xb": {"file": 123},
+            },
+        },
+        {"locales/xg.json": json.dumps({"testlang.greeting": "Good"})},
+    )
+    loaded = load_all(tmp_path, {"celerp-badfile"})
+    assert any(m["name"] == "celerp-badfile" for m in loaded)
+    assert "xg" in i18n.available_langs()
+    assert "xb" not in i18n.available_langs()
+
+
+def test_non_string_language_code_skipped(tmp_path):
+    """A non-string language code in the manifest is skipped: the module loads,
+    a valid sibling registers, and available_langs() (which sorts codes) does
+    not crash on a poisoned key."""
+    from celerp.modules.loader import load_all
+
+    _write_module(
+        tmp_path,
+        "celerp-badcode",
+        {
+            "name": "celerp-badcode",
+            "version": "1.0.0",
+            "locales": {
+                123: {"file": "locales/n.json"},
+                "xg": {"file": "locales/xg.json"},
+            },
+        },
+        {
+            "locales/n.json": json.dumps({"testlang.greeting": "Nope"}),
+            "locales/xg.json": json.dumps({"testlang.greeting": "Good"}),
+        },
+    )
+    loaded = load_all(tmp_path, {"celerp-badcode"})
+    assert any(m["name"] == "celerp-badcode" for m in loaded)
+    langs = i18n.available_langs()  # must not raise on a mixed-type sort
+    assert "xg" in langs
+    assert 123 not in i18n._registry
+
+
+def test_register_catalog_rejects_non_string_lang():
+    """The public API self-defends: a non-string language code is ignored."""
+    i18n.register_catalog(123, {"testlang.k": "v"})
+    assert 123 not in i18n._registry
+    assert i18n.available_langs() == sorted(i18n._DISK_LANGS)
+
+
+def test_non_bool_rtl_treated_false(tmp_path):
+    """A non-bool `rtl` value in the manifest is not treated as True: the
+    language registers but is left LTR."""
+    from celerp.modules.loader import load_all
+
+    _write_module(
+        tmp_path,
+        "celerp-truthyrtl",
+        {
+            "name": "celerp-truthyrtl",
+            "version": "1.0.0",
+            "locales": {"xy": {"file": "locales/xy.json", "rtl": "yes"}},
+        },
+        {"locales/xy.json": json.dumps({"testlang.greeting": "Hi"})},
+    )
+    load_all(tmp_path, {"celerp-truthyrtl"})
+    assert "xy" in i18n.available_langs()
+    assert i18n.is_rtl("xy") is False
+
+
+def test_module_cannot_flip_central_language_rtl():
+    """A module declaring rtl=True for an EXISTING central language cannot flip
+    its direction: central owns a disk language's direction."""
+    i18n.register_catalog("en", {"testlang.k": "v"}, rtl=True)
+    assert i18n.is_rtl("en") is False
+
+
+# ---------------------------------------------------------------------------
+# Repeated-loader lifecycle (the registry is rebuilt each pass)
+# ---------------------------------------------------------------------------
+
+def _write_langmod(dirpath: Path, name: str, code: str, value: str) -> None:
+    _write_module(
+        dirpath,
+        name,
+        {"name": name, "version": "1.0.0", "locales": {code: {"file": f"locales/{code}.json"}}},
+        {f"locales/{code}.json": json.dumps({"testlang.greeting": value})},
+    )
+
+
+def test_reload_reflects_changed_catalog(tmp_path):
+    """Two consecutive load_all() passes over the SAME module whose catalog
+    changed between them: the second pass reflects the new value, not the stale
+    first-registered one (the registry is rebuilt, not accreted)."""
+    from celerp.modules.loader import load_all
+
+    _write_langmod(tmp_path, "celerp-reload", "xx", "first")
+    load_all(tmp_path, {"celerp-reload"})
+    assert i18n.t("testlang.greeting", "xx") == "first"
+
+    (tmp_path / "celerp-reload" / "locales" / "xx.json").write_text(
+        json.dumps({"testlang.greeting": "second"})
+    )
+    load_all(tmp_path, {"celerp-reload"})
+    assert i18n.t("testlang.greeting", "xx") == "second"
+
+
+def test_disabled_module_language_removed(tmp_path):
+    """A language contributed on the first pass is gone after a second pass that
+    no longer enables the contributing module."""
+    from celerp.modules.loader import load_all
+
+    _write_langmod(tmp_path, "celerp-gone", "xx", "here")
+    load_all(tmp_path, {"celerp-gone"})
+    assert "xx" in i18n.available_langs()
+
+    load_all(tmp_path, set())  # nothing enabled this pass
+    assert "xx" not in i18n.available_langs()
+
+
+def test_two_module_collision_deterministic(tmp_path):
+    """Two modules contributing the SAME new language resolve deterministically:
+    name-sorted discovery loads the alphabetically-first module first, and
+    first-registered wins - stable across runs regardless of filesystem order."""
+    from celerp.modules.loader import load_all
+
+    _write_langmod(tmp_path, "celerp-la", "xx", "from-la")
+    _write_langmod(tmp_path, "celerp-lb", "xx", "from-lb")
+
+    load_all(tmp_path, {"celerp-la", "celerp-lb"})
+    first = i18n.t("testlang.greeting", "xx")
+    load_all(tmp_path, {"celerp-la", "celerp-lb"})
+    second = i18n.t("testlang.greeting", "xx")
+
+    assert first == second == "from-la"
+
+
+# ---------------------------------------------------------------------------
+# English fallback for module-contributed keys, and cookie availability
+# ---------------------------------------------------------------------------
+
+def test_module_english_fallback_for_new_keys():
+    """A module that ships a NEW key for English makes it the fallback for every
+    language: an English user sees it, and a module language missing that key
+    falls back to the module-contributed English value."""
+    i18n.register_catalog("en", {"testlang.only_en": "English only"})
+    i18n.register_catalog("xx", {"testlang.greeting": "Hi"})
+    assert i18n.t("testlang.only_en", "en") == "English only"
+    # xx has no such key -> falls back through en to the module-contributed value.
+    assert i18n.t("testlang.only_en", "xx") == "English only"
+
+
+def test_cookie_unavailable_language_falls_back():
+    """get_lang honours a cookie only when the language is actually available;
+    a stale cookie for an unknown/removed language falls back to en."""
+    assert i18n.get_lang(_StubRequest(cookie="zz")) == "en"
+    i18n.register_catalog("xx", {"testlang.greeting": "Hi"})
+    assert i18n.get_lang(_StubRequest(cookie="xx")) == "xx"
+
+
+def test_switcher_marks_module_language_selected():
+    """The topbar switcher renders a module-contributed language as the SELECTED
+    option when it is the active language (render path)."""
+    from fasthtml.common import to_xml
+
+    from ui.components.shell import _topbar
+
+    i18n.register_catalog("xx", {"testlang.greeting": "Hi"})
+    xml = to_xml(_topbar([], lang="xx"))
+    assert 'value="xx"' in xml
+    assert "selected" in xml

--- a/tests/test_module_i18n_seam.py
+++ b/tests/test_module_i18n_seam.py
@@ -420,3 +420,101 @@ def test_switcher_marks_module_language_selected():
     xml = to_xml(_topbar([], lang="xx"))
     assert 'value="xx"' in xml
     assert "selected" in xml
+
+
+# ---------------------------------------------------------------------------
+# UTF-8 decoding: catalogs are read as UTF-8 regardless of platform default
+# ---------------------------------------------------------------------------
+
+_UNICODE_SAMPLE = {
+    "testlang.greeting": "ሰላም",   # Amharic
+    "testlang.hello": "مرحبا",    # Arabic
+    "testlang.city": "东京",       # CJK
+}
+
+
+def _patch_ascii_default_read_text(monkeypatch):
+    """Simulate a platform whose default text encoding is not UTF-8: Path.read_text
+    with no explicit encoding decodes as ascii. Code that reads catalogs correctly
+    must pass encoding='utf-8'; code that relies on the platform default raises
+    UnicodeDecodeError on any non-ASCII catalog. (The Amharic/Arabic/CJK bytes are
+    written UTF-8 with an explicit encoding, so authoring the fixture is unaffected.)"""
+    real_read_text = Path.read_text
+
+    def _ascii_default(self, encoding=None, errors=None):
+        return real_read_text(self, encoding=encoding or "ascii", errors=errors)
+
+    monkeypatch.setattr(Path, "read_text", _ascii_default)
+
+
+def test_module_catalog_read_as_utf8(tmp_path, monkeypatch):
+    """A module catalog carrying non-ASCII values (Amharic, Arabic, CJK) loads
+    and round-trips exactly on a non-UTF-8-default platform. Without an explicit
+    utf-8 read the catalog raises UnicodeDecodeError (a ValueError) and the loader
+    skips the whole language - the portability bug this guards against."""
+    from celerp.modules.loader import load_all
+
+    (tmp_path / "celerp-amharic").mkdir()
+    (tmp_path / "celerp-amharic" / "__init__.py").write_text(
+        "PLUGIN_MANIFEST = {'name': 'celerp-amharic', 'version': '1.0.0', "
+        "'locales': {'am': {'file': 'locales/am.json'}}}\n"
+    )
+    (tmp_path / "celerp-amharic" / "locales").mkdir()
+    (tmp_path / "celerp-amharic" / "locales" / "am.json").write_text(
+        json.dumps(_UNICODE_SAMPLE, ensure_ascii=False), encoding="utf-8"
+    )
+
+    _patch_ascii_default_read_text(monkeypatch)
+    load_all(tmp_path, {"celerp-amharic"})
+    assert "am" in i18n.available_langs()
+    assert i18n.t("testlang.greeting", "am") == "ሰላም"
+    assert i18n.t("testlang.city", "am") == "东京"
+
+
+def test_central_catalog_read_as_utf8(tmp_path, monkeypatch):
+    """The central catalog loader (_load) also reads as UTF-8 regardless of the
+    platform default, so a non-ASCII central language renders its own strings."""
+    (tmp_path / "zz.json").write_text(
+        json.dumps({"testlang.greeting": "ሰላም"}, ensure_ascii=False),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(i18n, "_LOCALES_DIR", tmp_path)
+    _patch_ascii_default_read_text(monkeypatch)
+    i18n._invalidate_cache()
+    assert i18n.t("testlang.greeting", "zz") == "ሰላም"
+
+
+# ---------------------------------------------------------------------------
+# Regional locale negotiation and case-insensitive language codes
+# ---------------------------------------------------------------------------
+
+def test_accept_language_matches_regional_then_base():
+    """Accept-Language negotiation tries the full regional tag before its base:
+    a module-contributed regional catalog (pt-br) is reachable, and plain base
+    negotiation (de-AT -> de) still resolves."""
+    i18n.register_catalog("pt-br", {"testlang.greeting": "Ola"})
+    i18n.register_catalog("de", {"testlang.greeting": "Hallo"})
+    assert i18n.get_lang(_StubRequest(accept_language="pt-BR,pt;q=0.9")) == "pt-br"
+    assert i18n.get_lang(_StubRequest(accept_language="de-AT")) == "de"
+
+
+def test_language_code_normalized_lowercase():
+    """A module registering a mixed-case regional code is normalized to lower
+    case (tags are case-insensitive), so the switcher value, the cookie, and
+    Accept-Language all resolve one key."""
+    i18n.register_catalog("PT-BR", {"testlang.greeting": "Ola"})
+    assert "pt-br" in i18n.available_langs()
+    assert "PT-BR" not in i18n._registry
+    assert i18n.get_lang(_StubRequest(cookie="pt-BR")) == "pt-br"
+    assert i18n.t("testlang.greeting", "pt-br") == "Ola"
+
+
+def test_rtl_first_registration_wins():
+    """A language's reading direction is fixed by its FIRST registration: a later
+    module cannot flip an established LTR language to RTL, nor an RTL one to LTR."""
+    i18n.register_catalog("xx", {"testlang.k": "v"}, rtl=False)
+    i18n.register_catalog("xx", {"testlang.k2": "v2"}, rtl=True)
+    assert i18n.is_rtl("xx") is False
+    i18n.register_catalog("yy", {"testlang.k": "v"}, rtl=True)
+    i18n.register_catalog("yy", {"testlang.k2": "v2"}, rtl=False)
+    assert i18n.is_rtl("yy") is True

--- a/tests/test_module_i18n_seam.py
+++ b/tests/test_module_i18n_seam.py
@@ -1,0 +1,214 @@
+# Copyright (c) 2026 Noah Severs
+# SPDX-License-Identifier: LicenseRef-Proprietary
+"""Unit and component tests for the i18n module seam.
+
+A loadable module contributes UI translation catalogs (a whole new language
+and/or extra keys for an existing one) through a `locales` manifest key. The
+loader pushes each declared catalog into ui.i18n via register_catalog; ui.i18n
+merges the central locale file over the module registry, central winning for an
+existing language.
+
+Symbols under test (register_catalog, clear_registry, available_langs) do not
+exist at merge-base, so the assertions below have no code to satisfy there.
+"""
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+# ui.i18n always imports; the seam symbols are referenced as attributes inside
+# each test so a merge-base run fails per-test (AttributeError) rather than as a
+# single collection error.
+from ui import i18n
+
+_FIXTURES_MODULES_DIR = Path(__file__).parent / "fixtures" / "modules"
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry():
+    """Reset the i18n catalog registry (and its load cache) around each test so
+    module-contributed catalogs never leak between tests. Guarded so the fixture
+    is harmless before the seam exists."""
+    getattr(i18n, "clear_registry", lambda: None)()
+    getattr(getattr(i18n, "_cached_load", None), "cache_clear", lambda: None)()
+    yield
+    getattr(i18n, "clear_registry", lambda: None)()
+    getattr(getattr(i18n, "_cached_load", None), "cache_clear", lambda: None)()
+
+
+class _StubRequest:
+    """Minimal stand-in for get_lang: a cookie jar and a header bag."""
+
+    def __init__(self, cookie: str = "", accept_language: str = ""):
+        self.cookies = {"celerp_lang": cookie} if cookie else {}
+        self.headers = {"accept-language": accept_language}
+
+
+def _write_module(dirpath: Path, name: str, manifest: dict, files: dict[str, str]) -> None:
+    """Build a loadable module package on disk: __init__.py plus catalog files."""
+    pkg = dirpath / name
+    pkg.mkdir(parents=True)
+    (pkg / "__init__.py").write_text(
+        "PLUGIN_MANIFEST = " + repr(manifest) + "\n"
+    )
+    for rel, content in files.items():
+        target = pkg / rel
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(content)
+
+
+# ---------------------------------------------------------------------------
+# Registry: resolution, precedence, fallback
+# ---------------------------------------------------------------------------
+
+def test_module_language_resolves():
+    """J1: a module-contributed language renders its own strings via t(key, 'xx')."""
+    i18n.register_catalog("xx", {"testlang.greeting": "Hi from Testish"})
+    assert i18n.t("testlang.greeting", "xx") == "Hi from Testish"
+
+
+def test_module_clash_first_wins():
+    """On a module-vs-module clash for the same lang+key, the FIRST value wins."""
+    i18n.register_catalog("xx", {"testlang.k": "first"})
+    i18n.register_catalog("xx", {"testlang.k": "second"})
+    assert i18n.t("testlang.k", "xx") == "first"
+
+
+def test_missing_key_falls_back_to_en():
+    """A PRESENT key returns the module's own value; an OMITTED key falls to en."""
+    i18n.register_catalog("xx", {"testlang.greeting": "Hi from Testish"})
+    assert i18n.t("testlang.greeting", "xx") == "Hi from Testish"
+    # btn.save is absent from the xx catalog but present in en.
+    assert i18n.t("btn.save", "xx") == "Save"
+
+
+def test_existing_lang_additive_central_wins():
+    """A module adds a NEW key to an existing language but cannot override a
+    central key: central copy wins, the new key is additive."""
+    i18n.register_catalog("en", {"testlang.newkey": "added", "btn.save": "HIJACKED"})
+    assert i18n.t("testlang.newkey", "en") == "added"
+    assert i18n.t("btn.save", "en") == "Save"
+
+
+def test_new_language_in_available_langs():
+    """available_langs() surfaces a module-contributed language code."""
+    i18n.register_catalog("xx", {"testlang.greeting": "Hi from Testish"})
+    assert "xx" in i18n.available_langs()
+
+
+def test_rtl_from_manifest():
+    """A module can declare a language right-to-left via its manifest `rtl` flag;
+    is_rtl resolves it. Driven end to end through the loader push path."""
+    from celerp.modules.loader import load_all
+
+    load_all(_FIXTURES_MODULES_DIR, {"celerp-testlang"})
+    assert i18n.is_rtl("xr") is True
+    assert i18n.is_rtl("xx") is False
+
+
+def test_register_catalog_invalidates_cache():
+    """Registering a catalog busts the load cache so a primed language re-reads."""
+    # Prime the cache for 'xx' (no catalog yet -> central-only, en fallback).
+    assert i18n.t("testlang.greeting", "xx") == "testlang.greeting"
+    i18n.register_catalog("xx", {"testlang.greeting": "Hi from Testish"})
+    assert i18n.t("testlang.greeting", "xx") == "Hi from Testish"
+
+
+def test_get_lang_accepts_module_language():
+    """get_lang ACCEPTS a module-registered code from Accept-Language AND still
+    falls back to en for an unknown code (guards the membership check from
+    over-accepting)."""
+    i18n.register_catalog("xx", {"testlang.greeting": "Hi from Testish"})
+    assert i18n.get_lang(_StubRequest(accept_language="xx")) == "xx"
+    assert i18n.get_lang(_StubRequest(accept_language="zz")) == "en"
+
+
+def test_malformed_catalog_skipped(tmp_path):
+    """A module with one valid and one malformed catalog loads: the valid
+    language registers, the malformed entry is logged and skipped."""
+    from celerp.modules.loader import load_all
+
+    _write_module(
+        tmp_path,
+        "celerp-badlang",
+        {
+            "name": "celerp-badlang",
+            "version": "1.0.0",
+            "locales": {
+                "xg": {"file": "locales/xg.json", "rtl": False},
+                "xb": {"file": "locales/xb.json", "rtl": False},
+            },
+        },
+        {
+            "locales/xg.json": json.dumps({"testlang.greeting": "Good"}),
+            "locales/xb.json": "{ this is not valid json ",
+        },
+    )
+    loaded = load_all(tmp_path, {"celerp-badlang"})
+
+    assert any(m["name"] == "celerp-badlang" for m in loaded)
+    assert "xg" in i18n.available_langs()
+    assert "xb" not in i18n.available_langs()
+    assert i18n.t("testlang.greeting", "xg") == "Good"
+
+
+def test_register_catalog_rejects_non_dict():
+    """A non-dict mapping is rejected without poisoning the registry."""
+    i18n.register_catalog("xx", ["not", "a", "dict"])
+    assert "xx" not in i18n.available_langs()
+    # The registry is not poisoned: a later valid registration still works.
+    i18n.register_catalog("xx", {"testlang.greeting": "Hi from Testish"})
+    assert i18n.t("testlang.greeting", "xx") == "Hi from Testish"
+
+
+def test_register_catalog_drops_non_string_value():
+    """A non-str catalog value is dropped and logged; str values still register."""
+    i18n.register_catalog("xx", {"testlang.a": "ok", "testlang.b": 123})
+    assert i18n.t("testlang.a", "xx") == "ok"
+    # 123 was dropped, so the key falls back to itself (absent from en).
+    assert i18n.t("testlang.b", "xx") == "testlang.b"
+
+
+# ---------------------------------------------------------------------------
+# Rendering surfaces
+# ---------------------------------------------------------------------------
+
+def test_switcher_lists_module_language():
+    """The topbar language switcher lists a module-contributed language."""
+    from fasthtml.common import to_xml
+
+    from ui.components.shell import _topbar
+
+    i18n.register_catalog("xx", {"testlang.greeting": "Hi from Testish"})
+    xml = to_xml(_topbar([], lang="en"))
+    assert 'value="xx"' in xml
+    assert "XX" in xml
+
+
+def test_module_catalog_value_escaped_in_attribute_sink():
+    """A module catalog value carrying an attribute-breakout payload is
+    neutralized when rendered into an f-string attribute sink (the files delete
+    button's hx_confirm), exactly as the central catalog would be."""
+    from fasthtml.common import Button, to_xml
+
+    from ui.components.attrs import esc_attr
+
+    payload = '"><img src=x onerror=alert(1)>'
+    i18n.register_catalog("xx", {"action.delete_file": payload})
+
+    # Mirror the ui/components/files.py delete-button sink verbatim: the t()
+    # value is interpolated into hx_confirm without a manual esc_attr, relying
+    # on FastHTML's to_xml attribute escaping.
+    btn = Button(
+        "×",
+        hx_confirm=f"{i18n.t('action.delete_file', 'xx')}: {esc_attr('file.txt')}?",
+        cls="btn btn--ghost btn--xs",
+    )
+    xml = to_xml(btn)
+
+    assert i18n.t("action.delete_file", "xx") == payload  # stored raw
+    assert "<img src=x" not in xml                        # no raw breakout tag
+    assert "&lt;img src=x" in xml                          # escaped instead

--- a/ui/components/shell.py
+++ b/ui/components/shell.py
@@ -6,13 +6,12 @@ from __future__ import annotations
 import hashlib
 import json
 import os
-from pathlib import Path
 from urllib.parse import parse_qs, urlencode, urlparse
 
 from fasthtml.common import *
 
 from ui.config import COOKIE_NAME, get_role
-from ui.i18n import t, get_lang
+from ui.i18n import t, get_lang, available_langs
 from celerp.config import settings as _app_settings
 
 # Cache-bust static assets by hashing app.css content
@@ -25,25 +24,6 @@ def _css_version() -> str:
         return "1"
 
 _CSS_VER = _css_version()
-
-# Discover available locales at startup
-_LOCALE_LABELS: dict[str, str] = {
-    "en": "English", "th": "ไทย", "zh": "中文", "ja": "日本語",
-    "ko": "한국어", "es": "Español", "fr": "Français", "de": "Deutsch",
-    "pt": "Português", "it": "Italiano", "nl": "Nederlands", "ru": "Русский",
-    "ar": "العربية", "hi": "हिन्दी", "vi": "Tiếng Việt", "id": "Bahasa Indonesia",
-    "ms": "Bahasa Melayu", "tr": "Türkçe", "pl": "Polski", "sv": "Svenska",
-}
-
-def _available_locales() -> list[tuple[str, str]]:
-    """Return [(code, label)] for all locales with a .json file, sorted by label."""
-    locales_dir = Path(__file__).parent.parent / "locales"
-    codes = sorted(
-        p.stem for p in locales_dir.glob("*.json")
-    )
-    return [(c, _LOCALE_LABELS.get(c, c.upper())) for c in codes]
-
-_LOCALES = _available_locales()
 
 # Idle auto-logout: after N minutes with no user interaction, send the browser to /logout. Uniform
 # across direct and relay access (no token-TTL surgery), and it implements "15 minutes of inactivity"
@@ -1437,7 +1417,7 @@ def _topbar(companies: list[dict], lang: str = "en", user_email: str | None = No
         Div(
             Span("🌐", cls="lang-switcher__globe"),
             Select(
-                *[Option(code.upper(), value=code, selected=(code == lang)) for code, _label in _LOCALES],
+                *[Option(code.upper(), value=code, selected=(code == lang)) for code in available_langs()],
                 id="lang-switcher",
                 cls="lang-switcher",
                 title="Language",

--- a/ui/i18n.py
+++ b/ui/i18n.py
@@ -58,6 +58,11 @@ def register_catalog(lang: str, mapping, *, rtl: bool = False) -> None:
     module-vs-module clash for the same language and key, the FIRST registration
     wins. The load cache is invalidated so the new catalog is visible at once.
     """
+    if not isinstance(lang, str) or not lang.strip():
+        _log.warning(
+            "register_catalog: ignoring catalog with invalid language code %r", lang,
+        )
+        return
     if not isinstance(mapping, dict):
         _log.warning(
             "register_catalog: ignoring non-dict catalog for %r (%s)",
@@ -76,13 +81,16 @@ def register_catalog(lang: str, mapping, *, rtl: bool = False) -> None:
     entry = _registry.setdefault(lang, {"catalog": {}, "rtl": False})
     # First-registered wins: existing keys overlay the incoming ones.
     entry["catalog"] = {**clean, **entry["catalog"]}
-    if rtl:
+    if rtl is True:
         entry["rtl"] = True
     _invalidate_cache()
 
 
 def clear_registry() -> None:
-    """Clear all module-contributed catalogs and drop the load cache. Tests only."""
+    """Clear all module-contributed catalogs and drop the load cache. Called by
+    the module loader at the start of every load_all() pass so the registry is
+    rebuilt from scratch (no stale/orphaned catalogs across re-scans), and by
+    tests for isolation."""
     _registry.clear()
     _invalidate_cache()
 
@@ -118,7 +126,7 @@ def get_lang(request) -> str:
     if request is None:
         return "en"
     lang = request.cookies.get("celerp_lang", "")
-    if lang:
+    if lang and (lang in _DISK_LANGS or lang in _registry):
         return lang
     accept = request.headers.get("accept-language", "")
     for part in accept.split(","):
@@ -144,5 +152,9 @@ def is_rtl(lang: str | None = None) -> bool:
     code = lang or _current_lang.get()
     if code in RTL_LANGS:
         return True
+    if code in _DISK_LANGS:
+        # A central language's direction is owned centrally: a module contributing
+        # extra keys for it (central wins for text) cannot flip its direction either.
+        return False
     entry = _registry.get(code)
     return bool(entry and entry.get("rtl"))

--- a/ui/i18n.py
+++ b/ui/i18n.py
@@ -35,7 +35,7 @@ def _load(lang: str) -> dict:
     file, so the central copy wins for an existing language. A language with no
     central file (a wholly module-owned language) returns the module catalog."""
     path = _LOCALES_DIR / f"{lang}.json"
-    central = json.loads(path.read_text()) if path.exists() else {}
+    central = json.loads(path.read_text(encoding="utf-8")) if path.exists() else {}
     mod = _registry.get(lang, {}).get("catalog", {})
     return {**mod, **central}
 
@@ -63,6 +63,10 @@ def register_catalog(lang: str, mapping, *, rtl: bool = False) -> None:
             "register_catalog: ignoring catalog with invalid language code %r", lang,
         )
         return
+    # Language tags are case-insensitive (BCP-47); normalize to lower case so a
+    # module registering "pt-BR" and a browser sending "pt-BR" resolve to the
+    # same key, and the code matches the lower-case central files on disk.
+    lang = lang.strip().lower()
     if not isinstance(mapping, dict):
         _log.warning(
             "register_catalog: ignoring non-dict catalog for %r (%s)",
@@ -78,11 +82,18 @@ def register_catalog(lang: str, mapping, *, rtl: bool = False) -> None:
                 "register_catalog: dropping non-str value for key %r in %r (%s)",
                 key, lang, type(value).__name__,
             )
-    entry = _registry.setdefault(lang, {"catalog": {}, "rtl": False})
-    # First-registered wins: existing keys overlay the incoming ones.
+    is_new = lang not in _registry
+    entry = _registry.setdefault(lang, {"catalog": {}, "rtl": rtl is True})
+    # First-registered wins for both keys and direction: existing keys overlay the
+    # incoming ones, and direction is fixed by the first registration (a language's
+    # reading direction is intrinsic, not something a later module may OR on).
     entry["catalog"] = {**clean, **entry["catalog"]}
-    if rtl is True:
-        entry["rtl"] = True
+    if not is_new and (rtl is True) != entry["rtl"]:
+        _log.warning(
+            "register_catalog: language %r already registered rtl=%s; ignoring "
+            "conflicting rtl=%s (first registration wins)",
+            lang, entry["rtl"], rtl is True,
+        )
     _invalidate_cache()
 
 
@@ -125,14 +136,18 @@ def get_lang(request) -> str:
     """Extract language from cookie, falling back to Accept-Language header, then 'en'."""
     if request is None:
         return "en"
-    lang = request.cookies.get("celerp_lang", "")
+    lang = request.cookies.get("celerp_lang", "").strip().lower()
     if lang and (lang in _DISK_LANGS or lang in _registry):
         return lang
     accept = request.headers.get("accept-language", "")
     for part in accept.split(","):
-        code = part.split(";")[0].strip().split("-")[0].lower()
-        if code and (code in _DISK_LANGS or code in _registry):
-            return code
+        # Try the full regional tag first (pt-br), then its base language (pt),
+        # so a module contributing a regional catalog is reachable while plain
+        # base-language negotiation still works.
+        tag = part.split(";")[0].strip().lower()
+        for code in (tag, tag.split("-")[0]):
+            if code and (code in _DISK_LANGS or code in _registry):
+                return code
     return "en"
 
 

--- a/ui/i18n.py
+++ b/ui/i18n.py
@@ -2,29 +2,95 @@
 # SPDX-License-Identifier: LicenseRef-Proprietary
 
 import json
+import logging
 import os
 from contextvars import ContextVar
 from pathlib import Path
 from functools import lru_cache
 
+_log = logging.getLogger(__name__)
+
 _LOCALES_DIR = Path(__file__).parent / "locales"
 _DEBUG = os.getenv("CELERP_DEBUG_I18N") == "1"
+
+# Language codes with a central catalog file on disk, frozen once at import
+# (no per-request glob). Module-contributed languages are held in _registry.
+_DISK_LANGS = frozenset(p.stem for p in _LOCALES_DIR.glob("*.json"))
+
+# Module-contributed catalogs, keyed by language code:
+#   {lang: {"catalog": {key: value}, "rtl": bool}}
+# Modules push into this via register_catalog(); central files still win for an
+# existing language, so a module can only ADD keys or a new language.
+_registry: dict[str, dict] = {}
 
 # Context variable holds the active language for the current request
 _current_lang: ContextVar[str] = ContextVar("celerp_lang", default="en")
 
-# RTL languages
+# RTL languages (central set; a module may additionally declare its own RTL)
 RTL_LANGS = frozenset({"ar", "he", "fa", "ur"})
 
 
 def _load(lang: str) -> dict:
+    """Merged catalog for *lang*: module contributions overlaid by the central
+    file, so the central copy wins for an existing language. A language with no
+    central file (a wholly module-owned language) returns the module catalog."""
     path = _LOCALES_DIR / f"{lang}.json"
-    if not path.exists():
-        path = _LOCALES_DIR / "en.json"
-    return json.loads(path.read_text())
+    central = json.loads(path.read_text()) if path.exists() else {}
+    mod = _registry.get(lang, {}).get("catalog", {})
+    return {**mod, **central}
 
 
 _cached_load = lru_cache(maxsize=32)(_load) if not _DEBUG else _load
+
+
+def _invalidate_cache() -> None:
+    """Drop the memoized catalogs. In CELERP_DEBUG_I18N mode _cached_load is the
+    raw function with no cache_clear, so the call is guarded."""
+    getattr(_cached_load, "cache_clear", lambda: None)()
+
+
+def register_catalog(lang: str, mapping, *, rtl: bool = False) -> None:
+    """Register a module's UI catalog for *lang*.
+
+    Validates that *mapping* is a dict of string values: a non-dict mapping is
+    logged and ignored; individual non-str values are dropped and logged, so a
+    bad value degrades honestly instead of failing later in t().format(). On a
+    module-vs-module clash for the same language and key, the FIRST registration
+    wins. The load cache is invalidated so the new catalog is visible at once.
+    """
+    if not isinstance(mapping, dict):
+        _log.warning(
+            "register_catalog: ignoring non-dict catalog for %r (%s)",
+            lang, type(mapping).__name__,
+        )
+        return
+    clean: dict[str, str] = {}
+    for key, value in mapping.items():
+        if isinstance(value, str):
+            clean[key] = value
+        else:
+            _log.warning(
+                "register_catalog: dropping non-str value for key %r in %r (%s)",
+                key, lang, type(value).__name__,
+            )
+    entry = _registry.setdefault(lang, {"catalog": {}, "rtl": False})
+    # First-registered wins: existing keys overlay the incoming ones.
+    entry["catalog"] = {**clean, **entry["catalog"]}
+    if rtl:
+        entry["rtl"] = True
+    _invalidate_cache()
+
+
+def clear_registry() -> None:
+    """Clear all module-contributed catalogs and drop the load cache. Tests only."""
+    _registry.clear()
+    _invalidate_cache()
+
+
+def available_langs() -> list[str]:
+    """Sorted language codes available in the UI: central files plus every
+    module-contributed language. The single source for language discovery."""
+    return sorted(_DISK_LANGS | _registry.keys())
 
 
 def t(key: str, lang: str | None = None, **kwargs) -> str:
@@ -57,7 +123,7 @@ def get_lang(request) -> str:
     accept = request.headers.get("accept-language", "")
     for part in accept.split(","):
         code = part.split(";")[0].strip().split("-")[0].lower()
-        if code and (_LOCALES_DIR / f"{code}.json").exists():
+        if code and (code in _DISK_LANGS or code in _registry):
             return code
     return "en"
 
@@ -73,5 +139,10 @@ def current_lang() -> str:
 
 
 def is_rtl(lang: str | None = None) -> bool:
-    """Check if the given (or current) language is RTL."""
-    return (lang or _current_lang.get()) in RTL_LANGS
+    """Check if the given (or current) language is RTL, consulting the central
+    RTL set and any module-declared RTL flag."""
+    code = lang or _current_lang.get()
+    if code in RTL_LANGS:
+        return True
+    entry = _registry.get(code)
+    return bool(entry and entry.get("rtl"))

--- a/ui/routes/settings.py
+++ b/ui/routes/settings.py
@@ -1540,48 +1540,6 @@ def setup_routes(app):
             return _R(str(e.detail), status_code=e.status)
         return _R("", status_code=204, headers={"HX-Redirect": "/settings/inventory?tab=locations"})
 
-    @app.post("/settings/company/language")
-    async def company_language_post(request: Request):
-        """HTMX: save company language setting and update celerp_lang cookie."""
-        from starlette.responses import HTMLResponse
-        token = _token(request)
-        if not token:
-            return P(t("error.unauthorized"), cls="cell-error")
-        form = await request.form()
-        new_lang = str(form.get("language", "en")).strip()
-        from pathlib import Path as _Path
-        _VALID_LANGS = {p.stem for p in (_Path(__file__).parent.parent / "locales").glob("*.json")}
-        if new_lang not in _VALID_LANGS:
-            new_lang = "en"
-        try:
-            company = await api.get_company(token)
-            settings_dict = dict(company.get("settings") or {})
-            settings_dict["language"] = new_lang
-            await api.patch_company(token, {"settings": settings_dict})
-        except APIError:
-            pass
-        _LANGUAGES = sorted(
-            [(p.stem, t(f"settings.language_{p.stem}", new_lang))
-             for p in (_Path(__file__).parent.parent / "locales").glob("*.json")],
-            key=lambda x: x[1],
-        )
-        from starlette.responses import HTMLResponse as _HR
-        import fasthtml.common as _fh
-        sel = Select(
-            *[Option(label, value=code, selected=(code == new_lang)) for code, label in _LANGUAGES],
-            name="language",
-            hx_post="/settings/company/language",
-            hx_target="this",
-            hx_swap="outerHTML",
-            hx_trigger="change",
-            cls="cell-input cell-input--select",
-        )
-        from fasthtml.common import to_xml
-        html = to_xml(sel)
-        resp = _HR(content=html)
-        resp.set_cookie("celerp_lang", new_lang, httponly=False, samesite="lax", max_age=86400 * 30)
-        return resp
-
     @app.post("/settings/bulk-attach")
     async def settings_bulk_attach(request: Request):
         token = _token(request)


### PR DESCRIPTION
A loadable module can now contribute UI translations through a new `locales` key in its manifest, mirroring how `slots` already work. A module can add a brand new language or extra keys for an existing one.

Each entry maps a language code to its catalog file and an optional right-to-left flag:

```python
PLUGIN_MANIFEST = {
    ...
    "locales": {
        "am": {"file": "locales/am.json", "rtl": False},
    },
}
```

On boot the loader reads each catalog and registers it. The language then appears in the topbar language switcher and renders its strings. Any key a language leaves out falls back to English, so a partial catalog is fine; because English is the shared fallback for every language, a module that introduces brand new interface text should also ship those strings in an English catalog. Central translations always win for an existing language, so a module can only add copy, never replace the core wording a user already sees, and a module cannot change the reading direction of a built-in language. A malformed or unreadable catalog, or a malformed locales entry, is logged and skipped, and the module still loads with its remaining languages. The registry is rebuilt from scratch on every module scan, so toggling a module off cleanly removes its language.

A module can also contribute a regional variant such as `pt-br`; a browser requesting that region is matched to it, falling back to the base language when only the base is available. Language codes are treated case-insensitively, and every catalog is read as UTF-8, so non-Latin scripts load correctly on any platform.

Language discovery is now single sourced: the switcher lists every available code from one place instead of two separate file scans. The orphaned `/settings/company/language` endpoint, which nothing linked to, has been removed.
