### PR TITLE
Duplicating an item now assigns a fresh unique barcode

### DIFF
--- a/default_modules/celerp-inventory/celerp_inventory/routes.py
+++ b/default_modules/celerp-inventory/celerp_inventory/routes.py
@@ -210,6 +210,7 @@ class ItemCreate(BaseModel):
     description: str | None = None
     unit: str | None = None
     barcode: str | None = None             # digits only if provided
+    auto_barcode: bool = False             # duplicate/clone: mint a fresh unique barcode from the shared sequence, never inherit one
     hs_code: str | None = None             # Harmonized System code for trade/customs
     tax_codes: list[str] = Field(default_factory=list)
     purchase_sku: str | None = None        # vendor's SKU / part number
@@ -1248,13 +1249,19 @@ async def post_item(payload: ItemCreate, company_id=Depends(get_current_company_
     if not payload.sku:
         payload = payload.model_copy(update={"sku": str(await _next_seq(session, company_id)).zfill(6)})
 
+    # Duplicate/clone: mint a fresh unique barcode from the shared SKU/barcode
+    # sequence and discard any inherited one. Mirrors the split child, which
+    # resets barcode for the same reason - a new entity needs a new unique
+    # barcode (barcode is globally unique, so a copy must never carry the source's).
+    if payload.auto_barcode:
+        payload = payload.model_copy(update={"barcode": str(await _next_seq(session, company_id)).zfill(6)})
     # Auto-copy SKU to barcode when barcode omitted and SKU is purely numeric.
     # SKU is now a (possibly repeated) product-type, so gate the copy on collision:
     # if another item already uses that barcode (e.g. a second item deliberately
     # sharing a numeric SKU), assign a fresh sequential barcode instead so the
     # duplicate-SKU create does not 409 on barcode. Single-SKU behaviour is
     # unchanged (the first/only item still gets barcode == sku).
-    if payload.barcode is None and payload.sku.isdigit():
+    elif payload.barcode is None and payload.sku.isdigit():
         clash = (await session.execute(
             select(Projection).where(
                 Projection.company_id == company_id,
@@ -1283,6 +1290,7 @@ async def post_item(payload: ItemCreate, company_id=Depends(get_current_company_
 
     entity_id = f"item:{uuid.uuid4()}"
     data = payload.model_dump(exclude_none=True)
+    data.pop("auto_barcode", None)  # request-only signal; never persisted onto the item
     if payload.location_id is not None:
         data["location_id"] = str(payload.location_id)
 

--- a/default_modules/first_party.lock.json
+++ b/default_modules/first_party.lock.json
@@ -7,7 +7,7 @@
   "celerp-contacts": "899cf9febb388356290f6eb8c8ab6d67f1f92a9c9fa8377ebb6d46bf04cedbc3",
   "celerp-dashboard": "1b813cb8756ac600f06f0c061b7e7c507ad8ede0e49901e98df6231fdb28ec46",
   "celerp-docs": "b968adb8c99c9ed016fb4d9ebdc09f0358953a7df4e68eac7daed14c7c01be3b",
-  "celerp-inventory": "5eba44cd752206ec19761846d38e9703cdef27dad0e2d0bf17fe030dfd91a33a",
+  "celerp-inventory": "cfb618e921b4353c0708ced8abdce444c95ef3a823edfd43444d65d72be9bcc9",
   "celerp-labels": "d3472486680ac655d28c68fbd7d4988d9bd22e175356604290bf4e9a94ddc591",
   "celerp-manufacturing": "62643ff7fe708ebe68fd0895a123af77d79c0951be82655c7f50b4d25b9c8956",
   "celerp-reports": "f100f83b3fc3e4565685d3a0c8e62dcc724bb35d32238f051b05c5f97ae10d13",

--- a/tests/test_routers/test_items.py
+++ b/tests/test_routers/test_items.py
@@ -1815,6 +1815,44 @@ async def test_new_item_non_numeric_sku_no_barcode(client):
 
 
 @pytest.mark.asyncio
+async def test_auto_barcode_mints_fresh_unique_barcode(client):
+    """A create with auto_barcode=True (the duplicate/clone path) mints a fresh
+    unique barcode from the shared sequence and never inherits the one passed in -
+    barcode is globally unique, mirroring the split child's reset."""
+    token = await _token(client)
+    h = {"Authorization": f"Bearer {token}"}
+    # Source item carrying a barcode.
+    r0 = await client.post("/items", json={"status": "available", "sku": "SRC-1", "name": "Src", "quantity": 1, "sell_by": "piece", "barcode": "700001"}, headers=h)
+    assert r0.status_code == 200, r0.text
+    src = (await client.get(f"/items/{r0.json()['id']}", headers=h)).json()
+    assert src["barcode"] == "700001"
+    # Duplicate: same barcode passed with auto_barcode=True -> fresh, distinct barcode
+    # (and no 409 on the source's barcode).
+    r1 = await client.post("/items", json={"status": "available", "sku": "SRC-1-copy", "name": "Src", "quantity": 1, "sell_by": "piece", "barcode": "700001", "auto_barcode": True}, headers=h)
+    assert r1.status_code == 200, r1.text
+    dup = (await client.get(f"/items/{r1.json()['id']}", headers=h)).json()
+    assert dup.get("barcode") is not None, "duplicate must receive a fresh barcode"
+    assert dup["barcode"] != src["barcode"], f"duplicate barcode must differ from source; both={dup['barcode']!r}"
+    assert dup["barcode"].isdigit()
+    # A second duplicate gets its own distinct barcode too.
+    r2 = await client.post("/items", json={"status": "available", "sku": "SRC-1-copy2", "name": "Src", "quantity": 1, "sell_by": "piece", "auto_barcode": True}, headers=h)
+    assert r2.status_code == 200, r2.text
+    dup2 = (await client.get(f"/items/{r2.json()['id']}", headers=h)).json()
+    assert dup2["barcode"] not in (None, src["barcode"], dup["barcode"])
+
+
+@pytest.mark.asyncio
+async def test_auto_barcode_not_persisted_as_field(client):
+    """auto_barcode is a request-only signal; it must not be stored on the item."""
+    token = await _token(client)
+    h = {"Authorization": f"Bearer {token}"}
+    r = await client.post("/items", json={"status": "available", "sku": "AB-1", "name": "AB", "quantity": 1, "sell_by": "piece", "auto_barcode": True}, headers=h)
+    assert r.status_code == 200, r.text
+    item = (await client.get(f"/items/{r.json()['id']}", headers=h)).json()
+    assert "auto_barcode" not in item, f"auto_barcode leaked onto stored item: {item!r}"
+
+
+@pytest.mark.asyncio
 async def test_split_children_get_unique_barcodes(client):
     """Each split child must receive a unique auto-assigned barcode from the shared sequence."""
     token = await _token(client)

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -4779,6 +4779,46 @@ class TestSprint5ItemActions:
         assert "id" not in captured
 
     @pytest.mark.asyncio
+    async def test_duplicate_item_drops_barcode_and_requests_fresh(self, ui_client):
+        """Single duplicate must not inherit the source barcode; it flags the create
+        path to mint a fresh unique one (barcodes are globally unique)."""
+        src = {"entity_id": "gc:123", "name": "Ruby", "sku": "GEM-001",
+               "status": "available", "barcode": "123456"}
+        captured = {}
+        async def _mock_create(token, data):
+            captured.update(data)
+            return {"id": "item:copy", "event_id": "e1"}
+        with (
+            patch("ui.api_client.get_item", new=AsyncMock(return_value=src)),
+            patch("ui.api_client.create_item", new=_mock_create),
+        ):
+            await ui_client.post("/api/items/gc:123/duplicate", data={"new_sku": "GEM-001-copy"}, cookies=_authed())
+        assert "barcode" not in captured, f"source barcode must not be copied top-level: {captured!r}"
+        assert "barcode" not in captured.get("attributes", {}), f"source barcode must not be copied via attributes: {captured!r}"
+        assert captured.get("auto_barcode") is True
+
+    @pytest.mark.asyncio
+    async def test_bulk_duplicate_drops_barcode_and_requests_fresh(self, ui_client):
+        """Bulk duplicate uses the same helper: each copy drops the source barcode
+        and requests a fresh unique one."""
+        src = {"entity_id": "gc:123", "name": "Ruby", "sku": "GEM-001",
+               "status": "available", "barcode": "123456"}
+        captured = []
+        async def _mock_create(token, data):
+            captured.append(dict(data))
+            return {"id": "item:copy", "event_id": "e1"}
+        with (
+            patch("ui.api_client.get_item", new=AsyncMock(return_value=src)),
+            patch("ui.api_client.list_items", new=AsyncMock(return_value={"items": [], "total": 0})),
+            patch("ui.api_client.create_item", new=_mock_create),
+        ):
+            await ui_client.post("/api/items/bulk/duplicate", data={"selected": "gc:123"}, cookies=_authed())
+        assert len(captured) == 1, f"expected one copy, got {captured!r}"
+        assert "barcode" not in captured[0], f"source barcode must not be copied top-level: {captured[0]!r}"
+        assert "barcode" not in captured[0].get("attributes", {}), f"source barcode must not be copied via attributes: {captured[0]!r}"
+        assert captured[0].get("auto_barcode") is True
+
+    @pytest.mark.asyncio
     async def test_duplicate_item_route_missing_sku(self, ui_client):
         """Empty new_sku → auto-generates a copy SKU and creates the item."""
         with (

--- a/ui/routes/inventory.py
+++ b/ui/routes/inventory.py
@@ -1020,12 +1020,15 @@ async def _import_export_allowed(request: Request, token: str) -> bool:
 def _duplicate_payload(source: dict, new_sku: str) -> dict:
     """Build a create payload from an existing item, carrying every field except
     id, status, location_name, created_at, updated_at (status is reset by the create
-    path). Core columns and any *_price stay top-level; everything else goes into
-    attributes. Shared by the single-item and bulk duplicate paths."""
-    _SKIP = {"id", "status", "location_name", "created_at", "updated_at"}
+    path) and barcode. Barcode is globally unique, so a copy never inherits the
+    source's: auto_barcode tells the create path to mint a fresh unique one from the
+    shared sequence (the same reset a split child gets). Core columns and any *_price
+    stay top-level; everything else goes into attributes. Shared by the single-item
+    and bulk duplicate paths."""
+    _SKIP = {"id", "status", "location_name", "created_at", "updated_at", "barcode"}
     _CORE = {"sku", "name", "quantity", "category", "location_id",
              "description", "unit", "sell_by", "tax_codes"}
-    payload: dict = {"sku": new_sku}
+    payload: dict = {"sku": new_sku, "auto_barcode": True}
     attrs: dict = {}
     for k, v in source.items():
         if k in _SKIP or k == "sku" or v is None:


### PR DESCRIPTION
Previously, using the bulk actions (or the single-item duplicate) to duplicate a product also copied its barcode. Barcodes must always be unique, so a copy that carried the source item's barcode was a problem.

Duplicating an item now leaves the source barcode behind and assigns the copy a fresh unique barcode from the shared numbering sequence, the same way a split lot receives its own barcode. This applies to both single and bulk duplication.