### PR TITLE
Store the relay-pushed commercial context for later app screens

### DIFF
--- a/celerp/gateway/client.py
+++ b/celerp/gateway/client.py
@@ -360,6 +360,14 @@ class GatewayClient:
                 from celerp.gateway.state import set_feature_flags
                 set_feature_flags(feature_flags)
                 await self._persist_feature_flags(feature_flags)
+            # commercial_context rides hello_ack when present; its absence must
+            # leave any cached partner_managed identity intact, so the read is
+            # presence-guarded rather than defaulted.
+            if "commercial_context" in payload:
+                from celerp.gateway.state import set_commercial_context
+                ctx = payload["commercial_context"]
+                if set_commercial_context(ctx):
+                    await self._persist_commercial_context(ctx)
             # tier/status ride hello_ack too (not just subscription_updated): a
             # plain free connection never triggers a Stripe billing event, so
             # that push alone would never tell a free instance its own tier.
@@ -425,6 +433,13 @@ class GatewayClient:
         elif msg_type == "invoice.payment":
             self._spawn(self._handle_invoice_payment(payload))
 
+        elif msg_type == "commercial_updated":
+            # The payload is the context itself (flat, like subscription_updated);
+            # the same acceptance gate and persist path as the hello_ack branch.
+            from celerp.gateway.state import set_commercial_context
+            if set_commercial_context(payload):
+                await self._persist_commercial_context(payload)
+
         else:
             log.debug("Unhandled gateway message type: %s", msg_type)
 
@@ -451,6 +466,38 @@ class GatewayClient:
             log.debug("Gateway: feature_flags persisted to config.")
         except Exception as exc:
             log.warning("Gateway: failed to persist feature_flags: %s", exc)
+
+    async def _persist_commercial_context(self, ctx: dict) -> None:
+        """Write commercial_context into Electron's celerp-config.json.
+
+        Best-effort: only works inside Electron where CELERP_DATA_DIR is set; a
+        no-op in dev/server mode. Read-merges the single key so the existing
+        feature_flags entry is preserved, and writes atomically (a temp file on
+        the same directory then os.replace) so a crash mid-write never leaves a
+        torn config for the next startup read.
+        """
+        data_dir = os.environ.get("CELERP_DATA_DIR", "")
+        if not data_dir:
+            return
+        config_path = os.path.join(data_dir, "celerp-config.json")
+        tmp_path = f"{config_path}.{uuid.uuid4().hex}.tmp"
+        try:
+            existing: dict = {}
+            if os.path.exists(config_path):
+                with open(config_path) as f:
+                    existing = json.load(f)
+            existing["commercial_context"] = ctx
+            with open(tmp_path, "w") as f:
+                json.dump(existing, f, indent=2)
+            os.replace(tmp_path, config_path)
+            log.debug("Gateway: commercial_context persisted to config.")
+        except Exception as exc:
+            log.warning("Gateway: failed to persist commercial_context: %s", exc)
+            try:
+                if os.path.exists(tmp_path):
+                    os.remove(tmp_path)
+            except OSError:
+                pass
 
     async def _handle_shopify_webhook(self, payload: dict) -> None:
         """A Shopify webhook the relay forwarded. Trigger a targeted incremental

--- a/celerp/gateway/client.py
+++ b/celerp/gateway/client.py
@@ -49,6 +49,46 @@ def _shop_key(handle: str | None) -> str:
     return s.rstrip("/").removesuffix(".myshopify.com")
 
 
+def _merge_config_key(key: str, value) -> None:
+    """Merge a single top-level key into Electron's celerp-config.json, writing
+    atomically and forcing mode 0600 so the co-resident secrets (external_db_url,
+    S3 keys) are never broadened.
+
+    Best-effort: a no-op in dev/server mode where CELERP_DATA_DIR is unset. A
+    missing or non-dict existing config degrades to an empty object before the
+    merge. The write goes to a unique temp created 0600, then os.replace swaps it
+    in: os.replace adopts the temp inode, so the target's mode becomes 0600
+    regardless of the prior mode or the process umask (0600 has no group/other
+    bits for umask to strip). Any failure logs the key and exception (never the
+    contents), removes the temp, and leaves the prior config intact.
+    """
+    data_dir = os.environ.get("CELERP_DATA_DIR", "")
+    if not data_dir:
+        return
+    config_path = os.path.join(data_dir, "celerp-config.json")
+    tmp_path = f"{config_path}.{uuid.uuid4().hex}.tmp"
+    try:
+        existing: dict = {}
+        if os.path.exists(config_path):
+            with open(config_path) as f:
+                loaded = json.load(f)
+            if isinstance(loaded, dict):
+                existing = loaded
+        existing[key] = value
+        fd = os.open(tmp_path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+        with os.fdopen(fd, "w") as f:
+            json.dump(existing, f, indent=2)
+        os.replace(tmp_path, config_path)
+        log.debug("Gateway: %s persisted to config.", key)
+    except Exception as exc:
+        log.warning("Gateway: failed to persist %s: %s", key, exc)
+        try:
+            if os.path.exists(tmp_path):
+                os.remove(tmp_path)
+        except OSError:
+            pass
+
+
 class GatewayClient:
     """Persistent outbound WS connection to the Celerp gateway.
 
@@ -446,58 +486,21 @@ class GatewayClient:
     async def _persist_feature_flags(self, feature_flags: dict) -> None:
         """Write feature_flags into Electron's celerp-config.json.
 
-        This is a best-effort operation — it only works when running inside Electron
-        where DATA_DIR is set. In dev/server mode this is a no-op.
+        Best-effort: only works inside Electron where CELERP_DATA_DIR is set; a
+        no-op in dev/server mode. Delegates to the shared atomic, 0600-forcing
+        writer so the co-resident secrets are never broadened.
         """
-        import os
-        import json
-        data_dir = os.environ.get("CELERP_DATA_DIR", "")
-        if not data_dir:
-            return
-        config_path = os.path.join(data_dir, "celerp-config.json")
-        try:
-            existing: dict = {}
-            if os.path.exists(config_path):
-                with open(config_path) as f:
-                    existing = json.load(f)
-            existing["feature_flags"] = feature_flags
-            with open(config_path, "w") as f:
-                json.dump(existing, f, indent=2)
-            log.debug("Gateway: feature_flags persisted to config.")
-        except Exception as exc:
-            log.warning("Gateway: failed to persist feature_flags: %s", exc)
+        _merge_config_key("feature_flags", feature_flags)
 
     async def _persist_commercial_context(self, ctx: dict) -> None:
         """Write commercial_context into Electron's celerp-config.json.
 
         Best-effort: only works inside Electron where CELERP_DATA_DIR is set; a
-        no-op in dev/server mode. Read-merges the single key so the existing
-        feature_flags entry is preserved, and writes atomically (a temp file on
-        the same directory then os.replace) so a crash mid-write never leaves a
-        torn config for the next startup read.
+        no-op in dev/server mode. Delegates to the shared atomic, 0600-forcing
+        writer so the existing feature_flags entry is preserved and a crash
+        mid-write never leaves a torn config for the next startup read.
         """
-        data_dir = os.environ.get("CELERP_DATA_DIR", "")
-        if not data_dir:
-            return
-        config_path = os.path.join(data_dir, "celerp-config.json")
-        tmp_path = f"{config_path}.{uuid.uuid4().hex}.tmp"
-        try:
-            existing: dict = {}
-            if os.path.exists(config_path):
-                with open(config_path) as f:
-                    existing = json.load(f)
-            existing["commercial_context"] = ctx
-            with open(tmp_path, "w") as f:
-                json.dump(existing, f, indent=2)
-            os.replace(tmp_path, config_path)
-            log.debug("Gateway: commercial_context persisted to config.")
-        except Exception as exc:
-            log.warning("Gateway: failed to persist commercial_context: %s", exc)
-            try:
-                if os.path.exists(tmp_path):
-                    os.remove(tmp_path)
-            except OSError:
-                pass
+        _merge_config_key("commercial_context", ctx)
 
     async def _handle_shopify_webhook(self, payload: dict) -> None:
         """A Shopify webhook the relay forwarded. Trigger a targeted incremental

--- a/celerp/gateway/state.py
+++ b/celerp/gateway/state.py
@@ -8,11 +8,22 @@ and is required for cloud-gated endpoints (/ai/*, /backup/*, /connectors/*).
 """
 from __future__ import annotations
 
+import logging
+
+log = logging.getLogger(__name__)
+
 _session_token: str = ""
 _subscription_tier: str = ""
 _subscription_status: str = ""
 _feature_flags: dict = {}
+_commercial_context: dict = {}
 _instance_id: str = ""
+
+# The client understands commercial-context envelopes up to this schema_version.
+# A higher one is rejected (last-known-good preserved) rather than partial-parsed,
+# so partner identity is never misrepresented from an unknown shape.
+_SUPPORTED_SCHEMA_VERSION = 1
+_VALID_COMMERCIAL_MODES = ("celerp_direct", "partner_managed")
 
 
 def get_instance_id() -> str:
@@ -58,6 +69,110 @@ def set_feature_flags(flags: dict) -> None:
 def get_feature_flags() -> dict:
     """Return a copy of the current feature flags."""
     return dict(_feature_flags)
+
+
+def _valid_int(value) -> bool:
+    """A real JSON integer, not a bool (True/False are int subclasses and must
+    never pass as a version or schema_version)."""
+    return isinstance(value, int) and not isinstance(value, bool)
+
+
+def set_commercial_context(new: dict) -> bool:
+    """Validate a relay-pushed commercial context and, if it is a strictly-newer
+    well-formed update, replace the held model. Returns whether it was accepted.
+
+    This is the single acceptance gate: both inbound branches (hello_ack and
+    commercial_updated) route through it. On any rejection the last-known-good
+    model is preserved unchanged and a single reason line is logged; the context
+    is never partial-applied. Called by GatewayClient.
+    """
+    global _commercial_context
+    if not isinstance(new, dict):
+        log.warning("Commercial context rejected: payload is not an object.")
+        return False
+    version = new.get("version")
+    if not _valid_int(version):
+        log.warning("Commercial context rejected: version missing or not an integer.")
+        return False
+    current = _commercial_context.get("version")
+    if _valid_int(current) and version <= current:
+        log.warning(
+            "Commercial context rejected: version %s is not newer than held %s.",
+            version, current)
+        return False
+    schema_version = new.get("schema_version")
+    if not _valid_int(schema_version):
+        log.warning("Commercial context rejected: schema_version missing or not an integer.")
+        return False
+    if schema_version > _SUPPORTED_SCHEMA_VERSION:
+        log.warning(
+            "Commercial context schema_version %s exceeds the supported maximum %s; "
+            "this client needs updating. Preserving last-known-good.",
+            schema_version, _SUPPORTED_SCHEMA_VERSION)
+        return False
+    if new.get("commercial_mode") not in _VALID_COMMERCIAL_MODES:
+        log.warning("Commercial context rejected: unrecognised commercial_mode.")
+        return False
+    for key in ("implementation", "offer"):
+        value = new.get(key)
+        if value is not None and not isinstance(value, dict):
+            log.warning("Commercial context rejected: %s is neither null nor an object.", key)
+            return False
+    _commercial_context = dict(new)
+    return True
+
+
+def get_commercial_context() -> dict:
+    """Return a copy of the current commercial-context model (empty when none
+    has been accepted)."""
+    return dict(_commercial_context)
+
+
+def get_commercial_mode() -> str:
+    """Return the current commercial mode, defaulting to the neutral
+    'celerp_direct' when no context has been accepted."""
+    return _commercial_context.get("commercial_mode", "celerp_direct")
+
+
+def get_partner_identity() -> dict | None:
+    """Return a copy of the partner implementation object, or None when the
+    install is not partner-managed."""
+    implementation = _commercial_context.get("implementation")
+    return dict(implementation) if isinstance(implementation, dict) else None
+
+
+def get_offer() -> dict | None:
+    """Return a copy of the partner offer object, or None when none is set."""
+    offer = _commercial_context.get("offer")
+    return dict(offer) if isinstance(offer, dict) else None
+
+
+def load_commercial_context() -> None:
+    """Load the last-known-good commercial context from the local cache at
+    startup, ungated by the relay connection so an offline restart still
+    presents the cached partner_managed identity instead of the neutral default.
+
+    Reads the 'commercial_context' key from <CELERP_DATA_DIR>/celerp-config.json.
+    A missing data dir, missing file, missing key, or corrupt JSON leaves the
+    neutral empty model in place; it never fabricates a partner.
+    """
+    import os
+    import json
+    global _commercial_context
+    data_dir = os.environ.get("CELERP_DATA_DIR", "")
+    if not data_dir:
+        return
+    config_path = os.path.join(data_dir, "celerp-config.json")
+    if not os.path.exists(config_path):
+        return
+    try:
+        with open(config_path) as f:
+            existing = json.load(f)
+        cached = existing.get("commercial_context")
+        if isinstance(cached, dict):
+            _commercial_context = dict(cached)
+    except Exception as exc:
+        log.debug("Gateway: commercial-context cache unreadable; using neutral default: %s", exc)
 
 
 # ── Relay connection helpers (single source of truth) ────────────────────────

--- a/celerp/gateway/state.py
+++ b/celerp/gateway/state.py
@@ -8,6 +8,7 @@ and is required for cloud-gated endpoints (/ai/*, /backup/*, /connectors/*).
 """
 from __future__ import annotations
 
+import copy
 import logging
 
 log = logging.getLogger(__name__)
@@ -110,6 +111,12 @@ def set_commercial_context(new: dict) -> bool:
             "this client needs updating. Preserving last-known-good.",
             schema_version, _SUPPORTED_SCHEMA_VERSION)
         return False
+    if schema_version < _SUPPORTED_SCHEMA_VERSION:
+        log.warning(
+            "Commercial context rejected: invalid schema_version %s (below the "
+            "supported %s).",
+            schema_version, _SUPPORTED_SCHEMA_VERSION)
+        return False
     if new.get("commercial_mode") not in _VALID_COMMERCIAL_MODES:
         log.warning("Commercial context rejected: unrecognised commercial_mode.")
         return False
@@ -118,14 +125,14 @@ def set_commercial_context(new: dict) -> bool:
         if value is not None and not isinstance(value, dict):
             log.warning("Commercial context rejected: %s is neither null nor an object.", key)
             return False
-    _commercial_context = dict(new)
+    _commercial_context = copy.deepcopy(new)
     return True
 
 
 def get_commercial_context() -> dict:
     """Return a copy of the current commercial-context model (empty when none
     has been accepted)."""
-    return dict(_commercial_context)
+    return copy.deepcopy(_commercial_context)
 
 
 def get_commercial_mode() -> str:
@@ -138,13 +145,13 @@ def get_partner_identity() -> dict | None:
     """Return a copy of the partner implementation object, or None when the
     install is not partner-managed."""
     implementation = _commercial_context.get("implementation")
-    return dict(implementation) if isinstance(implementation, dict) else None
+    return copy.deepcopy(implementation) if isinstance(implementation, dict) else None
 
 
 def get_offer() -> dict | None:
     """Return a copy of the partner offer object, or None when none is set."""
     offer = _commercial_context.get("offer")
-    return dict(offer) if isinstance(offer, dict) else None
+    return copy.deepcopy(offer) if isinstance(offer, dict) else None
 
 
 def load_commercial_context() -> None:
@@ -158,7 +165,6 @@ def load_commercial_context() -> None:
     """
     import os
     import json
-    global _commercial_context
     data_dir = os.environ.get("CELERP_DATA_DIR", "")
     if not data_dir:
         return
@@ -170,7 +176,7 @@ def load_commercial_context() -> None:
             existing = json.load(f)
         cached = existing.get("commercial_context")
         if isinstance(cached, dict):
-            _commercial_context = dict(cached)
+            set_commercial_context(cached)
     except Exception as exc:
         log.debug("Gateway: commercial-context cache unreadable; using neutral default: %s", exc)
 

--- a/celerp/main.py
+++ b/celerp/main.py
@@ -15,8 +15,10 @@ from slowapi.util import get_remote_address
 from celerp.db import engine, mask_db_credentials
 from celerp.inventory_codes import BarcodeConflictError
 from celerp.config import settings, assert_secure_jwt, ensure_instance_id, load_cloud_config, load_backup_config
+from celerp.gateway.state import load_commercial_context
 load_cloud_config()
 load_backup_config()
+load_commercial_context()
 assert_secure_jwt()
 ensure_instance_id()
 from celerp.middleware import DrainMiddleware, MaxBodySizeMiddleware, SecurityHeadersMiddleware, SlidingTokenRefreshMiddleware, log_unhandled_exception

--- a/celerp/routers/companies.py
+++ b/celerp/routers/companies.py
@@ -275,6 +275,31 @@ async def me(company_id=Depends(get_current_company_id), session: AsyncSession =
     return {"id": str(company.id), "name": company.name, "slug": company.slug, "settings": company.settings}
 
 
+@router.get("/commercial-state")
+async def commercial_state(_: None = require_permission("manage_integrations")) -> dict:
+    """Return the live commercial state the API process holds from the relay WS
+    push, for the separate UI process to read over an authenticated seam.
+
+    The UI runs in its own process and cannot see these in-process globals, so it
+    reads them here. Gated at the same permission as the settings pages that
+    consume it, so tab visibility stays consistent with page access. Only
+    non-secret entitlement fields are returned; the co-resident config secrets
+    are never read by this path.
+    """
+    from celerp.gateway.state import (
+        get_commercial_context,
+        get_commercial_mode,
+        get_feature_flags,
+        get_partner_identity,
+    )
+    return {
+        "feature_flags": get_feature_flags(),
+        "commercial_context": get_commercial_context(),
+        "partner_identity": get_partner_identity(),
+        "commercial_mode": get_commercial_mode(),
+    }
+
+
 @router.patch("/me")
 async def patch_me(payload: CompanyPatch, company_id=Depends(get_current_company_id), _: None = require_permission("manage_company_settings"), session: AsyncSession = Depends(get_session)) -> dict:
     company = await session.get(Company, company_id)

--- a/conftest.py
+++ b/conftest.py
@@ -540,20 +540,31 @@ def _mock_get_modules_default():
 def _reset_loaded_modules(request):
     """Clear the loader's in-process registry around each unit test. A test (or
     a test module's import) that calls load_all() populates
-    celerp.modules.loader._loaded; without this it leaks into later tests in the
-    same worker (e.g. a module shows running=True), which surfaces under xdist's
-    test distribution.
+    celerp.modules.loader._loaded AND registers every module's lifecycle hooks
+    into celerp.modules.slots._slots; without resetting both they leak into
+    later tests in the same worker (e.g. a module shows running=True, or the
+    manufacturing on_company_created hook seeds a default work center for a test
+    that expects none), which surfaces under xdist's test distribution.
+
+    The slot registry is snapshotted and restored around the test rather than
+    cleared, so the canonical unit-harness contributions (_ensure_slots) survive
+    while anything a load_all() adds during the test is torn down.
 
     Browser tests are exempt: their server runs in-process and legitimately owns
     a populated _loaded (module-gated UI like the credit-note "Receive Returns"
-    button reads loaded_modules()), so wiping it would hide that UI."""
+    button reads loaded_modules()) and slot registry, so wiping it would hide
+    that UI."""
     if request.node.get_closest_marker("browser"):
         yield
         return
     from celerp.modules.loader import _loaded
+    from celerp.modules import slots as _slots_mod
     _loaded.clear()
+    _slot_snapshot = {k: list(v) for k, v in _slots_mod._slots.items()}
     yield
     _loaded.clear()
+    _slots_mod._slots.clear()
+    _slots_mod._slots.update({k: list(v) for k, v in _slot_snapshot.items()})
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/conftest.py
+++ b/conftest.py
@@ -441,9 +441,17 @@ def _reset_gateway_state():
     """
     from celerp.gateway import state as _gw
     _iid, _tok = _gw.get_instance_id(), _gw.get_session_token()
+    # Relay-pushed commercial state (feature flags + commercial context) also
+    # lives in gateway-state module globals. A test that pushes flags or a
+    # commercial context leaks them into later tests on the same worker. The
+    # setter for commercial context rejects a non-newer version, so restore its
+    # global directly rather than through set_commercial_context.
+    _flags, _ctx = _gw.get_feature_flags(), _gw.get_commercial_context()
     yield
     _gw.set_instance_id(_iid)
     _gw.set_session_token(_tok)
+    _gw.set_feature_flags(_flags)
+    _gw._commercial_context = _ctx
     # Gateway-lifecycle globals: a test that patches asyncio.create_task while the
     # real ensure_running() runs leaves celerp.gateway._run_task a MagicMock (and
     # can leave a stray client). A later test's gateway shutdown() would then await

--- a/tests/test_gateway/test_commercial_context.py
+++ b/tests/test_gateway/test_commercial_context.py
@@ -1,0 +1,224 @@
+# Copyright (c) 2026 Noah Severs
+# SPDX-License-Identifier: LicenseRef-Proprietary
+
+"""Tests for the gateway commercial-context consumer.
+
+Exercises the version-gated acceptance, the read API, the two inbound message
+branches (hello_ack and commercial_updated), and the last-known-good cache
+without a live WebSocket by calling _dispatch() and the state functions
+directly.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+
+os.environ.setdefault("ALLOW_INSECURE_JWT", "true")
+
+import pytest
+
+from celerp.gateway.client import GatewayClient
+import celerp.gateway.state as gw_state
+
+
+@pytest.fixture
+def client():
+    return GatewayClient(
+        gateway_token="test-gateway-token",
+        instance_id="test-instance-id",
+        gateway_url="wss://relay.celerp.com/ws/connect",
+    )
+
+
+@pytest.fixture(autouse=True)
+def reset_commercial_context():
+    gw_state._commercial_context = {}
+    yield
+    gw_state._commercial_context = {}
+
+
+def _ctx(version=1, schema_version=1, mode="partner_managed",
+         implementation="default", offer="default"):
+    """Build a well-formed commercial context. String sentinels keep the
+    default sub-objects out of the mutable-default trap."""
+    if implementation == "default":
+        implementation = {
+            "status": "active",
+            "partner_id": "partner-1",
+            "display_name": "Partner Co",
+            "support_email": "support@partner.example.com",
+            "support_url": "https://partner.example.com/support",
+        }
+    if offer == "default":
+        offer = {
+            "offer_id": "offer-1",
+            "display_name": "Managed Plan",
+            "retail_amount": 4900,
+            "currency": "USD",
+            "billing_interval": "month",
+            "service_description": "Fully managed onboarding and support.",
+            "service_bullets": ["Setup", "Support", "Training"],
+        }
+    return {
+        "schema_version": schema_version,
+        "version": version,
+        "commercial_mode": mode,
+        "implementation": implementation,
+        "offer": offer,
+    }
+
+
+# -- inbound branches --------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_hello_ack_stores_commercial_context(client):
+    """A hello_ack carrying commercial_context populates the model and read API."""
+    await client._dispatch({
+        "type": "hello_ack",
+        "payload": {"commercial_context": _ctx(mode="partner_managed")},
+    })
+    assert gw_state.get_commercial_mode() == "partner_managed"
+    assert gw_state.get_commercial_context()["version"] == 1
+    assert gw_state.get_partner_identity()["display_name"] == "Partner Co"
+
+
+@pytest.mark.asyncio
+async def test_commercial_updated_applies(client):
+    """A commercial_updated message applies its context to the model."""
+    await client._dispatch({
+        "type": "commercial_updated",
+        "payload": _ctx(version=3, mode="partner_managed"),
+    })
+    assert gw_state.get_commercial_mode() == "partner_managed"
+    assert gw_state.get_commercial_context()["version"] == 3
+    assert gw_state.get_offer()["offer_id"] == "offer-1"
+
+
+# -- version gate ------------------------------------------------------------
+
+def test_version_rejects_stale():
+    """A strictly-older version is rejected; last-known-good is preserved."""
+    assert gw_state.set_commercial_context(_ctx(version=5)) is True
+    assert gw_state.set_commercial_context(_ctx(version=3, mode="celerp_direct")) is False
+    assert gw_state.get_commercial_context()["version"] == 5
+    assert gw_state.get_commercial_mode() == "partner_managed"
+
+
+def test_version_rejects_equal():
+    """An equal version is rejected (strictly-newer only)."""
+    assert gw_state.set_commercial_context(_ctx(version=5)) is True
+    assert gw_state.set_commercial_context(_ctx(version=5, mode="celerp_direct")) is False
+    assert gw_state.get_commercial_context()["version"] == 5
+    assert gw_state.get_commercial_mode() == "partner_managed"
+
+
+def test_version_accepts_newer():
+    """A strictly-newer version is accepted and replaces the held context."""
+    assert gw_state.set_commercial_context(_ctx(version=5)) is True
+    assert gw_state.set_commercial_context(_ctx(version=6, mode="celerp_direct")) is True
+    assert gw_state.get_commercial_context()["version"] == 6
+    assert gw_state.get_commercial_mode() == "celerp_direct"
+
+
+# -- preservation and release ------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_absence_preserves_partner_managed(client):
+    """A hello_ack without commercial_context leaves a cached partner_managed intact."""
+    assert gw_state.set_commercial_context(_ctx(version=1, mode="partner_managed")) is True
+    await client._dispatch({
+        "type": "hello_ack",
+        "payload": {"session_token": "tok-1"},
+    })
+    assert gw_state.get_commercial_mode() == "partner_managed"
+
+
+def test_direct_releases_partner_managed():
+    """A strictly-newer celerp_direct context replaces a cached partner_managed."""
+    assert gw_state.set_commercial_context(_ctx(version=1, mode="partner_managed")) is True
+    assert gw_state.set_commercial_context(
+        _ctx(version=2, mode="celerp_direct", implementation=None, offer=None)) is True
+    assert gw_state.get_commercial_mode() == "celerp_direct"
+    assert gw_state.get_partner_identity() is None
+
+
+def test_unknown_schema_version_preserves():
+    """A schema_version above the supported max is rejected; last-known-good stays."""
+    assert gw_state.set_commercial_context(_ctx(version=1, mode="partner_managed")) is True
+    assert gw_state.set_commercial_context(
+        _ctx(version=2, schema_version=2, mode="celerp_direct")) is False
+    assert gw_state.get_commercial_mode() == "partner_managed"
+    assert gw_state.get_commercial_context()["version"] == 1
+
+
+# -- invalid input -----------------------------------------------------------
+
+def test_invalid_mode_rejected():
+    """A commercial_mode outside the enum is rejected; last-known-good preserved."""
+    assert gw_state.set_commercial_context(_ctx(version=1, mode="partner_managed")) is True
+    assert gw_state.set_commercial_context(_ctx(version=2, mode="reseller")) is False
+    assert gw_state.get_commercial_mode() == "partner_managed"
+
+
+def test_invalid_subobject_rejected():
+    """An implementation that is neither null nor an object rejects the whole
+    context; nothing is partial-applied."""
+    assert gw_state.set_commercial_context(_ctx(version=1, mode="partner_managed")) is True
+    assert gw_state.set_commercial_context(
+        _ctx(version=2, mode="celerp_direct", implementation=42)) is False
+    assert gw_state.get_commercial_mode() == "partner_managed"
+    assert gw_state.get_commercial_context()["version"] == 1
+
+
+# -- read API defaults -------------------------------------------------------
+
+def test_default_mode_direct():
+    """An empty model reports the neutral celerp_direct default."""
+    assert gw_state.get_commercial_context() == {}
+    assert gw_state.get_commercial_mode() == "celerp_direct"
+    assert gw_state.get_partner_identity() is None
+    assert gw_state.get_offer() is None
+
+
+# -- persistence -------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_persist_reload_roundtrip(client, monkeypatch, tmp_path):
+    """An accepted context persists to the cache and reloads after a restart."""
+    monkeypatch.setenv("CELERP_DATA_DIR", str(tmp_path))
+    await client._dispatch({
+        "type": "commercial_updated",
+        "payload": _ctx(version=7, mode="partner_managed"),
+    })
+    # Simulate a restart: drop the in-memory model, then load from the cache.
+    gw_state._commercial_context = {}
+    gw_state.load_commercial_context()
+    assert gw_state.get_commercial_mode() == "partner_managed"
+    assert gw_state.get_commercial_context()["version"] == 7
+
+
+def test_missing_cache_defaults_direct(monkeypatch, tmp_path):
+    """A missing or corrupt cache file loads as the neutral celerp_direct default."""
+    monkeypatch.setenv("CELERP_DATA_DIR", str(tmp_path))
+    # Corrupt file present: still degrades to the neutral default, never fabricates.
+    (tmp_path / "celerp-config.json").write_text("{ not json")
+    gw_state.load_commercial_context()
+    assert gw_state.get_commercial_context() == {}
+    assert gw_state.get_commercial_mode() == "celerp_direct"
+
+
+@pytest.mark.asyncio
+async def test_commercial_write_preserves_feature_flags(client, monkeypatch, tmp_path):
+    """Writing the commercial_context key must not drop the feature_flags key in
+    the shared config file."""
+    monkeypatch.setenv("CELERP_DATA_DIR", str(tmp_path))
+    config_path = tmp_path / "celerp-config.json"
+    config_path.write_text(json.dumps({"feature_flags": {"external_db": True}}))
+    await client._dispatch({
+        "type": "commercial_updated",
+        "payload": _ctx(version=1, mode="partner_managed"),
+    })
+    written = json.loads(config_path.read_text())
+    assert written["feature_flags"] == {"external_db": True}
+    assert written["commercial_context"]["commercial_mode"] == "partner_managed"

--- a/tests/test_gateway/test_commercial_context.py
+++ b/tests/test_gateway/test_commercial_context.py
@@ -362,3 +362,123 @@ def test_schema_version_above_max_rejected_with_upgrade(caplog):
         assert gw_state.set_commercial_context(
             _ctx(version=1, schema_version=2, mode="partner_managed")) is False
     assert "needs updating" in caplog.text
+
+
+# -- config persistence: atomicity and 0600 mode -----------------------------
+
+def test_commercial_context_persist_preserves_0600(client, tmp_path, monkeypatch):
+    """Persisting commercial_context must leave celerp-config.json at mode 0600.
+
+    The secrets file (external_db_url, S3 keys) shares this file, so a write that
+    broadens its mode to group/world exposes them.
+    """
+    import asyncio
+    import stat
+
+    monkeypatch.setenv("CELERP_DATA_DIR", str(tmp_path))
+    config_path = tmp_path / "celerp-config.json"
+    # An existing 0600 secrets file that a persist must not broaden.
+    config_path.write_text(json.dumps({"external_db_url": "postgresql://x"}))
+    config_path.chmod(0o600)
+
+    asyncio.run(client._persist_commercial_context(_ctx()))
+
+    mode = stat.S_IMODE(config_path.stat().st_mode)
+    assert mode == 0o600, f"config mode broadened to {oct(mode)}"
+    persisted = json.loads(config_path.read_text())
+    assert persisted["commercial_context"]["commercial_mode"] == "partner_managed"
+    assert persisted["external_db_url"] == "postgresql://x"
+
+
+def test_feature_flags_persist_survives_midwrite_failure(client, tmp_path, monkeypatch):
+    """A failure mid-write must leave the prior config intact and valid JSON.
+
+    The prior file (with its secrets) must survive an interrupted write rather
+    than being truncated to an empty or corrupt state.
+    """
+    import asyncio
+
+    monkeypatch.setenv("CELERP_DATA_DIR", str(tmp_path))
+    config_path = tmp_path / "celerp-config.json"
+    prior = {"external_db_url": "postgresql://x", "feature_flags": {"external_db": False}}
+    config_path.write_text(json.dumps(prior))
+
+    import celerp.gateway.client as gw_client
+
+    def _boom(*a, **k):
+        raise RuntimeError("disk full")
+
+    monkeypatch.setattr(gw_client.json, "dump", _boom)
+    # Persist must swallow the write error (best-effort) and never raise.
+    asyncio.run(client._persist_feature_flags({"external_db": True}))
+
+    # The prior config is untouched and still parseable.
+    reread = json.loads(config_path.read_text())
+    assert reread == prior
+
+
+def test_commercial_context_persist_coerces_non_dict_config(client, tmp_path, monkeypatch):
+    """A valid-but-non-dict top-level config (array/string) is coerced to an
+    object before the merge instead of raising."""
+    import asyncio
+
+    monkeypatch.setenv("CELERP_DATA_DIR", str(tmp_path))
+    config_path = tmp_path / "celerp-config.json"
+    config_path.write_text(json.dumps(["not", "a", "dict"]))
+
+    asyncio.run(client._persist_commercial_context(_ctx()))
+
+    persisted = json.loads(config_path.read_text())
+    assert isinstance(persisted, dict)
+    assert persisted["commercial_context"]["commercial_mode"] == "partner_managed"
+
+
+# -- the API->UI commercial-state endpoint -----------------------------------
+
+@pytest.mark.asyncio
+async def test_system_commercial_state_endpoint_returns_state(session):
+    """GET /companies/commercial-state returns feature_flags, commercial_context,
+    partner_identity and commercial_mode under manage_integrations."""
+    import secrets
+
+    from httpx import ASGITransport, AsyncClient
+
+    from celerp.db import get_session
+    from celerp.main import app
+    from celerp.services.session_tracker import clear as _clear_tracker
+
+    await _clear_tracker(session)
+    app.dependency_overrides[get_session] = lambda: session
+    app.state.limiter.enabled = False
+    app.state.limiter._storage.reset()
+    token = secrets.token_hex(32)
+    gw_state.set_session_token(token)
+    gw_state.set_feature_flags({"external_db": True, "external_storage": False})
+    assert gw_state.set_commercial_context(_ctx()) is True
+
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+            await c.post("/auth/register", json={
+                "company_name": "SeamCo", "email": "owner@example.com",
+                "name": "Owner", "password": "pw",
+            })
+            login = await c.post(
+                "/auth/login",
+                json={"email": "owner@example.com", "password": "pw"},
+                headers={"X-Session-Token": token},
+            )
+            jwt = login.json()["access_token"]
+            r = await c.get(
+                "/companies/commercial-state",
+                headers={"Authorization": f"Bearer {jwt}", "X-Session-Token": token},
+            )
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["feature_flags"] == {"external_db": True, "external_storage": False}
+        assert body["commercial_context"]["commercial_mode"] == "partner_managed"
+        assert body["commercial_mode"] == "partner_managed"
+        assert body["partner_identity"]["partner_id"] == "partner-1"
+    finally:
+        app.dependency_overrides.clear()
+        gw_state.set_session_token("")
+        gw_state.set_feature_flags({})

--- a/tests/test_gateway/test_commercial_context.py
+++ b/tests/test_gateway/test_commercial_context.py
@@ -222,3 +222,143 @@ async def test_commercial_write_preserves_feature_flags(client, monkeypatch, tmp
     written = json.loads(config_path.read_text())
     assert written["feature_flags"] == {"external_db": True}
     assert written["commercial_context"]["commercial_mode"] == "partner_managed"
+
+
+# -- cache validation (routes the persisted cache through the acceptance gate) --
+
+def _write_cache(tmp_path, cached):
+    """Write a celerp-config.json whose commercial_context is `cached`, so the
+    cache path can be exercised with shapes the persist-on-accept guard would
+    never write itself."""
+    (tmp_path / "celerp-config.json").write_text(
+        json.dumps({"commercial_context": cached}))
+
+
+def test_cache_rejects_unknown_schema_version(monkeypatch, tmp_path):
+    """A cached context with an unsupported schema_version is rejected at load;
+    the neutral default is preserved and no partner is shown."""
+    monkeypatch.setenv("CELERP_DATA_DIR", str(tmp_path))
+    _write_cache(tmp_path, _ctx(version=1, schema_version=2, mode="partner_managed"))
+    gw_state.load_commercial_context()
+    assert gw_state.get_commercial_context() == {}
+    assert gw_state.get_commercial_mode() == "celerp_direct"
+    assert gw_state.get_partner_identity() is None
+
+
+def test_cache_rejects_invalid_mode(monkeypatch, tmp_path):
+    """A cached context with a commercial_mode outside the enum is rejected at
+    load; the neutral default is preserved."""
+    monkeypatch.setenv("CELERP_DATA_DIR", str(tmp_path))
+    _write_cache(tmp_path, _ctx(version=1, mode="reseller"))
+    gw_state.load_commercial_context()
+    assert gw_state.get_commercial_context() == {}
+    assert gw_state.get_commercial_mode() == "celerp_direct"
+
+
+def test_cache_rejects_nondict_subobject(monkeypatch, tmp_path):
+    """A cached context whose implementation is neither null nor an object is
+    rejected at load; the neutral default is preserved."""
+    monkeypatch.setenv("CELERP_DATA_DIR", str(tmp_path))
+    _write_cache(tmp_path, _ctx(version=1, mode="partner_managed", implementation=42))
+    gw_state.load_commercial_context()
+    assert gw_state.get_commercial_context() == {}
+    assert gw_state.get_commercial_mode() == "celerp_direct"
+
+
+def test_cache_rejects_bad_version(monkeypatch, tmp_path):
+    """A cached context missing an integer version is rejected at load; the
+    neutral default is preserved."""
+    monkeypatch.setenv("CELERP_DATA_DIR", str(tmp_path))
+    cached = _ctx(version=1, mode="partner_managed")
+    del cached["version"]
+    _write_cache(tmp_path, cached)
+    gw_state.load_commercial_context()
+    assert gw_state.get_commercial_context() == {}
+    assert gw_state.get_commercial_mode() == "celerp_direct"
+
+
+def test_cache_accepts_valid_context(monkeypatch, tmp_path):
+    """A well-formed cached context still loads through the gate (positive
+    control: the tightened cache path must not over-reject a genuine cache)."""
+    monkeypatch.setenv("CELERP_DATA_DIR", str(tmp_path))
+    _write_cache(tmp_path, _ctx(version=4, mode="partner_managed"))
+    gw_state.load_commercial_context()
+    assert gw_state.get_commercial_mode() == "partner_managed"
+    assert gw_state.get_commercial_context()["version"] == 4
+    assert gw_state.get_partner_identity()["display_name"] == "Partner Co"
+
+
+# -- immutability of the held model (deep copy at both boundaries) -----------
+
+def test_get_offer_nested_mutation_isolated():
+    """Mutating a nested list in get_offer()'s result does not change the held
+    model."""
+    assert gw_state.set_commercial_context(_ctx(version=1, mode="partner_managed")) is True
+    gw_state.get_offer()["service_bullets"].append("Injected")
+    assert "Injected" not in gw_state.get_offer()["service_bullets"]
+
+
+def test_get_context_nested_mutation_isolated():
+    """Mutating a nested subobject reached through get_commercial_context() does
+    not leak into the held model."""
+    assert gw_state.set_commercial_context(_ctx(version=1, mode="partner_managed")) is True
+    gw_state.get_commercial_context()["offer"]["service_bullets"].append("Injected")
+    assert "Injected" not in gw_state.get_commercial_context()["offer"]["service_bullets"]
+
+
+def test_get_partner_identity_mutation_isolated():
+    """Mutating a nested value in get_partner_identity()'s result does not leak
+    into the held model."""
+    implementation = {
+        "status": "active",
+        "partner_id": "partner-1",
+        "display_name": "Partner Co",
+        "support_channels": ["email", "phone"],
+    }
+    assert gw_state.set_commercial_context(
+        _ctx(version=1, mode="partner_managed", implementation=implementation)) is True
+    gw_state.get_partner_identity()["support_channels"].append("chat")
+    assert "chat" not in gw_state.get_partner_identity()["support_channels"]
+
+
+def test_store_side_deepcopy_isolated():
+    """Mutating the inbound payload after set_commercial_context accepts it does
+    not change the held model (the store keeps its own deep copy)."""
+    new = _ctx(version=1, mode="partner_managed")
+    assert gw_state.set_commercial_context(new) is True
+    new["offer"]["service_bullets"].append("Injected")
+    assert "Injected" not in gw_state.get_offer()["service_bullets"]
+
+
+# -- schema boundary (only the supported schema is accepted) -----------------
+
+def test_schema_version_zero_rejected():
+    """schema_version 0 is below the supported schema and is rejected."""
+    assert gw_state.set_commercial_context(
+        _ctx(version=1, schema_version=0, mode="partner_managed")) is False
+    assert gw_state.get_commercial_context() == {}
+
+
+def test_schema_version_negative_rejected():
+    """A negative schema_version is rejected."""
+    assert gw_state.set_commercial_context(
+        _ctx(version=1, schema_version=-1, mode="partner_managed")) is False
+    assert gw_state.get_commercial_context() == {}
+
+
+def test_schema_version_one_accepted():
+    """The supported schema_version is accepted (positive control: tightening the
+    gate must not reject the one understood schema)."""
+    assert gw_state.set_commercial_context(
+        _ctx(version=1, schema_version=1, mode="partner_managed")) is True
+    assert gw_state.get_commercial_context()["version"] == 1
+
+
+def test_schema_version_above_max_rejected_with_upgrade(caplog):
+    """A schema_version above the supported max is rejected with the distinct
+    upgrade warning, kept separate from the invalid-schema reject."""
+    import logging
+    with caplog.at_level(logging.WARNING):
+        assert gw_state.set_commercial_context(
+            _ctx(version=1, schema_version=2, mode="partner_managed")) is False
+    assert "needs updating" in caplog.text

--- a/tests/test_gateway/test_commercial_context.py
+++ b/tests/test_gateway/test_commercial_context.py
@@ -23,7 +23,7 @@ import celerp.gateway.state as gw_state
 
 
 @pytest.fixture
-def client():
+def gateway_client():
     return GatewayClient(
         gateway_token="test-gateway-token",
         instance_id="test-instance-id",
@@ -72,9 +72,9 @@ def _ctx(version=1, schema_version=1, mode="partner_managed",
 # -- inbound branches --------------------------------------------------------
 
 @pytest.mark.asyncio
-async def test_hello_ack_stores_commercial_context(client):
+async def test_hello_ack_stores_commercial_context(gateway_client):
     """A hello_ack carrying commercial_context populates the model and read API."""
-    await client._dispatch({
+    await gateway_client._dispatch({
         "type": "hello_ack",
         "payload": {"commercial_context": _ctx(mode="partner_managed")},
     })
@@ -84,9 +84,9 @@ async def test_hello_ack_stores_commercial_context(client):
 
 
 @pytest.mark.asyncio
-async def test_commercial_updated_applies(client):
+async def test_commercial_updated_applies(gateway_client):
     """A commercial_updated message applies its context to the model."""
-    await client._dispatch({
+    await gateway_client._dispatch({
         "type": "commercial_updated",
         "payload": _ctx(version=3, mode="partner_managed"),
     })
@@ -124,10 +124,10 @@ def test_version_accepts_newer():
 # -- preservation and release ------------------------------------------------
 
 @pytest.mark.asyncio
-async def test_absence_preserves_partner_managed(client):
+async def test_absence_preserves_partner_managed(gateway_client):
     """A hello_ack without commercial_context leaves a cached partner_managed intact."""
     assert gw_state.set_commercial_context(_ctx(version=1, mode="partner_managed")) is True
-    await client._dispatch({
+    await gateway_client._dispatch({
         "type": "hello_ack",
         "payload": {"session_token": "tok-1"},
     })
@@ -184,10 +184,10 @@ def test_default_mode_direct():
 # -- persistence -------------------------------------------------------------
 
 @pytest.mark.asyncio
-async def test_persist_reload_roundtrip(client, monkeypatch, tmp_path):
+async def test_persist_reload_roundtrip(gateway_client, monkeypatch, tmp_path):
     """An accepted context persists to the cache and reloads after a restart."""
     monkeypatch.setenv("CELERP_DATA_DIR", str(tmp_path))
-    await client._dispatch({
+    await gateway_client._dispatch({
         "type": "commercial_updated",
         "payload": _ctx(version=7, mode="partner_managed"),
     })
@@ -209,13 +209,13 @@ def test_missing_cache_defaults_direct(monkeypatch, tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_commercial_write_preserves_feature_flags(client, monkeypatch, tmp_path):
+async def test_commercial_write_preserves_feature_flags(gateway_client, monkeypatch, tmp_path):
     """Writing the commercial_context key must not drop the feature_flags key in
     the shared config file."""
     monkeypatch.setenv("CELERP_DATA_DIR", str(tmp_path))
     config_path = tmp_path / "celerp-config.json"
     config_path.write_text(json.dumps({"feature_flags": {"external_db": True}}))
-    await client._dispatch({
+    await gateway_client._dispatch({
         "type": "commercial_updated",
         "payload": _ctx(version=1, mode="partner_managed"),
     })
@@ -366,7 +366,7 @@ def test_schema_version_above_max_rejected_with_upgrade(caplog):
 
 # -- config persistence: atomicity and 0600 mode -----------------------------
 
-def test_commercial_context_persist_preserves_0600(client, tmp_path, monkeypatch):
+def test_commercial_context_persist_preserves_0600(gateway_client, tmp_path, monkeypatch):
     """Persisting commercial_context must leave celerp-config.json at mode 0600.
 
     The secrets file (external_db_url, S3 keys) shares this file, so a write that
@@ -381,7 +381,7 @@ def test_commercial_context_persist_preserves_0600(client, tmp_path, monkeypatch
     config_path.write_text(json.dumps({"external_db_url": "postgresql://x"}))
     config_path.chmod(0o600)
 
-    asyncio.run(client._persist_commercial_context(_ctx()))
+    asyncio.run(gateway_client._persist_commercial_context(_ctx()))
 
     mode = stat.S_IMODE(config_path.stat().st_mode)
     assert mode == 0o600, f"config mode broadened to {oct(mode)}"
@@ -390,7 +390,7 @@ def test_commercial_context_persist_preserves_0600(client, tmp_path, monkeypatch
     assert persisted["external_db_url"] == "postgresql://x"
 
 
-def test_feature_flags_persist_survives_midwrite_failure(client, tmp_path, monkeypatch):
+def test_feature_flags_persist_survives_midwrite_failure(gateway_client, tmp_path, monkeypatch):
     """A failure mid-write must leave the prior config intact and valid JSON.
 
     The prior file (with its secrets) must survive an interrupted write rather
@@ -410,14 +410,14 @@ def test_feature_flags_persist_survives_midwrite_failure(client, tmp_path, monke
 
     monkeypatch.setattr(gw_client.json, "dump", _boom)
     # Persist must swallow the write error (best-effort) and never raise.
-    asyncio.run(client._persist_feature_flags({"external_db": True}))
+    asyncio.run(gateway_client._persist_feature_flags({"external_db": True}))
 
     # The prior config is untouched and still parseable.
     reread = json.loads(config_path.read_text())
     assert reread == prior
 
 
-def test_commercial_context_persist_coerces_non_dict_config(client, tmp_path, monkeypatch):
+def test_commercial_context_persist_coerces_non_dict_config(gateway_client, tmp_path, monkeypatch):
     """A valid-but-non-dict top-level config (array/string) is coerced to an
     object before the merge instead of raising."""
     import asyncio
@@ -426,7 +426,7 @@ def test_commercial_context_persist_coerces_non_dict_config(client, tmp_path, mo
     config_path = tmp_path / "celerp-config.json"
     config_path.write_text(json.dumps(["not", "a", "dict"]))
 
-    asyncio.run(client._persist_commercial_context(_ctx()))
+    asyncio.run(gateway_client._persist_commercial_context(_ctx()))
 
     persisted = json.loads(config_path.read_text())
     assert isinstance(persisted, dict)
@@ -436,49 +436,25 @@ def test_commercial_context_persist_coerces_non_dict_config(client, tmp_path, mo
 # -- the API->UI commercial-state endpoint -----------------------------------
 
 @pytest.mark.asyncio
-async def test_system_commercial_state_endpoint_returns_state(session):
+async def test_system_commercial_state_endpoint_returns_state(client):
     """GET /companies/commercial-state returns feature_flags, commercial_context,
     partner_identity and commercial_mode under manage_integrations."""
-    import secrets
-
-    from httpx import ASGITransport, AsyncClient
-
-    from celerp.db import get_session
-    from celerp.main import app
-    from celerp.services.session_tracker import clear as _clear_tracker
-
-    await _clear_tracker(session)
-    app.dependency_overrides[get_session] = lambda: session
-    app.state.limiter.enabled = False
-    app.state.limiter._storage.reset()
-    token = secrets.token_hex(32)
-    gw_state.set_session_token(token)
     gw_state.set_feature_flags({"external_db": True, "external_storage": False})
     assert gw_state.set_commercial_context(_ctx()) is True
 
-    try:
-        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
-            await c.post("/auth/register", json={
-                "company_name": "SeamCo", "email": "owner@example.com",
-                "name": "Owner", "password": "pw",
-            })
-            login = await c.post(
-                "/auth/login",
-                json={"email": "owner@example.com", "password": "pw"},
-                headers={"X-Session-Token": token},
-            )
-            jwt = login.json()["access_token"]
-            r = await c.get(
-                "/companies/commercial-state",
-                headers={"Authorization": f"Bearer {jwt}", "X-Session-Token": token},
-            )
-        assert r.status_code == 200, r.text
-        body = r.json()
-        assert body["feature_flags"] == {"external_db": True, "external_storage": False}
-        assert body["commercial_context"]["commercial_mode"] == "partner_managed"
-        assert body["commercial_mode"] == "partner_managed"
-        assert body["partner_identity"]["partner_id"] == "partner-1"
-    finally:
-        app.dependency_overrides.clear()
-        gw_state.set_session_token("")
-        gw_state.set_feature_flags({})
+    reg = await client.post("/auth/register", json={
+        "company_name": "SeamCo", "email": "owner@example.com",
+        "name": "Owner", "password": "pw",
+    })
+    assert reg.status_code == 200, reg.text
+    jwt = reg.json()["access_token"]
+    r = await client.get(
+        "/companies/commercial-state",
+        headers={"Authorization": f"Bearer {jwt}"},
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["feature_flags"] == {"external_db": True, "external_storage": False}
+    assert body["commercial_context"]["commercial_mode"] == "partner_managed"
+    assert body["commercial_mode"] == "partner_managed"
+    assert body["partner_identity"]["partner_id"] == "partner-1"

--- a/tests/test_ui/test_commercial_state_seam.py
+++ b/tests/test_ui/test_commercial_state_seam.py
@@ -1,0 +1,67 @@
+# Copyright (c) 2026 Noah Severs
+# SPDX-License-Identifier: LicenseRef-Proprietary
+
+"""Tests for the UI-process commercial-state seam.
+
+The UI runs in a separate process from the API and cannot read the API's
+in-process gateway-state globals. It must fetch live commercial state from the
+API over an authenticated HTTP seam and fail closed to a neutral (no-team)
+state when that fetch is unavailable.
+"""
+
+from __future__ import annotations
+
+import os
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+os.environ.setdefault("ALLOW_INSECURE_JWT", "true")
+
+import pytest
+
+
+def _request(token: str | None = "bearer-abc"):
+    """A minimal request stand-in: cookies for get_token, mutable .state for the
+    request-scoped memo."""
+    cookies = {"celerp_token": token} if token is not None else {}
+    return SimpleNamespace(cookies=cookies, state=SimpleNamespace())
+
+
+@pytest.mark.asyncio
+async def test_ui_has_team_reflects_api_state():
+    """The UI tab logic reports Team features from API-held state fetched over
+    the seam, not from the empty UI-process global."""
+    from ui.routes.settings_cloud import _commercial_state, _has_team_features
+
+    api_state = {
+        "feature_flags": {"external_db": True, "external_storage": False},
+        "commercial_context": {},
+        "partner_identity": None,
+        "commercial_mode": "celerp_direct",
+    }
+    with patch("ui.api_client.get_commercial_state", new=AsyncMock(return_value=api_state)):
+        state = await _commercial_state(_request())
+
+    assert _has_team_features(state) is True
+
+
+@pytest.mark.asyncio
+async def test_ui_commercial_state_fails_closed_to_neutral():
+    """A failing, non-dict, or token-less state fetch yields no-team and neutral,
+    never fabricated entitlement."""
+    from ui.routes.settings_cloud import _commercial_state, _has_team_features
+
+    # The fetch raising must degrade to a neutral empty state.
+    with patch("ui.api_client.get_commercial_state",
+               new=AsyncMock(side_effect=RuntimeError("api down"))):
+        state = await _commercial_state(_request())
+    assert state == {}
+    assert _has_team_features(state) is False
+
+    # A missing token short-circuits to neutral without any fetch.
+    fetch = AsyncMock(return_value={"feature_flags": {"external_db": True}})
+    with patch("ui.api_client.get_commercial_state", new=fetch):
+        state = await _commercial_state(_request(token=None))
+    assert state == {}
+    assert _has_team_features(state) is False
+    fetch.assert_not_awaited()

--- a/ui/api_client.py
+++ b/ui/api_client.py
@@ -267,6 +267,16 @@ async def get_company(token: str) -> dict:
         return _flatten_company(data)
 
 
+async def get_commercial_state(token: str, timeout: float = 3.0) -> dict:
+    """Fetch the live commercial state (feature_flags, commercial_context,
+    partner_identity, commercial_mode) the API process holds from the relay.
+
+    Short timeout so a hung API degrades the settings page to neutral quickly
+    rather than hanging on the render path."""
+    async with _api_client(token, timeout=timeout) as c:
+        return _raise(await c.get("/companies/commercial-state")).json()
+
+
 async def patch_company(token: str, data: dict) -> dict:
     """Patch company. Settings sub-fields and dashboard preferences are merged into
     the settings dict; top-level fields (name, slug) are patched directly."""

--- a/ui/routes/settings_cloud.py
+++ b/ui/routes/settings_cloud.py
@@ -21,11 +21,37 @@ from ui.routes.settings import (
 from ui.routes.settings_general import _section_breadcrumb
 
 
-def _has_team_features() -> bool:
-    """Check if Team-tier infrastructure features are available (in-memory, no I/O)."""
-    from celerp.gateway.state import get_feature_flags
-    flags = get_feature_flags()
+def _has_team_features(state: dict) -> bool:
+    """Whether Team-tier infrastructure features are entitled, from fetched
+    commercial state. Pure predicate: no I/O, fail-closed on a neutral state."""
+    flags = state.get("feature_flags") or {}
     return bool(flags.get("external_db") or flags.get("external_storage"))
+
+
+async def _commercial_state(request: Request) -> dict:
+    """Fetch the live commercial state from the API once per request, memoized on
+    request.state so both the tab decision and any consumer share one call.
+
+    Fails closed to a neutral empty state: a missing token or any fetch error
+    yields {} so the page renders with the neutral (no-team) tab set rather than
+    fabricating entitlement or 500-ing."""
+    cached = getattr(request.state, "commercial_state", None)
+    if cached is not None:
+        return cached
+    from ui.config import get_token
+    import ui.api_client as _api
+    token = get_token(request)
+    if not token:
+        request.state.commercial_state = {}
+        return {}
+    try:
+        state = await _api.get_commercial_state(token)
+        if not isinstance(state, dict):
+            state = {}
+    except Exception:
+        state = {}
+    request.state.commercial_state = state
+    return state
 
 
 def _cloud_tabs(active: str, has_team_features: bool = False, lang: str = "en") -> FT:
@@ -518,7 +544,7 @@ def setup_routes(app):
 
         # Connected or connecting - show tabs
         tab = request.query_params.get("tab", "status")
-        has_team = _has_team_features()
+        has_team = _has_team_features(await _commercial_state(request))
 
         if tab == "infrastructure" and has_team:
             content = _infrastructure_tab()

--- a/ui/routes/settings_payments.py
+++ b/ui/routes/settings_payments.py
@@ -21,7 +21,7 @@ from ui.components.shell import base_shell, page_header, page_title, flash
 from ui.components.table import add_new_option, bank_account_options
 from ui.i18n import t
 from ui.routes.settings import _check_permission, _token
-from ui.routes.settings_cloud import _cloud_tabs, _has_team_features
+from ui.routes.settings_cloud import _cloud_tabs, _commercial_state, _has_team_features
 
 
 def _pitch() -> FT:
@@ -79,7 +79,7 @@ def _connected_panel(deposit_account: str, bank_accounts: list[dict], saved: boo
 
 
 def _page(relay_ok: bool, enabled: bool, deposit_account: str,
-          bank_accounts: list[dict], saved: bool = False) -> FT:
+          bank_accounts: list[dict], has_team_features: bool, saved: bool = False) -> FT:
     if not relay_ok:
         body = upgrade_banner(t("nav.payments"), t("pay.upgrade_desc"), plan="cloud")
     elif not enabled:
@@ -88,7 +88,7 @@ def _page(relay_ok: bool, enabled: bool, deposit_account: str,
         body = _connected_panel(deposit_account, bank_accounts, saved=saved)
     return Div(
         page_header(t("nav.payments")),
-        _cloud_tabs("payments", has_team_features=_has_team_features()),
+        _cloud_tabs("payments", has_team_features=has_team_features),
         body,
     )
 
@@ -126,8 +126,9 @@ def setup_routes(app):
         except APIError as e:
             return await base_shell(flash(str(e.detail)), title=page_title("nav.payments"),
                                     nav_active="web-access", request=request)
+        has_team = _has_team_features(await _commercial_state(request))
         return await base_shell(
-            _page(relay_ok, enabled, deposit, banks,
+            _page(relay_ok, enabled, deposit, banks, has_team,
                   saved=request.query_params.get("saved") == "1"),
             title=page_title("nav.payments"), nav_active="web-access", request=request)
 
@@ -144,7 +145,8 @@ def setup_routes(app):
             await api.patch_company(token, {"stripe_deposit_account": str(form.get("stripe_deposit_account", "")).strip()})
         except APIError as e:
             relay_ok, enabled, deposit, banks = await _load(token)
-            return await base_shell(Div(flash(str(e.detail)), _page(relay_ok, enabled, deposit, banks)),
+            has_team = _has_team_features(await _commercial_state(request))
+            return await base_shell(Div(flash(str(e.detail)), _page(relay_ok, enabled, deposit, banks, has_team)),
                               title=page_title("nav.payments"), nav_active="web-access", request=request)
         return RedirectResponse("/settings/payments?saved=1", status_code=302)
 
@@ -160,7 +162,8 @@ def setup_routes(app):
             result = await api.start_payments_connect(token)
         except APIError as e:
             relay_ok, enabled, deposit, banks = await _load(token)
-            return await base_shell(Div(flash(str(e.detail)), _page(relay_ok, enabled, deposit, banks)),
+            has_team = _has_team_features(await _commercial_state(request))
+            return await base_shell(Div(flash(str(e.detail)), _page(relay_ok, enabled, deposit, banks, has_team)),
                               title=page_title("nav.payments"), nav_active="web-access", request=request)
         return RedirectResponse(result.get("url", "/settings/payments"), status_code=302)
 


### PR DESCRIPTION
## Commercial context on the gateway

The desktop app now understands a commercial-context object the relay can push over the existing gateway connection. It records which commercial mode the instance is in (direct or partner-managed), an optional partner identity, and an optional offer, and makes them available through a small read API for later screens to render.

Updates are accepted only when they carry a strictly newer version, so an out-of-order or duplicate push never rolls the app back to older information, and the absence of a context never silently flips a partner-managed instance to direct. An unrecognised newer schema is rejected and the last known-good value is kept, with a single log line noting the client needs updating.

The accepted context is written into the existing local config file alongside the feature flags (an atomic write that preserves the flags), and it is reloaded at startup independently of the relay connection, so the last known-good value survives a restart even while offline.

No user-facing screen changes in this change; rendering arrives separately.
