### PR TITLE
Scope inventory search to user-facing fields and make the low-disk warning actionable

### DIFF
--- a/celerp/services/system_health.py
+++ b/celerp/services/system_health.py
@@ -25,12 +25,21 @@ _MESSAGES = {
         " unresponsive. Upgrade your RAM or close other applications."
     ),
     "cpu_warning": "Your computer's processor is under heavy load. Response times may be slow.",
-    "disk_warning": "Your disk is getting full. Free up space to keep Celerp running smoothly.",
-    "disk_critical": (
-        "Your disk is almost full. Celerp may stop working if disk space runs out."
-        " Free up space immediately."
-    ),
 }
+
+
+def _disk_message(suffix: str, used_percent: float, free_gb: float, total_gb: float) -> str:
+    """A disk warning that names the numbers the user needs to act: how much is free
+    now, the total, and how much to free to clear the warning. The clear target is the
+    warning threshold (used <= _DISK_WARN), so the same actionable figure is shown for
+    both warning and critical - it is what makes the message disappear."""
+    to_free = round(max(0.0, (used_percent - _DISK_WARN) / 100.0 * total_gb), 1)
+    where = f"{free_gb:.1f} GB free of {total_gb:.1f} GB"
+    if suffix == "critical":
+        return (f"Your disk is almost full: {where}. Free up about {to_free:.1f} GB to"
+                " clear this warning, or Celerp may stop working if space runs out.")
+    return (f"Your disk is getting full: {where}. Free up about {to_free:.1f} GB more"
+            " to clear this warning.")
 
 
 def _threshold(value: float, warn: float, crit: float | None) -> tuple[str, str | None]:
@@ -54,6 +63,8 @@ def get_system_health() -> dict:
     ram_status, ram_suffix = _threshold(mem.percent, _RAM_WARN, _RAM_CRIT)
     cpu_status, cpu_suffix = _threshold(cpu_pct, _CPU_WARN, None)
     disk_status, disk_suffix = _threshold(disk.percent, _DISK_WARN, _DISK_CRIT)
+    disk_free_gb = round(disk.free / _GB, 2)
+    disk_total_gb = round(disk.total / _GB, 2)
 
     return {
         "ram": {
@@ -70,10 +81,10 @@ def get_system_health() -> dict:
         },
         "disk": {
             "used_percent": disk.percent,
-            "free_gb": round(disk.free / _GB, 2),
-            "total_gb": round(disk.total / _GB, 2),
+            "free_gb": disk_free_gb,
+            "total_gb": disk_total_gb,
             "status": disk_status,
-            "message": _MESSAGES.get(f"disk_{disk_suffix}") if disk_suffix else None,
+            "message": _disk_message(disk_suffix, disk.percent, disk_free_gb, disk_total_gb) if disk_suffix else None,
         },
         "overall": _worst(ram_status, cpu_status, disk_status),
     }

--- a/default_modules/celerp-inventory/celerp_inventory/routes.py
+++ b/default_modules/celerp-inventory/celerp_inventory/routes.py
@@ -472,13 +472,19 @@ async def assert_not_draft(session: AsyncSession, company_id, entity_id: str, ac
 # The inventory (and global) search bar accepts: `,` = OR groups, `&` = AND terms,
 # `lo-hi` = numeric range over quantity/weight/pieces, a bare number = numeric-exact
 # OR text substring, anything else = text substring over the fields below.
-# The closed allowlist of user-facing core fields the free-text search covers. Any
-# core field NOT listed here (idempotency_key, id/lineage refs, unit-of-measure codes,
-# internal classifications) is deliberately excluded - user search reflects the item's
-# user-facing data, not internal bookkeeping (#306).
+# The closed allowlist of user-facing text fields the free-text search covers. It is
+# every core field a user reads on an item: identity, descriptions, unit-of-measure
+# codes, inventory type, and the status doc number rows are traced by. "Core" here is
+# the projection's write-side storage class, NOT a synonym for "internal", so the list
+# is chosen by what the user actually sees, not by that classification. Core fields
+# left off are genuine bookkeeping (idempotency_key, id/lineage refs like parent_id and
+# status_doc_id, internal classifications) and are deliberately unsearchable (#306);
+# numeric columns match only through the explicit numeric path.
 _SEARCH_FIELDS = ("name", "sku", "barcode", "description", "category",
                   "short_description", "notes", "hs_code", "batch_no",
-                  "purchase_name", "purchase_sku", "location_name")
+                  "purchase_name", "purchase_sku", "location_name",
+                  "sell_by", "unit", "weight_unit", "gross_weight_unit",
+                  "purchase_unit", "inventory_type", "status_doc_number", "lot")
 _NUMERIC_FIELDS = ("quantity", "weight", "pieces")
 # A range is PURE number-dash-number only, so a hyphenated SKU (SHOT274-005) stays literal.
 _RANGE_RE = re.compile(r"^(\d+(?:\.\d+)?)-(\d+(?:\.\d+)?)$")
@@ -505,10 +511,12 @@ def _text_match(record: dict, term: str) -> str | None:
     for field in _SEARCH_FIELDS:
         if term in str(record.get(field, "")).lower():
             return field
-    # Beyond the named core fields, only DYNAMIC attribute values are searchable. Core
-    # keys are a closed set (projections._is_core_key), so skipping them keeps internal
-    # bookkeeping (idempotency_key, id/lineage refs, unit codes) out of search (#306);
-    # numeric columns are matched only by the explicit numeric path, never by substring.
+    # Named fields aside, the only other searchable values are DYNAMIC category
+    # attributes, which flatten to the top level. Skipping every core key
+    # (projections._is_core_key marks the closed core set) is what keeps internal
+    # bookkeeping (idempotency_key, id/lineage refs) out of search (#306) while still
+    # matching user-defined attribute values; numeric columns match only via the
+    # explicit numeric path, never by substring.
     for k, v in record.items():
         if _is_core_key(k) or k in _NUMERIC_FIELDS:
             continue

--- a/default_modules/celerp-inventory/celerp_inventory/routes.py
+++ b/default_modules/celerp-inventory/celerp_inventory/routes.py
@@ -49,7 +49,7 @@ from celerp.services.pricing import (
 )
 from celerp.services.units import validate_quantity, build_unit_map, get_company_units, is_weight_unit, is_pieces_unit, LANDED_COST_KINDS
 from celerp.services.line_measures import splitting_allowed
-from celerp_inventory.projections import is_item_available
+from celerp_inventory.projections import _is_core_key, is_item_available
 
 router = APIRouter(dependencies=[Depends(get_current_user)])
 
@@ -472,12 +472,14 @@ async def assert_not_draft(session: AsyncSession, company_id, entity_id: str, ac
 # The inventory (and global) search bar accepts: `,` = OR groups, `&` = AND terms,
 # `lo-hi` = numeric range over quantity/weight/pieces, a bare number = numeric-exact
 # OR text substring, anything else = text substring over the fields below.
-_SEARCH_FIELDS = ("name", "sku", "barcode", "description", "category")
+# The closed allowlist of user-facing core fields the free-text search covers. Any
+# core field NOT listed here (idempotency_key, id/lineage refs, unit-of-measure codes,
+# internal classifications) is deliberately excluded - user search reflects the item's
+# user-facing data, not internal bookkeeping (#306).
+_SEARCH_FIELDS = ("name", "sku", "barcode", "description", "category",
+                  "short_description", "notes", "hs_code", "batch_no",
+                  "purchase_name", "purchase_sku", "location_name")
 _NUMERIC_FIELDS = ("quantity", "weight", "pieces")
-# Keys excluded from the free-text substring loop (numeric columns are matched only
-# by the explicit numeric path, never by substring, so "5" never matches "50").
-_SKIP_KEYS = frozenset({"id", "entity_id", "company_id", "location_id", "quantity",
-                        "weight", "pieces", "status", "created_at", "updated_at"})
 # A range is PURE number-dash-number only, so a hyphenated SKU (SHOT274-005) stays literal.
 _RANGE_RE = re.compile(r"^(\d+(?:\.\d+)?)-(\d+(?:\.\d+)?)$")
 
@@ -503,8 +505,12 @@ def _text_match(record: dict, term: str) -> str | None:
     for field in _SEARCH_FIELDS:
         if term in str(record.get(field, "")).lower():
             return field
+    # Beyond the named core fields, only DYNAMIC attribute values are searchable. Core
+    # keys are a closed set (projections._is_core_key), so skipping them keeps internal
+    # bookkeeping (idempotency_key, id/lineage refs, unit codes) out of search (#306);
+    # numeric columns are matched only by the explicit numeric path, never by substring.
     for k, v in record.items():
-        if k in _SKIP_KEYS or k in _SEARCH_FIELDS or k.endswith("_price"):
+        if _is_core_key(k) or k in _NUMERIC_FIELDS:
             continue
         if isinstance(v, str) and term in v.lower():
             return k

--- a/default_modules/first_party.lock.json
+++ b/default_modules/first_party.lock.json
@@ -7,7 +7,7 @@
   "celerp-contacts": "899cf9febb388356290f6eb8c8ab6d67f1f92a9c9fa8377ebb6d46bf04cedbc3",
   "celerp-dashboard": "1b813cb8756ac600f06f0c061b7e7c507ad8ede0e49901e98df6231fdb28ec46",
   "celerp-docs": "11f60e0205d61c8036a9711337166a7e9816958d00407954a6f79f85f319102e",
-  "celerp-inventory": "3037dfeafdc908ef1f37314cd9ebf0a2fac69503d537ebb54deaea9a88ce524c",
+  "celerp-inventory": "a2bec072fcac9fb499fd8ce2cbe963c76f06457b7a9068634a1dbd9335206b44",
   "celerp-labels": "d3472486680ac655d28c68fbd7d4988d9bd22e175356604290bf4e9a94ddc591",
   "celerp-manufacturing": "f1d90823286b6815e2c4ca88d4e86e9de7feb568c6540c84d1d342bc051283ee",
   "celerp-reports": "f100f83b3fc3e4565685d3a0c8e62dcc724bb35d32238f051b05c5f97ae10d13",

--- a/default_modules/first_party.lock.json
+++ b/default_modules/first_party.lock.json
@@ -7,7 +7,7 @@
   "celerp-contacts": "899cf9febb388356290f6eb8c8ab6d67f1f92a9c9fa8377ebb6d46bf04cedbc3",
   "celerp-dashboard": "1b813cb8756ac600f06f0c061b7e7c507ad8ede0e49901e98df6231fdb28ec46",
   "celerp-docs": "11f60e0205d61c8036a9711337166a7e9816958d00407954a6f79f85f319102e",
-  "celerp-inventory": "ac4e239d52d46016baf2548b616087dbe10ab295f39103f1fbec16fdf17f15f9",
+  "celerp-inventory": "3037dfeafdc908ef1f37314cd9ebf0a2fac69503d537ebb54deaea9a88ce524c",
   "celerp-labels": "d3472486680ac655d28c68fbd7d4988d9bd22e175356604290bf4e9a94ddc591",
   "celerp-manufacturing": "f1d90823286b6815e2c4ca88d4e86e9de7feb568c6540c84d1d342bc051283ee",
   "celerp-reports": "f100f83b3fc3e4565685d3a0c8e62dcc724bb35d32238f051b05c5f97ae10d13",

--- a/tests/test_inventory_search_grammar.py
+++ b/tests/test_inventory_search_grammar.py
@@ -82,3 +82,26 @@ def test_inventory_search_match_reasons():
     # item_matches_query stays the boolean view of the same grammar.
     assert item_matches_query(item, "255")
     assert not item_matches_query(item, "nope")
+
+
+def test_inventory_search_excludes_internal_fields():
+    """Issue #306: user-facing search must not reach internal bookkeeping fields.
+    A term that appears only inside the item's idempotency key (or id/lineage refs)
+    is not a hit; current user-facing fields and dynamic attributes still match."""
+    # The idempotency key preserves the ORIGINAL import barcode (csv:item:bc:100) even
+    # after the barcode is edited to 200. Searching the obsolete 100 must not find it.
+    item = _item(name="Widget", sku="WDGT", barcode="200",
+                 idempotency_key="csv:item:bc:100")
+    assert query_match_reasons(item, "100") is None
+    assert not item_matches_query(item, "100")
+    assert item_matches_query(item, "200")  # the current barcode still matches
+    # Other internal identifiers are excluded by the same core-key scoping.
+    leaky = _item(name="Bolt", sku="BLT", parent_id="itm_abc123",
+                  status_doc_id="doc_xyz", inventory_type="consignment")
+    assert query_match_reasons(leaky, "abc123") is None
+    assert query_match_reasons(leaky, "doc_xyz") is None
+    assert query_match_reasons(leaky, "consignment") is None
+    # A genuine attribute value is not a core key, so it stays searchable.
+    assert query_match_reasons(_item(color="ruby red"), "ruby") == [("color", "ruby")]
+    # Legitimate user-facing core text stays searchable.
+    assert query_match_reasons(_item(notes="handle with care"), "care") == [("notes", "care")]

--- a/tests/test_inventory_search_grammar.py
+++ b/tests/test_inventory_search_grammar.py
@@ -124,7 +124,7 @@ def test_inventory_search_preserves_user_facing_fields():
         ("weight_unit", "gram", "gram"),
         ("gross_weight_unit", "ounce", "ounce"),
         ("purchase_unit", "dozen", "dozen"),
-        ("inventory_type", "consignment", "consignment"),
+        ("inventory_type", "service", "service"),
         ("status_doc_number", "SO-1042", "so-1042"),
         ("lot", "LOT-77A", "lot-77a"),
     ]

--- a/tests/test_inventory_search_grammar.py
+++ b/tests/test_inventory_search_grammar.py
@@ -84,10 +84,9 @@ def test_inventory_search_match_reasons():
     assert not item_matches_query(item, "nope")
 
 
-def test_inventory_search_excludes_internal_fields():
-    """Issue #306: user-facing search must not reach internal bookkeeping fields.
-    A term that appears only inside the item's idempotency key (or id/lineage refs)
-    is not a hit; current user-facing fields and dynamic attributes still match."""
+def test_inventory_search_excludes_internal_bookkeeping():
+    """Issue #306: search must not reach internal bookkeeping. A term that appears
+    only inside the idempotency key, an id, or a lineage reference is not a hit."""
     # The idempotency key preserves the ORIGINAL import barcode (csv:item:bc:100) even
     # after the barcode is edited to 200. Searching the obsolete 100 must not find it.
     item = _item(name="Widget", sku="WDGT", barcode="200",
@@ -95,13 +94,42 @@ def test_inventory_search_excludes_internal_fields():
     assert query_match_reasons(item, "100") is None
     assert not item_matches_query(item, "100")
     assert item_matches_query(item, "200")  # the current barcode still matches
-    # Other internal identifiers are excluded by the same core-key scoping.
+    # ids and lineage references (the internal *_id / relationship fields) are excluded.
     leaky = _item(name="Bolt", sku="BLT", parent_id="itm_abc123",
-                  status_doc_id="doc_xyz", inventory_type="consignment")
+                  status_doc_id="doc_xyz", merged_into="itm_gone")
     assert query_match_reasons(leaky, "abc123") is None
     assert query_match_reasons(leaky, "doc_xyz") is None
-    assert query_match_reasons(leaky, "consignment") is None
-    # A genuine attribute value is not a core key, so it stays searchable.
+    assert query_match_reasons(leaky, "itm_gone") is None
+
+
+def test_inventory_search_preserves_user_facing_fields():
+    """The user-facing text fields a person reads on an item stay searchable - the #306
+    fix must not narrow this. status_doc_number in particular is what sold and consigned
+    items are traced by (test_fulfillment / test_doc_workflows assert this end to end)."""
+    cases = [
+        ("name", "Special Widget", "special"),
+        ("sku", "WDGT-9", "wdgt-9"),
+        ("barcode", "5901234", "5901234"),
+        ("description", "brushed nickel", "nickel"),
+        ("short_description", "left-hand thread", "thread"),
+        ("category", "Fasteners", "fasteners"),
+        ("notes", "handle with care", "care"),
+        ("hs_code", "7318.15", "7318"),
+        ("batch_no", "B-2026-07", "2026-07"),
+        ("purchase_name", "Hex Bolt M8", "hex bolt"),
+        ("purchase_sku", "SUP-HB-M8", "sup-hb"),
+        ("location_name", "Aisle 4 Bay 2", "aisle 4"),
+        ("sell_by", "carat", "carat"),
+        ("unit", "kilogram", "kilogram"),
+        ("weight_unit", "gram", "gram"),
+        ("gross_weight_unit", "ounce", "ounce"),
+        ("purchase_unit", "dozen", "dozen"),
+        ("inventory_type", "consignment", "consignment"),
+        ("status_doc_number", "SO-1042", "so-1042"),
+        ("lot", "LOT-77A", "lot-77a"),
+    ]
+    for field, value, term in cases:
+        assert query_match_reasons(_item(**{field: value}), term) == [(field, term)], field
+        assert item_matches_query(_item(**{field: value}), term), field
+    # A dynamic category attribute is not a core key, so it stays searchable too.
     assert query_match_reasons(_item(color="ruby red"), "ruby") == [("color", "ruby")]
-    # Legitimate user-facing core text stays searchable.
-    assert query_match_reasons(_item(notes="handle with care"), "care") == [("notes", "care")]

--- a/tests/test_system_health.py
+++ b/tests/test_system_health.py
@@ -76,15 +76,26 @@ def test_cpu_warning():
 
 def test_disk_warning():
     result = _call(*_OK_MEM, _OK_CPU, 85.0, 15.0, 100.0)
+    msg = result["disk"]["message"]
     assert result["disk"]["status"] == "warning"
-    assert "full" in result["disk"]["message"].lower()
+    assert "full" in msg.lower()
+    # The message names the current free space, the total, and how much to free to
+    # clear the warning (used 85% -> free 5.0 GB to reach the 80% threshold on 100 GB).
+    assert "15.0 GB free of 100.0 GB" in msg
+    assert "5.0 GB" in msg
+    assert "clear this warning" in msg
 
 
 def test_disk_critical():
     result = _call(*_OK_MEM, _OK_CPU, 93.0, 7.0, 100.0)
+    msg = result["disk"]["message"]
     assert result["disk"]["status"] == "critical"
-    assert "almost full" in result["disk"]["message"].lower()
+    assert "almost full" in msg.lower()
     assert result["overall"] == "critical"
+    # Critical also names the numbers and the clear-warning target (used 93% -> 13.0 GB).
+    assert "7.0 GB free of 100.0 GB" in msg
+    assert "13.0 GB" in msg
+    assert "clear this warning" in msg
 
 
 def test_overall_worst_wins():


### PR DESCRIPTION
Two small fixes.

## Inventory search stays on user-facing fields (#306)

Free-text inventory search now covers the fields a user can actually see (name,
SKU, barcode, description, category, notes, and the other visible text columns)
plus any category attribute values. It no longer reaches internal bookkeeping such
as the idempotency key or id and lineage references.

Before this, a search could match a value that only survived inside an item's
import key. For example, if an item was imported with barcode 100 and the barcode
was later edited to 200, searching 100 still returned that item because the
original code lived on in the idempotency key. Search now reflects the item's
current, user-facing data.

## The low-disk warning tells you what to do about it

The storage warning now names the current free space, the total, and roughly how
much more space to free to bring usage back under the threshold. Previously it only
said the disk was full, with no indication of how much needed to be cleared for the
message to go away.