### PR TITLE
Open and edit large lists quickly, and keep the app responsive under load

### DIFF
--- a/celerp/gateway/client.py
+++ b/celerp/gateway/client.py
@@ -36,6 +36,10 @@ _AUTH_FAILED_MAX = 3
 # a revoke-then-reshare so it does not flap connect/disconnect).
 _REAP_INTERVAL = 15 * 60   # seconds
 _REAP_GRACE = 5 * 60       # seconds
+# A single websocket send that cannot be handed to the transport within this long means the
+# socket is wedged (a stalled or backpressured peer). Bound every send so it surfaces as an
+# error instead of pinning the proxy task holding a relay slot forever.
+_SEND_DEADLINE = 30        # seconds
 
 
 def _shop_key(handle: str | None) -> str:
@@ -792,7 +796,12 @@ class GatewayClient:
 
     @staticmethod
     async def _send(ws, message: dict) -> None:
-        await ws.send(json.dumps(message))
+        # Bound the send: a websocket send awaits until the frame is handed to the transport, and a
+        # stalled or backpressured peer would otherwise block it forever, pinning the proxy task and
+        # its relay slot. On the deadline the send is cancelled and TimeoutError surfaces to the
+        # caller, which lets the wedged socket be torn down and rebuilt.
+        async with asyncio.timeout(_SEND_DEADLINE):
+            await ws.send(json.dumps(message))
 
 
 # Module-level singleton — set by main.py lifespan

--- a/celerp/gateway/client.py
+++ b/celerp/gateway/client.py
@@ -26,7 +26,6 @@ from websockets.exceptions import ConnectionClosed
 
 log = logging.getLogger(__name__)
 
-_PING_INTERVAL = 30   # seconds
 _BACKOFF_MAX = 60     # seconds
 # Consecutive auth rejections before the client stops retrying: a rejected
 # credential never heals on its own, so beyond a small allowance for a
@@ -85,6 +84,22 @@ class GatewayClient:
         # Hold strong refs to fire-and-forget tasks so the loop can't GC them mid-run
         # (a dropped task = a lost proxy response or webhook sync).
         self._bg_tasks: set = set()
+        # In-flight proxy tasks keyed by relay request id so an http.cancel frame can
+        # abort exactly the one request it names, and no other.
+        self._inflight: dict[str, asyncio.Task] = {}
+        # Connection generation: bumped on every teardown so a response produced by a
+        # request that outlived its socket can be recognised as stale and dropped
+        # rather than sent on the freshly rebuilt connection.
+        self._generation: int = 0
+        # One shared httpx client for all proxied requests, built lazily with bounded
+        # connection limits. A fresh client per request opened an unbounded number of
+        # pools under load; one bounded client caps the concurrency into the local app.
+        self._http_client: Any = None
+        # Observability counters for the proxy path, surfaced when the connection ends.
+        self._proxied_count = 0
+        self._cancelled_count = 0
+        self._timeout_count = 0
+        self._stale_dropped_count = 0
         # Resolve local server ports for proxy routing.
         # In Electron builds the ports are dynamic; Electron passes them via
         # CELERP_API_PORT / CELERP_UI_PORT env vars so we don't rely on the
@@ -121,6 +136,22 @@ class GatewayClient:
         task = asyncio.create_task(coro)
         self._bg_tasks.add(task)
         task.add_done_callback(self._bg_tasks.discard)
+
+    def _spawn_proxy(self, payload: dict) -> None:
+        """Run a proxied request fire-and-forget, keyed by its relay request id so an
+        http.cancel frame can abort exactly that task. The key is cleared when the task
+        finishes (a cancel arriving after completion is then a harmless no-op)."""
+        request_id = payload.get("id", "")
+        task = asyncio.create_task(self._handle_proxy_request(payload))
+        self._bg_tasks.add(task)
+        self._inflight[request_id] = task
+
+        def _done(t: asyncio.Task) -> None:
+            self._bg_tasks.discard(t)
+            if self._inflight.get(request_id) is t:
+                del self._inflight[request_id]
+
+        task.add_done_callback(_done)
 
     # ── Public API ─────────────────────────────────────────────────────
 
@@ -198,6 +229,7 @@ class GatewayClient:
                 await ws.close()
             except Exception:
                 pass
+        await self._close_http_client()
 
     async def _should_reap(self) -> bool:
         """A free instance with no live share and no recent proxied request should
@@ -326,6 +358,15 @@ class GatewayClient:
                     continue
                 await self._dispatch(msg)
         self._ws = None
+        # A new generation for the next connection: any proxy response still in flight
+        # from this socket is now stale and must not be sent on the rebuilt one.
+        self._generation += 1
+        log.debug(
+            "Gateway proxy activity this connection: proxied=%d cancelled=%d "
+            "timed_out=%d stale_dropped=%d",
+            self._proxied_count, self._cancelled_count,
+            self._timeout_count, self._stale_dropped_count,
+        )
         self._set_status("inactive")
 
     async def _dispatch(self, msg: dict) -> None:
@@ -414,7 +455,13 @@ class GatewayClient:
             set_subscription_state(tier, status)
 
         elif msg_type == "http.request":
-            self._spawn(self._handle_proxy_request(payload))
+            self._spawn_proxy(payload)
+
+        elif msg_type == "http.cancel":
+            request_id = payload.get("id", "")
+            task = self._inflight.get(request_id)
+            if task is not None and not task.done():
+                task.cancel()
 
         elif msg_type == "shopify.webhook":
             self._spawn(self._handle_shopify_webhook(payload))
@@ -533,6 +580,31 @@ class GatewayClient:
         except Exception as exc:
             log.warning("invoice.payment handling failed (entity=%s): %s", entity_id, exc)
 
+    def _get_http_client(self):
+        """Return the one shared httpx client used for every proxied request, building
+        it lazily on first use. A bounded connection pool caps how many concurrent
+        requests this client can drive into the local app, so a burst of relayed
+        requests can no longer open an unbounded number of pools. The default timeout
+        is the fixed cap; a per-request timeout_ms tightens it further."""
+        import httpx
+
+        if self._http_client is None:
+            self._http_client = httpx.AsyncClient(
+                timeout=180.0,
+                limits=httpx.Limits(max_connections=32, max_keepalive_connections=8),
+            )
+        return self._http_client
+
+    async def _close_http_client(self) -> None:
+        """Close the shared httpx client if one was built. Safe to call when none was."""
+        client = self._http_client
+        self._http_client = None
+        if client is not None:
+            try:
+                await client.aclose()
+            except Exception:
+                pass
+
     async def _handle_proxy_request(self, payload: dict) -> None:
         """Handle a proxied HTTP request from the relay.
 
@@ -545,10 +617,14 @@ class GatewayClient:
         local access.
         """
         import base64
-        import httpx
 
         # Activity stamp for the reaper's grace window: any proxied request counts.
         self._last_request_monotonic = time.monotonic()
+        self._proxied_count += 1
+        # The generation this request belongs to: if the socket is rebuilt before the
+        # response is ready, self._generation advances past this and the response is
+        # dropped rather than sent on a connection that never issued the request.
+        generation = self._generation
 
         request_id = payload.get("id", "")
         method = payload.get("method", "GET")
@@ -557,6 +633,13 @@ class GatewayClient:
         headers = payload.get("headers", {})
         body_b64 = payload.get("body_b64", "")
         body = base64.b64decode(body_b64) if body_b64 else None
+        # Additive per-request deadline: a numeric timeout_ms bounds this request below
+        # the fixed cap so a single slow local handler can't pin a relay slot for 180s.
+        # Absent or non-numeric leaves the default cap in force.
+        timeout_ms = payload.get("timeout_ms")
+        deadline_s: float | None = None
+        if isinstance(timeout_ms, (int, float)) and not isinstance(timeout_ms, bool) and timeout_ms > 0:
+            deadline_s = timeout_ms / 1000.0
 
         # SSE / long-poll paths cannot be proxied over the WS request/response
         # protocol. Return an empty stream so the browser doesn't 500.
@@ -599,47 +682,92 @@ class GatewayClient:
         if query:
             url = f"{url}?{query}"
 
+        client = self._get_http_client()
         try:
-            async with httpx.AsyncClient(timeout=180.0) as client:
+            if deadline_s is not None:
+                async with asyncio.timeout(deadline_s):
+                    resp = await client.request(
+                        method=method,
+                        url=url,
+                        headers=headers,
+                        content=body,
+                    )
+            else:
                 resp = await client.request(
                     method=method,
                     url=url,
                     headers=headers,
                     content=body,
                 )
-            resp_body_b64 = base64.b64encode(resp.content).decode() if resp.content else ""
-            # Serialize as an ORDERED LIST of pairs (not a dict): a response can carry several
-            # Set-Cookie headers (login/refresh emit access_token + refresh_token), and a dict would
-            # collapse them into one comma-joined value the browser can't parse — so the refresh
-            # cookie never reaches the browser and the session dies at the access token's hard cap.
-            # multi_items() keeps each header separate. Drop content-length; the relay recomputes it.
-            _skip = {"transfer-encoding", "connection", "keep-alive", "content-length"}
-            resp_headers = [
-                [k, v] for k, v in resp.headers.multi_items()
-                if k.lower() not in _skip
-            ]
-            await self._send(self._ws, {
-                "type": "http.response",
-                "payload": {
-                    "id": request_id,
-                    "status": resp.status_code,
-                    "headers": resp_headers,
-                    "body_b64": resp_body_b64,
-                },
-            })
+        except asyncio.CancelledError:
+            # http.cancel aborted this request: emit nothing and let the cancellation
+            # propagate so the task is recorded cancelled.
+            self._cancelled_count += 1
+            raise
+        except TimeoutError:
+            # The per-request deadline elapsed before the local handler answered. Surface
+            # it as an error response instead of hanging to the fixed cap.
+            self._timeout_count += 1
+            log.warning("Proxy request timed out after %sms for %s %s", timeout_ms, method, path)
+            if generation == self._generation:
+                await self._send(self._ws, {
+                    "type": "http.response",
+                    "payload": {
+                        "id": request_id,
+                        "status": 504,
+                        "headers": [["content-type", "text/plain"]],
+                        "body_b64": base64.b64encode(b"Local app timed out").decode(),
+                    },
+                })
+            else:
+                self._stale_dropped_count += 1
+            return
         except Exception as exc:
             log.warning("Proxy request failed for %s %s: %s", method, path, exc)
-            await self._send(self._ws, {
-                "type": "http.response",
-                "payload": {
-                    "id": request_id,
-                    "status": 502,
-                    "headers": [["content-type", "text/plain"]],
-                    "body_b64": base64.b64encode(
-                        f"Local app error: {type(exc).__name__}: {exc}".encode()
-                    ).decode(),
-                },
-            })
+            if generation == self._generation:
+                await self._send(self._ws, {
+                    "type": "http.response",
+                    "payload": {
+                        "id": request_id,
+                        "status": 502,
+                        "headers": [["content-type", "text/plain"]],
+                        "body_b64": base64.b64encode(
+                            f"Local app error: {type(exc).__name__}: {exc}".encode()
+                        ).decode(),
+                    },
+                })
+            else:
+                self._stale_dropped_count += 1
+            return
+
+        # The socket that carried this request may have been rebuilt while it was in
+        # flight. A response from a superseded generation belongs to a connection the
+        # relay no longer has; sending it on the new socket would answer the wrong
+        # request, so it is dropped.
+        if generation != self._generation:
+            self._stale_dropped_count += 1
+            return
+
+        resp_body_b64 = base64.b64encode(resp.content).decode() if resp.content else ""
+        # Serialize as an ORDERED LIST of pairs (not a dict): a response can carry several
+        # Set-Cookie headers (login/refresh emit access_token + refresh_token), and a dict would
+        # collapse them into one comma-joined value the browser can't parse, so the refresh
+        # cookie never reaches the browser and the session dies at the access token's hard cap.
+        # multi_items() keeps each header separate. Drop content-length; the relay recomputes it.
+        _skip = {"transfer-encoding", "connection", "keep-alive", "content-length"}
+        resp_headers = [
+            [k, v] for k, v in resp.headers.multi_items()
+            if k.lower() not in _skip
+        ]
+        await self._send(self._ws, {
+            "type": "http.response",
+            "payload": {
+                "id": request_id,
+                "status": resp.status_code,
+                "headers": resp_headers,
+                "body_b64": resp_body_b64,
+            },
+        })
 
     async def send_message(self, msg_type: str, **payload) -> None:
         """Send a JSON message over the active WS connection.

--- a/celerp/gateway/client.py
+++ b/celerp/gateway/client.py
@@ -325,49 +325,61 @@ class GatewayClient:
             import ssl as _ssl
             _ssl_ctx = _ssl.create_default_context()
             _ssl_ctx.set_alpn_protocols(["http/1.1"])
-        async with websockets.connect(
-            self._url, ssl=_ssl_ctx, ping_interval=20, ping_timeout=20, max_size=160 * 1024 * 1024
-        ) as ws:
-            self._ws = ws
-            # Read current TOS version from config
-            from celerp.config import read_config
-            cfg = read_config() or {}
-            tos_version = cfg.get("cloud", {}).get("tos_version", "")
-            # App version: the Electron wrapper passes the release version via
-            # CELERP_APP_VERSION; fall back to the package version. Sent on every
-            # connect so the handshake reflects the build that is actually running.
-            from celerp import __version__ as _pkg_version
-            app_version = os.environ.get("CELERP_APP_VERSION") or _pkg_version
-            # Send hello handshake
-            await self._send(ws, {
-                "type": "hello",
-                "id": str(uuid.uuid4()),
-                "payload": {
-                    "gateway_token": self._token,
-                    "instance_id": self._instance_id,
-                    "tos_version": tos_version,
-                    "version": app_version,
-                },
-            })
-            # Message dispatch loop
-            async for raw in ws:
-                try:
-                    msg = json.loads(raw)
-                except json.JSONDecodeError:
-                    log.warning("Gateway sent non-JSON frame: %r", raw)
-                    continue
-                await self._dispatch(msg)
-        self._ws = None
-        # A new generation for the next connection: any proxy response still in flight
-        # from this socket is now stale and must not be sent on the rebuilt one.
-        self._generation += 1
-        log.debug(
-            "Gateway proxy activity this connection: proxied=%d cancelled=%d "
-            "timed_out=%d stale_dropped=%d",
-            self._proxied_count, self._cancelled_count,
-            self._timeout_count, self._stale_dropped_count,
-        )
-        self._set_status("inactive")
+        try:
+            async with websockets.connect(
+                self._url, ssl=_ssl_ctx, ping_interval=20, ping_timeout=20, max_size=160 * 1024 * 1024
+            ) as ws:
+                self._ws = ws
+                # Read current TOS version from config
+                from celerp.config import read_config
+                cfg = read_config() or {}
+                tos_version = cfg.get("cloud", {}).get("tos_version", "")
+                # App version: the Electron wrapper passes the release version via
+                # CELERP_APP_VERSION; fall back to the package version. Sent on every
+                # connect so the handshake reflects the build that is actually running.
+                from celerp import __version__ as _pkg_version
+                app_version = os.environ.get("CELERP_APP_VERSION") or _pkg_version
+                # Send hello handshake
+                await self._send(ws, {
+                    "type": "hello",
+                    "id": str(uuid.uuid4()),
+                    "payload": {
+                        "gateway_token": self._token,
+                        "instance_id": self._instance_id,
+                        "tos_version": tos_version,
+                        "version": app_version,
+                    },
+                })
+                # Message dispatch loop
+                async for raw in ws:
+                    try:
+                        msg = json.loads(raw)
+                    except json.JSONDecodeError:
+                        log.warning("Gateway sent non-JSON frame: %r", raw)
+                        continue
+                    await self._dispatch(msg)
+        finally:
+            # Teardown runs on every exit - clean end of the message stream OR an
+            # abnormal disconnect raised mid-serve. Kept in a finally so an exception
+            # from the async-for can't leave a dangling socket, an unfenced generation,
+            # and a stuck status behind.
+            self._ws = None
+            # A new generation for the next connection: any proxy response still in
+            # flight from this socket is now stale and must not be sent on the rebuilt
+            # one. Cancel the in-flight proxy tasks that belong to the dead connection -
+            # their responses can never be delivered on a socket that no longer exists.
+            self._generation += 1
+            for task in list(self._inflight.values()):
+                if not task.done():
+                    task.cancel()
+            self._inflight.clear()
+            log.debug(
+                "Gateway proxy activity this connection: proxied=%d cancelled=%d "
+                "timed_out=%d stale_dropped=%d",
+                self._proxied_count, self._cancelled_count,
+                self._timeout_count, self._stale_dropped_count,
+            )
+            self._set_status("inactive")
 
     async def _dispatch(self, msg: dict) -> None:
         msg_type = msg.get("type", "")

--- a/celerp/gateway/client.py
+++ b/celerp/gateway/client.py
@@ -701,13 +701,19 @@ class GatewayClient:
         client = self._get_http_client()
         try:
             if deadline_s is not None:
-                async with asyncio.timeout(deadline_s):
-                    resp = await client.request(
+                # asyncio.wait_for, not asyncio.timeout: the latter is 3.11+, and this package
+                # supports Python >=3.10 where it does not exist. wait_for cancels the request and
+                # raises TimeoutError on the deadline, which the handler below turns into an error
+                # response.
+                resp = await asyncio.wait_for(
+                    client.request(
                         method=method,
                         url=url,
                         headers=headers,
                         content=body,
-                    )
+                    ),
+                    deadline_s,
+                )
             else:
                 resp = await client.request(
                     method=method,
@@ -799,9 +805,9 @@ class GatewayClient:
         # Bound the send: a websocket send awaits until the frame is handed to the transport, and a
         # stalled or backpressured peer would otherwise block it forever, pinning the proxy task and
         # its relay slot. On the deadline the send is cancelled and TimeoutError surfaces to the
-        # caller, which lets the wedged socket be torn down and rebuilt.
-        async with asyncio.timeout(_SEND_DEADLINE):
-            await ws.send(json.dumps(message))
+        # caller, which lets the wedged socket be torn down and rebuilt. asyncio.wait_for, not
+        # asyncio.timeout: the latter is 3.11+ and this package supports Python >=3.10.
+        await asyncio.wait_for(ws.send(json.dumps(message)), _SEND_DEADLINE)
 
 
 # Module-level singleton — set by main.py lifespan

--- a/default_modules/celerp-docs/celerp_docs/doc_projections.py
+++ b/default_modules/celerp-docs/celerp_docs/doc_projections.py
@@ -17,7 +17,16 @@ def _recalc_list_totals(state: dict) -> dict:
     """
     currency = state.get("currency")
     items = state.get("line_items", [])
-    subtotal = round_money(sum((to_decimal(i.get("line_total", 0) or 0) for i in items), to_decimal(0)), currency)
+
+    def _li_amount(i: dict):
+        # An explicit line_total wins (it may be a per-line discount below quantity*unit_price);
+        # otherwise fall back to quantity*unit_price so a priced line still contributes.
+        lt = i.get("line_total")
+        if lt not in (None, ""):
+            return to_decimal(lt or 0)
+        return to_decimal(i.get("quantity", 0) or 0) * to_decimal(i.get("unit_price", 0) or 0)
+
+    subtotal = round_money(sum((_li_amount(i) for i in items), to_decimal(0)), currency)
     state["subtotal"] = to_stored_float(subtotal)
 
     discount = to_decimal(state.get("discount", 0) or 0)
@@ -28,7 +37,7 @@ def _recalc_list_totals(state: dict) -> dict:
     taxable = subtotal - discount_amount
     # Use per-line tax rates if present; fall back to header tax rate.
     per_line_tax = sum(
-        (to_decimal(i.get("line_total", 0) or 0) * to_decimal(i.get("tax_rate", 0) or 0) / 100 for i in items),
+        (_li_amount(i) * to_decimal(i.get("tax_rate", 0) or 0) / 100 for i in items),
         to_decimal(0),
     )
     if per_line_tax:

--- a/default_modules/celerp-docs/celerp_docs/routes.py
+++ b/default_modules/celerp-docs/celerp_docs/routes.py
@@ -3983,26 +3983,47 @@ async def export_lists_csv(
     list_type: str | None = None,
     status: str | None = None,
 ) -> StreamingResponse:
-    rows = (await session.execute(
-        select(Projection).where(Projection.company_id == company_id, Projection.entity_type == "list")
-    )).scalars().all()
-    items = [r.state | {"id": r.entity_id} for r in rows]
+    base_where = _list_base_where(company_id)
     if q:
-        ql = q.lower()
-        items = [d for d in items if ql in str(d.get("ref_id", "")).lower() or ql in str(d.get("customer_name", "")).lower()]
+        # Export matches ref_id / customer_name only (never customer_id), matching its own historic
+        # behaviour rather than the wider index search.
+        base_where.append(_list_search_where(q, include_customer_id=False))
     if list_type:
-        items = [d for d in items if d.get("list_type") == list_type]
+        base_where.append(Projection.state["list_type"].as_string() == list_type)
     if status:
-        items = [d for d in items if d.get("status") == status]
+        base_where.append(Projection.state["status"].as_string() == status)
     _COLS = ["id", "ref_id", "list_type", "customer_name", "date", "total", "status"]
-    output = io.StringIO()
-    writer = csv.DictWriter(output, fieldnames=_COLS, extrasaction="ignore")
-    writer.writeheader()
-    for d in items:
-        writer.writerow({c: d.get(c, "") for c in _COLS})
-    output.seek(0)
+
+    async def _rows():
+        # Read the projection in bounded SQL batches so the whole set is never buffered in Python.
+        header = io.StringIO()
+        writer = csv.DictWriter(header, fieldnames=_COLS, extrasaction="ignore")
+        writer.writeheader()
+        yield header.getvalue()
+        batch = 500
+        offset = 0
+        while True:
+            rows = (await session.execute(
+                select(Projection)
+                .where(*base_where)
+                .order_by(Projection.entity_id.desc())
+                .offset(offset)
+                .limit(batch)
+            )).scalars().all()
+            if not rows:
+                break
+            buf = io.StringIO()
+            w = csv.DictWriter(buf, fieldnames=_COLS, extrasaction="ignore")
+            for r in rows:
+                d = r.state | {"id": r.entity_id}
+                w.writerow({c: d.get(c, "") for c in _COLS})
+            yield buf.getvalue()
+            if len(rows) < batch:
+                break
+            offset += batch
+
     return StreamingResponse(
-        iter([output.getvalue()]),
+        _rows(),
         media_type="text/csv",
         headers={"Content-Disposition": "attachment; filename=lists.csv"},
     )

--- a/default_modules/celerp-docs/celerp_docs/routes.py
+++ b/default_modules/celerp-docs/celerp_docs/routes.py
@@ -4303,17 +4303,20 @@ async def patch_list_line_page(
         original_count = len(page)
     elif original_count < 0:
         raise HTTPException(status_code=400, detail="original_count must be zero or greater")
-    # A submitted row carrying an id must land on the position holding that same id: this catches a
-    # page saved against a shifted array. Free-text rows carry no id and overwrite by position.
-    for i, incoming in enumerate(page):
-        pos = offset + i
-        if pos < len(stored):
-            incoming_id = _line_identity(incoming)
-            stored_id = _line_identity(stored[pos])
-            if incoming_id is not None and stored_id is not None and incoming_id != stored_id:
-                raise HTTPException(
-                    status_code=409,
-                    detail="This list was changed by someone else; reload to get the latest before saving")
+    # The loaded window [offset:offset+original_count] must lie within the stored array: it is the
+    # exact slice the client read, so it can neither start past the end nor run beyond it. A larger
+    # claimed window would splice away tail rows the client never loaded and cannot have edited
+    # (offset 0 + a huge original_count + a one-row page would collapse the whole list to that row).
+    # The optimistic version guard above already pins `stored` to exactly what the client loaded, so
+    # any window outside it means the client's view is stale: reject and reload rather than mutate.
+    if offset > len(stored) or offset + original_count > len(stored):
+        raise HTTPException(
+            status_code=409,
+            detail="This list was changed by someone else; reload to get the latest before saving")
+    # No positional id comparison: the page replaces the WHOLE window [offset:offset+original_count],
+    # so a delete or insert legitimately shifts the surviving rows out of id-for-id alignment with
+    # `stored`. Concurrency is guarded by the version pin (every save bumps the list version), not by
+    # matching incoming rows to stored positions, which would falsely reject a mid-window delete.
 
     # A draft item is not stock and must never reach a list, on this path as on the full save.
     _existing = {_line_identity(li) for li in stored}

--- a/default_modules/celerp-docs/celerp_docs/routes.py
+++ b/default_modules/celerp-docs/celerp_docs/routes.py
@@ -4166,6 +4166,71 @@ async def patch_list(
     return {"event_id": entry.id, "version": entry.id}
 
 
+class ListLinePagePatch(BaseModel):
+    line_items: list[dict] = Field(default_factory=list)
+    offset: int = 0
+    expected_version: int | None = None
+
+
+def _line_identity(li: dict) -> str | None:
+    """The stable identity of a catalog-backed line, or None for a free-text line that carries none."""
+    return li.get("item_id") or li.get("entity_id")
+
+
+@lists_router.patch("/{entity_id}/line-page")
+async def patch_list_line_page(
+    entity_id: str,
+    payload: ListLinePagePatch,
+    company_id: str = Depends(get_current_company_id),
+    _: None = require_permission("edit_documents"),
+    user=Depends(get_current_user),
+    session: AsyncSession = Depends(get_session),
+) -> dict:
+    """Save one page of a list's lines without scraping or re-sending the whole array. Under the same
+    row lock and optimistic-version guard as a full save, the submitted page overwrites stored
+    positions [offset:offset+len(page)] by position; off-page rows are left byte-identical and totals
+    are recomputed from the full merged array."""
+    row = await _get_list_for_update(session, company_id, entity_id)
+    if row.state.get("status") != "draft":
+        raise HTTPException(status_code=409, detail="Cannot edit non-draft list")
+    if payload.expected_version is None:
+        raise HTTPException(status_code=409, detail="Reload the list to get its latest version before saving line changes")
+    if row.version != payload.expected_version:
+        raise HTTPException(status_code=409, detail="This list was changed by someone else; reload to get the latest before saving")
+
+    page = payload.line_items
+    _normalize_line_item_ids(page)
+    stored = list(row.state.get("line_items") or [])
+    offset = payload.offset
+    if offset < 0:
+        raise HTTPException(status_code=400, detail="offset must be zero or greater")
+    # A submitted row carrying an id must land on the position holding that same id: this catches a
+    # page saved against a shifted array. Free-text rows carry no id and overwrite by position.
+    for i, incoming in enumerate(page):
+        pos = offset + i
+        if pos < len(stored):
+            incoming_id = _line_identity(incoming)
+            stored_id = _line_identity(stored[pos])
+            if incoming_id is not None and stored_id is not None and incoming_id != stored_id:
+                raise HTTPException(
+                    status_code=409,
+                    detail="This list was changed by someone else; reload to get the latest before saving")
+
+    merged = stored[:]
+    for i, incoming in enumerate(page):
+        pos = offset + i
+        if pos < len(merged):
+            merged[pos] = incoming
+        else:
+            merged.append(incoming)
+
+    entry = await _emit_list(
+        session, company_id, entity_id, "list.updated",
+        {"fields_changed": {"line_items": {"new": merged}}}, user)
+    await session.commit()
+    return {"event_id": entry.id, "version": entry.id}
+
+
 @lists_router.post("/{entity_id}/finalize")
 async def finalize_list(
     entity_id: str,

--- a/default_modules/celerp-docs/celerp_docs/routes.py
+++ b/default_modules/celerp-docs/celerp_docs/routes.py
@@ -4039,6 +4039,58 @@ async def get_list(
     return row.state | {"id": row.entity_id, "version": row.version}
 
 
+_PAGE_LIMIT_MAX = 100
+
+
+def _page_bounds(offset: str, limit: str) -> tuple[int, int]:
+    """Validate the page window at the function level (never by hiding controls): offset must be a
+    non-negative integer, limit a positive integer hard-capped at 100. Returns the effective values."""
+    try:
+        off = int(offset)
+    except (TypeError, ValueError):
+        raise HTTPException(status_code=400, detail="offset must be an integer")
+    if off < 0:
+        raise HTTPException(status_code=400, detail="offset must be zero or greater")
+    try:
+        lim = int(limit)
+    except (TypeError, ValueError):
+        raise HTTPException(status_code=400, detail="limit must be an integer")
+    if lim <= 0:
+        raise HTTPException(status_code=400, detail="limit must be greater than zero")
+    return off, min(lim, _PAGE_LIMIT_MAX)
+
+
+@lists_router.get("/{entity_id}/page")
+async def get_list_page(
+    entity_id: str,
+    offset: str = "0",
+    limit: str = str(_PAGE_LIMIT_MAX),
+    company_id: str = Depends(get_current_company_id),
+    session: AsyncSession = Depends(get_session),
+) -> dict:
+    """One bounded page of a list's line_items read in SQL: json_array_length for the total and a
+    positional json subscript over generate_series for the window, so a large list is never expanded
+    into Python. Metadata enrichment stays in the UI layer; this returns the raw stored page slice."""
+    off, lim = _page_bounds(offset, limit)
+    row = await _get_list(session, company_id, entity_id)
+    total = (await session.execute(
+        text("SELECT COALESCE(json_array_length(state -> 'line_items'), 0) AS total "
+             "FROM projections WHERE company_id = :cid AND entity_id = :eid"),
+        {"cid": str(company_id), "eid": entity_id},
+    )).scalar_one()
+    window = (await session.execute(
+        text("""
+            SELECT (state -> 'line_items') -> gs AS item
+            FROM projections, generate_series(CAST(:lo AS integer), CAST(:hi AS integer)) AS gs
+            WHERE company_id = :cid AND entity_id = :eid
+            ORDER BY gs
+        """),
+        {"lo": off, "hi": off + lim - 1, "cid": str(company_id), "eid": entity_id},
+    )).all()
+    items = [r.item for r in window if r.item is not None]
+    return {"items": items, "total": total, "version": row.version}
+
+
 @lists_router.post("")
 async def create_list(
     payload: ListCreatePayload,

--- a/default_modules/celerp-docs/celerp_docs/routes.py
+++ b/default_modules/celerp-docs/celerp_docs/routes.py
@@ -3839,6 +3839,35 @@ async def _emit_list(session, company_id, entity_id, event_type, data, user, ide
     )
 
 
+def _list_base_where(company_id) -> list:
+    """The company-scoped list projection selector shared by every list read."""
+    return [Projection.company_id == company_id, Projection.entity_type == "list"]
+
+
+def _list_sort_date():
+    """The list's effective sort/window date, matching the Python order issue_date > created_at
+    column > date with the historic [:10] truncation. A list's state carries no date of its own,
+    so the projection's created_at column is the fallback. Written once and reused by the index
+    ORDER BY, the index date_from/date_to bounds, and the page/export ordering."""
+    issue = _func.nullif(_func.substr(Projection.state["issue_date"].as_string(), 1, 10), "")
+    created = _func.substr(_sa.cast(Projection.created_at, _sa.Text), 1, 10)
+    date = _func.nullif(_func.substr(Projection.state["date"].as_string(), 1, 10), "")
+    return _func.coalesce(issue, created, date)
+
+
+def _list_search_where(q: str, *, include_customer_id: bool):
+    """SQL predicate for the free-text list search over ref_id / customer_name (and customer_id for
+    the index, matching its wider Python match; export deliberately omits customer_id)."""
+    ql = f"%{q.lower()}%"
+    clauses = [
+        _func.lower(Projection.state["ref_id"].as_string()).like(ql),
+        _func.lower(Projection.state["customer_name"].as_string()).like(ql),
+    ]
+    if include_customer_id:
+        clauses.append(_func.lower(Projection.state["customer_id"].as_string()).like(ql))
+    return _sa.or_(*clauses)
+
+
 @lists_router.get("")
 async def list_lists(
     list_type: str | None = None,
@@ -3854,42 +3883,42 @@ async def list_lists(
     company_id: str = Depends(get_current_company_id),
     session: AsyncSession = Depends(get_session),
 ) -> dict:
-    rows = (await session.execute(
-        select(Projection).where(Projection.company_id == company_id, Projection.entity_type == "list")
-    )).scalars().all()
-    # Surface the projection's created_at column: a list's state has no date of its own, so without
-    # this the date-window filter/sort below (default last 12 months) silently drops every list while
-    # the count/summary — which ignores dates — still shows them. (Bug: "All issued (3)" but 0 rows.)
+    base_where = _list_base_where(company_id)
+    if list_type:
+        base_where.append(Projection.state["list_type"].as_string() == list_type)
+    if all_issued:
+        base_where.append(Projection.state["status"].as_string().notin_((DRAFT, VOID)))
+    elif status:
+        base_where.append(Projection.state["status"].as_string() == status)
+    if exclude_status:
+        base_where.append(Projection.state["status"].as_string() != exclude_status)
+    if converted_to_type:
+        base_where.append(Projection.state["converted_to_type"].as_string() == converted_to_type)
+    sort_date = _list_sort_date()
+    if date_from:
+        base_where.append(sort_date >= date_from)
+    if date_to:
+        base_where.append(sort_date <= date_to)
+    if q:
+        base_where.append(_list_search_where(q, include_customer_id=True))
+
+    total = (await session.execute(
+        select(_func.count()).select_from(Projection).where(*base_where))).scalar_one()
+    list_q = (
+        select(Projection)
+        .where(*base_where)
+        # Descending newest-first with the unique entity_id tiebreak so equal-date rows have a
+        # total order and OFFSET pagination never skips or duplicates a boundary row.
+        .order_by(sort_date.desc(), Projection.entity_id.desc())
+        .offset(offset)
+    )
+    if limit is not None:
+        list_q = list_q.limit(limit)
+    rows = (await session.execute(list_q)).scalars().all()
     out = [r.state | {"id": r.entity_id,
                       "created_at": (r.created_at.isoformat() if r.created_at is not None
                                      else r.state.get("created_at") or "")}
            for r in rows]
-    if list_type:
-        out = [x for x in out if x.get("list_type") == list_type]
-    if all_issued:
-        out = [x for x in out if x.get("status") not in ("draft", "void")]
-    elif status:
-        out = [x for x in out if x.get("status") == status]
-    if exclude_status:
-        out = [x for x in out if x.get("status") != exclude_status]
-    if converted_to_type:
-        out = [x for x in out if x.get("converted_to_type") == converted_to_type]
-    if date_from:
-        out = [x for x in out if (x.get("issue_date") or x.get("created_at") or x.get("date") or "")[:10] >= date_from]
-    if date_to:
-        out = [x for x in out if (x.get("issue_date") or x.get("created_at") or x.get("date") or "")[:10] <= date_to]
-    if q:
-        ql = q.lower()
-        out = [x for x in out if ql in str(x.get("ref_id") or "").lower()
-               or ql in str(x.get("customer_name") or x.get("customer_id") or "").lower()]
-    # Tiebreak on the unique id so equal-date rows have a deterministic order (else OFFSET
-    # pagination can skip/duplicate a boundary row — same fix as list_docs).
-    out.sort(key=lambda x: (x.get("issue_date") or x.get("created_at") or x.get("date") or "", x.get("id") or ""), reverse=True)
-    total = len(out)
-    if offset:
-        out = out[offset:]
-    if limit is not None:
-        out = out[:limit]
     return {"items": out, "total": total}
 
 

--- a/default_modules/celerp-docs/celerp_docs/routes.py
+++ b/default_modules/celerp-docs/celerp_docs/routes.py
@@ -4068,9 +4068,11 @@ async def get_list_page(
     company_id: str = Depends(get_current_company_id),
     session: AsyncSession = Depends(get_session),
 ) -> dict:
-    """One bounded page of a list's line_items read in SQL: json_array_length for the total and a
-    positional json subscript over generate_series for the window, so a large list is never expanded
-    into Python. Metadata enrichment stays in the UI layer; this returns the raw stored page slice."""
+    """The list header (stored state without line_items) plus one bounded page of line_items and the
+    total. The page is read in SQL: json_array_length for the total and a positional json subscript
+    over generate_series for the window, so a large list is never expanded into Python. The header
+    lets the detail view render from this one call; metadata enrichment stays in the UI layer, over
+    the returned page slice."""
     off, lim = _page_bounds(offset, limit)
     row = await _get_list(session, company_id, entity_id)
     total = (await session.execute(
@@ -4088,7 +4090,10 @@ async def get_list_page(
         {"lo": off, "hi": off + lim - 1, "cid": str(company_id), "eid": entity_id},
     )).all()
     items = [r.item for r in window if r.item is not None]
-    return {"items": items, "total": total, "version": row.version}
+    header = {k: v for k, v in row.state.items() if k != "line_items"}
+    header["id"] = row.entity_id
+    header["version"] = row.version
+    return {"list": header, "items": items, "total": total, "version": row.version}
 
 
 @lists_router.post("")

--- a/default_modules/celerp-docs/celerp_docs/routes.py
+++ b/default_modules/celerp-docs/celerp_docs/routes.py
@@ -4303,6 +4303,15 @@ async def patch_list_line_page(
         original_count = len(page)
     elif original_count < 0:
         raise HTTPException(status_code=400, detail="original_count must be zero or greater")
+    elif original_count > _PAGE_LIMIT_MAX:
+        # A page fetch returns at most _PAGE_LIMIT_MAX rows, so the client can never have loaded a
+        # window wider than that. A claimed original_count above the cap - even one that still fits
+        # inside the stored array - is a forged window that would splice away rows beyond the page the
+        # client actually read (150 stored, offset 0, original_count 149, a one-row page fits the
+        # array yet collapses 148 unseen rows). Reject rather than mutate rows the client never loaded.
+        raise HTTPException(
+            status_code=400,
+            detail=f"original_count cannot exceed the {_PAGE_LIMIT_MAX}-line page limit")
     # The loaded window [offset:offset+original_count] must lie within the stored array: it is the
     # exact slice the client read, so it can neither start past the end nor run beyond it. A larger
     # claimed window would splice away tail rows the client never loaded and cannot have edited

--- a/default_modules/celerp-docs/celerp_docs/routes.py
+++ b/default_modules/celerp-docs/celerp_docs/routes.py
@@ -4271,9 +4271,12 @@ async def patch_list_line_page(
 ) -> dict:
     """Save one page of a list's lines without scraping or re-sending the whole array. Under the same
     row lock and optimistic-version guard as a full save, the submitted page REPLACES the stored
-    window [offset:offset+original_count] the client originally loaded: a shorter page truncates
-    (deletes) tail rows, a longer one inserts, off-window rows are left byte-identical and totals are
-    recomputed from the full merged array."""
+    window [offset:offset+original_count] the client originally loaded. Relative to that window a
+    shorter page truncates (deletes) tail rows and a longer one inserts; off-window rows are left
+    byte-identical and totals are recomputed from the full merged array. Omitting original_count means
+    the window is exactly the submitted page's own length (a pure in-place replace that never drops
+    off-window rows), so a delete or insert must carry the loaded window length, which the editor
+    always sends."""
     row = await _get_list_for_update(session, company_id, entity_id)
     if row.state.get("status") != "draft":
         raise HTTPException(status_code=409, detail="Cannot edit non-draft list")
@@ -4291,12 +4294,13 @@ async def patch_list_line_page(
     if offset < 0:
         raise HTTPException(status_code=400, detail="offset must be zero or greater")
     # The window the client loaded is [offset:offset+original_count]; the page replaces exactly it.
-    # Omitting original_count means the page covers the whole stored tail from offset onward, so a
-    # bare {page, offset} save that carries fewer rows still truncates instead of inserting a
-    # duplicate copy ahead of the untouched original.
+    # When original_count is omitted the window is the submitted page's own length, so a bare
+    # {page, offset} save is a pure in-place replace that leaves every off-window row intact. A
+    # delete or insert changes the window size and so must send original_count (the editor does); the
+    # UI proxy applies the same len(page) default, keeping the two layers in lockstep.
     original_count = payload.original_count
     if original_count is None:
-        original_count = max(0, len(stored) - offset)
+        original_count = len(page)
     elif original_count < 0:
         raise HTTPException(status_code=400, detail="original_count must be zero or greater")
     # A submitted row carrying an id must land on the position holding that same id: this catches a

--- a/default_modules/celerp-docs/celerp_docs/routes.py
+++ b/default_modules/celerp-docs/celerp_docs/routes.py
@@ -3927,34 +3927,50 @@ async def get_list_summary(
     company_id: str = Depends(get_current_company_id),
     session: AsyncSession = Depends(get_session),
 ) -> dict:
-    rows = (await session.execute(
-        select(Projection).where(Projection.company_id == company_id, Projection.entity_type == "list")
-    )).scalars().all()
+    base_where = _list_base_where(company_id)
+    status_expr = _func.coalesce(Projection.state["status"].as_string(), "")
+    # One grouped pass over the projection: a bounded histogram (one row per status), with the
+    # value sum carried per group so total_value is derived without a second scan. total is text
+    # in the json state, so cast the ->> output to numeric - never a jsonb cast.
+    total_num = _sa.cast(
+        _func.nullif(Projection.state["total"].as_string(), ""), _sa.Numeric)
+    grouped = (await session.execute(
+        select(status_expr,
+               _func.count(),
+               _func.coalesce(_func.sum(total_num), 0))
+        .where(*base_where)
+        .group_by(status_expr)
+    )).all()
     count_by_status: dict[str, int] = {}
+    total_count = 0
     total_value = 0.0
-    converted_to_memo_count = 0
-    converted_to_invoice_count = 0
-    for row in rows:
-        st = row.state.get("status", "")
-        count_by_status[st] = count_by_status.get(st, 0) + 1
+    for st, n, value_sum in grouped:
+        count_by_status[st] = n
+        total_count += n
         if st != VOID:
-            total_value += float(row.state.get("total", 0) or 0)
-        if st == CLOSED and row.state.get("result") == "converted":
-            ctt = row.state.get("converted_to_type") or ""
-            if ctt == "memo":
-                converted_to_memo_count += 1
-            elif ctt == "invoice":
-                converted_to_invoice_count += 1
+            total_value += float(value_sum or 0)
     draft_count = count_by_status.get(DRAFT, 0)
-    void_count = count_by_status.get(VOID, 0)
     all_issued_count = sum(v for k, v in count_by_status.items() if k not in (DRAFT, VOID))
+
+    # Converted outcomes: closed lists whose result is a conversion, split by target type.
+    converted_where = base_where + [
+        status_expr == CLOSED,
+        Projection.state["result"].as_string() == "converted",
+    ]
+    ctt_expr = Projection.state["converted_to_type"].as_string()
+    converted_rows = (await session.execute(
+        select(ctt_expr, _func.count())
+        .where(*converted_where)
+        .group_by(ctt_expr)
+    )).all()
+    converted_by_type = {ctt: n for ctt, n in converted_rows}
     return {
-        "total_count": len(rows),
+        "total_count": total_count,
         "draft_count": draft_count,
         "all_issued_count": all_issued_count,
         "total_value": total_value,
-        "converted_to_memo_count": converted_to_memo_count,
-        "converted_to_invoice_count": converted_to_invoice_count,
+        "converted_to_memo_count": converted_by_type.get("memo", 0),
+        "converted_to_invoice_count": converted_by_type.get("invoice", 0),
         "count_by_status": count_by_status,
     }
 

--- a/default_modules/celerp-docs/celerp_docs/routes.py
+++ b/default_modules/celerp-docs/celerp_docs/routes.py
@@ -3904,8 +3904,31 @@ async def list_lists(
 
     total = (await session.execute(
         select(_func.count()).select_from(Projection).where(*base_where))).scalar_one()
+    # The index table needs only the header fields plus a line count and total weight; it never shows
+    # individual lines. Push the count and weight sum into SQL and select the header columns alone, so
+    # a list with thousands of lines never drags its whole line_items array back into Python here.
+    item_count = _func.coalesce(_func.json_array_length(Projection.state["line_items"]), 0)
+    weight_sum = _sa.literal_column(
+        "(SELECT COALESCE(SUM(COALESCE("
+        "NULLIF(elem ->> 'weight_ct', '')::numeric, NULLIF(elem ->> 'weight', '')::numeric, 0)), 0) "
+        "FROM json_array_elements(projections.state -> 'line_items') AS elem)"
+    )
     list_q = (
-        select(Projection)
+        select(
+            Projection.entity_id,
+            Projection.created_at,
+            Projection.state["ref_id"].as_string().label("ref_id"),
+            Projection.state["list_type"].as_string().label("list_type"),
+            Projection.state["customer_name"].as_string().label("customer_name"),
+            Projection.state["receiver"].as_string().label("receiver"),
+            Projection.state["customer_id"].as_string().label("customer_id"),
+            Projection.state["date"].as_string().label("date"),
+            Projection.state["total"].as_string().label("total"),
+            Projection.state["status"].as_string().label("status"),
+            Projection.state["created_at"].as_string().label("state_created_at"),
+            item_count.label("item_count"),
+            weight_sum.label("total_weight"),
+        )
         .where(*base_where)
         # Descending newest-first with the unique entity_id tiebreak so equal-date rows have a
         # total order and OFFSET pagination never skips or duplicates a boundary row.
@@ -3914,11 +3937,22 @@ async def list_lists(
     )
     if limit is not None:
         list_q = list_q.limit(limit)
-    rows = (await session.execute(list_q)).scalars().all()
-    out = [r.state | {"id": r.entity_id,
-                      "created_at": (r.created_at.isoformat() if r.created_at is not None
-                                     else r.state.get("created_at") or "")}
-           for r in rows]
+    rows = (await session.execute(list_q)).all()
+    out = [{
+        "id": r.entity_id,
+        "created_at": (r.created_at.isoformat() if r.created_at is not None
+                       else r.state_created_at or ""),
+        "ref_id": r.ref_id,
+        "list_type": r.list_type,
+        "customer_name": r.customer_name,
+        "receiver": r.receiver,
+        "customer_id": r.customer_id,
+        "date": r.date,
+        "total": r.total,
+        "status": r.status,
+        "item_count": r.item_count,
+        "total_weight": float(r.total_weight or 0),
+    } for r in rows]
     return {"items": out, "total": total}
 
 
@@ -4002,21 +4036,25 @@ async def export_lists_csv(
         yield header.getvalue()
         batch = 500
         offset = 0
+        # Select only the seven columns the CSV emits, straight from the json state, so a list's whole
+        # line_items array is never deserialized just to write its header row.
+        col_exprs = [Projection.entity_id.label("id")] + [
+            Projection.state[c].as_string().label(c) for c in _COLS if c != "id"
+        ]
         while True:
             rows = (await session.execute(
-                select(Projection)
+                select(*col_exprs)
                 .where(*base_where)
                 .order_by(Projection.entity_id.desc())
                 .offset(offset)
                 .limit(batch)
-            )).scalars().all()
+            )).all()
             if not rows:
                 break
             buf = io.StringIO()
             w = csv.DictWriter(buf, fieldnames=_COLS, extrasaction="ignore")
             for r in rows:
-                d = r.state | {"id": r.entity_id}
-                w.writerow({c: d.get(c, "") for c in _COLS})
+                w.writerow({c: (getattr(r, c) or "") for c in _COLS})
             yield buf.getvalue()
             if len(rows) < batch:
                 break
@@ -4068,18 +4106,25 @@ async def get_list_page(
     company_id: str = Depends(get_current_company_id),
     session: AsyncSession = Depends(get_session),
 ) -> dict:
-    """The list header (stored state without line_items) plus one bounded page of line_items and the
-    total. The page is read in SQL: json_array_length for the total and a positional json subscript
-    over generate_series for the window, so a large list is never expanded into Python. The header
-    lets the detail view render from this one call; metadata enrichment stays in the UI layer, over
-    the returned page slice."""
+    """The list header (stored state without line_items), one bounded page of line_items, the total,
+    and enriched item metadata for exactly the page's ids. Everything is read in bounded SQL: the
+    header is `state - line_items` (never the whole document row), the total is json_array_length, the
+    window is a positional json subscript over generate_series, and item_meta joins the page's catalog
+    items only. The detail view renders the page and enriches it from this one call, so a large list
+    is never expanded into Python and no follow-up metadata round-trip is needed."""
     off, lim = _page_bounds(offset, limit)
-    row = await _get_list(session, company_id, entity_id)
-    total = (await session.execute(
-        text("SELECT COALESCE(json_array_length(state -> 'line_items'), 0) AS total "
-             "FROM projections WHERE company_id = :cid AND entity_id = :eid"),
+    # Header, version and total in ONE bounded read: the header is the stored state with line_items
+    # stripped in SQL, so the whole line array is never dragged back into Python on a page request.
+    head = (await session.execute(
+        text("SELECT state::jsonb - 'line_items' AS header, version, "
+             "COALESCE(json_array_length(state -> 'line_items'), 0) AS total "
+             "FROM projections "
+             "WHERE company_id = :cid AND entity_id = :eid AND entity_type = 'list'"),
         {"cid": str(company_id), "eid": entity_id},
-    )).scalar_one()
+    )).first()
+    if head is None:
+        raise HTTPException(status_code=404, detail="List not found")
+    total = head.total
     window = (await session.execute(
         text("""
             SELECT (state -> 'line_items') -> gs AS item
@@ -4090,10 +4135,42 @@ async def get_list_page(
         {"lo": off, "hi": off + lim - 1, "cid": str(company_id), "eid": entity_id},
     )).all()
     items = [r.item for r in window if r.item is not None]
-    header = {k: v for k, v in row.state.items() if k != "line_items"}
-    header["id"] = row.entity_id
-    header["version"] = row.version
-    return {"list": header, "items": items, "total": total, "version": row.version}
+    header = dict(head.header or {})
+    header["id"] = entity_id
+    header["version"] = head.version
+    item_meta = await _page_item_meta(session, company_id, items)
+    return {"list": header, "items": items, "total": total, "version": head.version,
+            "item_meta": item_meta}
+
+
+async def _page_item_meta(session: AsyncSession, company_id, page_items: list[dict]) -> dict:
+    """Catalog metadata for exactly the ids on this page, keyed by entity_id: the flattened item state
+    (attributes lifted to the top level, matching the bulk item-metadata shape) the detail view enriches
+    each line with (measures, on-hand, item status). Off-page lines are never touched. A page with no
+    catalog-backed lines returns an empty map, and the UI degrades to each line's stored values."""
+    ids = list(dict.fromkeys(
+        (li.get("item_id") or li.get("entity_id"))
+        for li in page_items
+        if (li.get("item_id") or li.get("entity_id"))
+    ))
+    if not ids:
+        return {}
+    rows = (await session.execute(
+        select(Projection.entity_id, Projection.state)
+        .where(Projection.company_id == company_id,
+               Projection.entity_type == "item",
+               Projection.entity_id.in_(ids))
+    )).all()
+    meta: dict = {}
+    for eid, state in rows:
+        flat = dict(state or {})
+        # Lift attributes.* to the top level so item_measure_meta reads pieces and friends directly,
+        # exactly as the bulk item-metadata read does; never overwrite a core field.
+        for k, v in (flat.pop("attributes", None) or {}).items():
+            flat.setdefault(k, v)
+        flat["id"] = eid
+        meta[eid] = flat
+    return meta
 
 
 @lists_router.post("")
@@ -4174,6 +4251,7 @@ async def patch_list(
 class ListLinePagePatch(BaseModel):
     line_items: list[dict] = Field(default_factory=list)
     offset: int = 0
+    original_count: int | None = None
     expected_version: int | None = None
 
 
@@ -4192,9 +4270,10 @@ async def patch_list_line_page(
     session: AsyncSession = Depends(get_session),
 ) -> dict:
     """Save one page of a list's lines without scraping or re-sending the whole array. Under the same
-    row lock and optimistic-version guard as a full save, the submitted page overwrites stored
-    positions [offset:offset+len(page)] by position; off-page rows are left byte-identical and totals
-    are recomputed from the full merged array."""
+    row lock and optimistic-version guard as a full save, the submitted page REPLACES the stored
+    window [offset:offset+original_count] the client originally loaded: a shorter page truncates
+    (deletes) tail rows, a longer one inserts, off-window rows are left byte-identical and totals are
+    recomputed from the full merged array."""
     row = await _get_list_for_update(session, company_id, entity_id)
     if row.state.get("status") != "draft":
         raise HTTPException(status_code=409, detail="Cannot edit non-draft list")
@@ -4204,11 +4283,22 @@ async def patch_list_line_page(
         raise HTTPException(status_code=409, detail="This list was changed by someone else; reload to get the latest before saving")
 
     page = payload.line_items
+    if len(page) > _PAGE_LIMIT_MAX:
+        raise HTTPException(status_code=400, detail=f"A saved page cannot exceed {_PAGE_LIMIT_MAX} lines")
     _normalize_line_item_ids(page)
     stored = list(row.state.get("line_items") or [])
     offset = payload.offset
     if offset < 0:
         raise HTTPException(status_code=400, detail="offset must be zero or greater")
+    # The window the client loaded is [offset:offset+original_count]; the page replaces exactly it.
+    # Omitting original_count means the page covers the whole stored tail from offset onward, so a
+    # bare {page, offset} save that carries fewer rows still truncates instead of inserting a
+    # duplicate copy ahead of the untouched original.
+    original_count = payload.original_count
+    if original_count is None:
+        original_count = max(0, len(stored) - offset)
+    elif original_count < 0:
+        raise HTTPException(status_code=400, detail="original_count must be zero or greater")
     # A submitted row carrying an id must land on the position holding that same id: this catches a
     # page saved against a shifted array. Free-text rows carry no id and overwrite by position.
     for i, incoming in enumerate(page):
@@ -4221,13 +4311,16 @@ async def patch_list_line_page(
                     status_code=409,
                     detail="This list was changed by someone else; reload to get the latest before saving")
 
-    merged = stored[:]
-    for i, incoming in enumerate(page):
-        pos = offset + i
-        if pos < len(merged):
-            merged[pos] = incoming
-        else:
-            merged.append(incoming)
+    # A draft item is not stock and must never reach a list, on this path as on the full save.
+    _existing = {_line_identity(li) for li in stored}
+    await _assert_no_draft_items(
+        session, company_id,
+        {_line_identity(li) for li in page} - _existing,
+    )
+
+    # Slice-splice: replace exactly the originally-loaded window. A shorter page truncates, a longer
+    # one inserts; positional overwrite/append could never delete a tail row.
+    merged = stored[:offset] + list(page) + stored[offset + original_count:]
 
     entry = await _emit_list(
         session, company_id, entity_id, "list.updated",

--- a/default_modules/celerp-docs/tests/test_line_page_patch_truncate.py
+++ b/default_modules/celerp-docs/tests/test_line_page_patch_truncate.py
@@ -132,3 +132,75 @@ async def test_line_page_patch_rejects_draft_item(client):
         assert 400 <= r.status_code < 500, r.text
         assert after == before, "a rejected draft save must write nothing"
         assert draft_item not in _ids(after)
+
+
+@pytest.mark.asyncio
+async def test_line_page_patch_deletes_middle_row(client):
+    """Delete a row in the MIDDLE of the covered window. After the delete the surviving
+    tail rows shift up one position, so the incoming page no longer sits id-for-id over
+    the stored rows: incoming[1] carries item:2 while stored[1] still holds item:2's
+    old neighbour item:1. A positional id comparison reads that legitimate shift as a
+    concurrent edit and rejects the save 409; the slice-splice must accept it, because
+    the window it replaces is the whole loaded slice, not a row-by-row overwrite.
+
+    Observable: the save succeeds and the persisted array is exactly the post-delete
+    set, read back through the real API - never a status-code-only assertion."""
+    t = await _register(client)
+    q = await _quotation(client, t)
+    lines = [{"item_id": f"item:{i}", "sku": f"SKU{i}", "description": f"Item {i}",
+              "quantity": 1, "unit_price": 1.0} for i in range(3)]
+    v = await _set_lines(client, t, q, lines)
+    before = (await _state(client, t, q))["line_items"]
+    assert len(before) == 3
+
+    # The user deletes item:1 (the middle row). The editor resubmits the surviving rows
+    # [item:0, item:2] and the loaded window length (original_count == 3).
+    page = [dict(before[0]), dict(before[2])]
+    r = await client.patch(f"/lists/{q}/line-page", headers=_h(t),
+                           json={"line_items": page, "offset": 0,
+                                 "original_count": len(before), "expected_version": v})
+    assert r.status_code == 200, (
+        f"deleting a middle row is a legitimate edit within the loaded window, not a "
+        f"concurrent-edit conflict; got {r.status_code}: {r.text}")
+
+    after = (await _state(client, t, q))["line_items"]
+    assert _ids(after) == ["item:0", "item:2"], (
+        f"the persisted array must be exactly the post-delete set; got {_ids(after)}")
+    assert "item:1" not in _ids(after), "the deleted middle row's identity must be gone"
+
+
+@pytest.mark.asyncio
+async def test_line_page_patch_window_cannot_exceed_loaded_array(client):
+    """original_count is the length of the window the client loaded, so it can never
+    reach past the end of the stored array. A page that claims a window running beyond
+    len(stored) would splice away rows the client never loaded and cannot have edited.
+
+    Prod hazard: offset 0 + a large original_count + a one-row page collapses the whole
+    list to that single row. The write must be rejected, or at worst leave the
+    off-window rows intact - it must NEVER silently drop rows past the loaded window.
+
+    Observable: the rows beyond the claimed window survive, read back through the real
+    API."""
+    t = await _register(client)
+    q = await _quotation(client, t)
+    lines = [{"item_id": f"item:{i}", "sku": f"SKU{i}", "description": f"Item {i}",
+              "quantity": 1, "unit_price": 1.0} for i in range(3)]
+    v = await _set_lines(client, t, q, lines)
+    before = (await _state(client, t, q))["line_items"]
+    assert len(before) == 3
+
+    # A window that claims to cover 999 rows starting at 0, replaced by a single row.
+    page = [dict(before[0])]
+    r = await client.patch(f"/lists/{q}/line-page", headers=_h(t),
+                           json={"line_items": page, "offset": 0,
+                                 "original_count": 999, "expected_version": v})
+
+    after = (await _state(client, t, q))["line_items"]
+    if r.status_code == 200:
+        assert _ids(after) == ["item:0", "item:1", "item:2"], (
+            f"a window past the loaded array must not drop rows the client never "
+            f"loaded; persisted identities were {_ids(after)}")
+    else:
+        assert 400 <= r.status_code < 500, r.text
+        assert after == before, (
+            f"a rejected over-wide window must write nothing; got {_ids(after)}")

--- a/default_modules/celerp-docs/tests/test_line_page_patch_truncate.py
+++ b/default_modules/celerp-docs/tests/test_line_page_patch_truncate.py
@@ -75,11 +75,13 @@ async def test_line_page_patch_truncates_on_shorter_page(client):
     before = (await _state(client, t, q))["line_items"]
     assert len(before) == 3
 
-    # The whole list is one page; the user deletes item:2 (the tail). The autosave
-    # resubmits the page as the surviving rows only: [item:0, item:1].
+    # The whole list is one page; the user deletes item:2 (the tail). The autosave resubmits the
+    # surviving rows [item:0, item:1] and, as the real editor does, the length of the window it
+    # loaded (original_count == 3) so the server knows the page shrank by one and truncates the tail.
     page = [dict(before[0]), dict(before[1])]
     r = await client.patch(f"/lists/{q}/line-page", headers=_h(t),
-                           json={"line_items": page, "offset": 0, "expected_version": v})
+                           json={"line_items": page, "offset": 0,
+                                 "original_count": len(before), "expected_version": v})
     assert r.status_code == 200, r.text
 
     after = (await _state(client, t, q))["line_items"]

--- a/default_modules/celerp-docs/tests/test_line_page_patch_truncate.py
+++ b/default_modules/celerp-docs/tests/test_line_page_patch_truncate.py
@@ -204,3 +204,42 @@ async def test_line_page_patch_window_cannot_exceed_loaded_array(client):
         assert 400 <= r.status_code < 500, r.text
         assert after == before, (
             f"a rejected over-wide window must write nothing; got {_ids(after)}")
+
+
+@pytest.mark.asyncio
+async def test_line_page_patch_window_cannot_exceed_page_limit(client):
+    """A page fetch returns at most the page cap (100 rows), so the client can never have
+    loaded a window wider than that. A claimed original_count above the cap - even one that
+    still fits INSIDE the stored array - is a forged window that would splice away rows
+    beyond the page the client actually read.
+
+    Prod hazard the end-of-array bounds check misses: 150 stored rows, offset 0,
+    original_count 149, a one-row page. The window fits the array (149 <= 150) so a pure
+    bounds check lets it through, and the splice collapses 148 rows the client could never
+    have loaded. The write must be rejected and every off-page row must survive.
+
+    Observable: all 150 rows survive, read back through the real API."""
+    t = await _register(client)
+    q = await _quotation(client, t)
+    lines = [{"item_id": f"item:{i}", "sku": f"SKU{i}", "description": f"Item {i}",
+              "quantity": 1, "unit_price": 1.0} for i in range(150)]
+    v = await _set_lines(client, t, q, lines)
+    before = (await _state(client, t, q))["line_items"]
+    assert len(before) == 150
+
+    # A window claiming 149 loaded rows - well past the 100-row page cap - replaced by one row.
+    # 149 <= 150, so the end-of-array bounds check alone would accept this and drop 148 rows.
+    page = [dict(before[0])]
+    r = await client.patch(f"/lists/{q}/line-page", headers=_h(t),
+                           json={"line_items": page, "offset": 0,
+                                 "original_count": 149, "expected_version": v})
+
+    after = (await _state(client, t, q))["line_items"]
+    if r.status_code == 200:
+        assert len(after) == 150, (
+            f"a window wider than the 100-row page cap must not drop rows the client never "
+            f"loaded; persisted {len(after)} rows, identities {_ids(after)}")
+    else:
+        assert 400 <= r.status_code < 500, r.text
+        assert _ids(after) == _ids(before), (
+            f"a rejected over-wide window must write nothing; persisted {len(after)} rows")

--- a/default_modules/celerp-docs/tests/test_line_page_patch_truncate.py
+++ b/default_modules/celerp-docs/tests/test_line_page_patch_truncate.py
@@ -1,0 +1,132 @@
+# Copyright (c) 2026 Noah Severs
+# SPDX-License-Identifier: MIT
+"""Line-page PATCH must be a slice-splice, not a positional overwrite/append.
+
+Prod incident: deleting a line inside a page (the incoming page carries fewer rows
+than the stored window it covers) left the tail rows intact - the server overwrote
+by position and never truncated, so deleted lines came back as phantom rows on
+reload. The line-page path also skipped the draft-item guard the full save applies,
+so a draft item could be smuggled onto a list through it.
+
+These assert the observable persisted line_items after the write, read back through
+the real API - never a SQL surface property."""
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+
+async def _register(client) -> str:
+    addr = f"admin-{uuid.uuid4().hex[:8]}@lptrunc.test"
+    r = await client.post("/auth/register", json={
+        "company_name": "LinePage Co", "email": addr, "name": "A", "password": "pw"})
+    assert r.status_code == 200, r.text
+    return r.json()["access_token"]
+
+
+def _h(t):
+    return {"Authorization": f"Bearer {t}"}
+
+
+async def _quotation(client, t) -> str:
+    r = await client.post("/lists", headers=_h(t), json={"list_type": "quotation"})
+    assert r.status_code == 200, r.text
+    return r.json()["id"]
+
+
+async def _state(client, t, list_id) -> dict:
+    return (await client.get(f"/lists/{list_id}", headers=_h(t))).json()
+
+
+async def _version(client, t, list_id) -> int:
+    return (await client.get(f"/lists/{list_id}", headers=_h(t))).json()["version"]
+
+
+async def _set_lines(client, t, list_id, lines: list[dict]) -> int:
+    """Replace the whole line_items array (mandatory version pin) and return the new version."""
+    v = await _version(client, t, list_id)
+    r = await client.patch(f"/lists/{list_id}", headers=_h(t),
+                           json={"fields_changed": {"line_items": {"new": lines}},
+                                 "expected_version": v})
+    assert r.status_code == 200, r.text
+    return r.json()["version"]
+
+
+def _ids(lines: list[dict]) -> list[str | None]:
+    """The stable identity server-side uses for each line (item_id or entity_id)."""
+    return [(li.get("item_id") or li.get("entity_id")) for li in lines]
+
+
+@pytest.mark.asyncio
+async def test_line_page_patch_truncates_on_shorter_page(client):
+    """Delete the tail row of the covered window: the incoming page carries one FEWER
+    row than the stored positions [offset:offset+len(window)] it represents. The
+    persisted array must shrink by one and the deleted row's identity must be gone.
+
+    The delete drops the LAST id-bearing row of the window so the surviving rows stay
+    positionally aligned (no id-mismatch 409 fires); the red is purely the truncation
+    behaviour, not a schema or version error."""
+    t = await _register(client)
+    q = await _quotation(client, t)
+    lines = [{"item_id": f"item:{i}", "sku": f"SKU{i}", "description": f"Item {i}",
+              "quantity": 1, "unit_price": 1.0} for i in range(3)]
+    v = await _set_lines(client, t, q, lines)
+    before = (await _state(client, t, q))["line_items"]
+    assert len(before) == 3
+
+    # The whole list is one page; the user deletes item:2 (the tail). The autosave
+    # resubmits the page as the surviving rows only: [item:0, item:1].
+    page = [dict(before[0]), dict(before[1])]
+    r = await client.patch(f"/lists/{q}/line-page", headers=_h(t),
+                           json={"line_items": page, "offset": 0, "expected_version": v})
+    assert r.status_code == 200, r.text
+
+    after = (await _state(client, t, q))["line_items"]
+    assert len(after) == 2, (
+        f"deleting a line must shrink the persisted array to 2, got {len(after)}; "
+        f"identities {_ids(after)} (the deleted item:2 survived as a phantom row)")
+    assert _ids(after) == ["item:0", "item:1"], (
+        f"surviving rows must be exactly the post-delete set; got {_ids(after)}")
+    assert "item:2" not in _ids(after), "the deleted row's identity must be gone"
+
+
+@pytest.mark.asyncio
+async def test_line_page_patch_rejects_draft_item(client):
+    """A line-page PATCH whose page carries a DRAFT item must not land that item on the
+    list (the full save applies the draft-item guard; the line-page path must too).
+    Observable: the draft's identity is absent from the persisted list, or the request
+    is rejected 4xx and writes nothing."""
+    t = await _register(client)
+    q = await _quotation(client, t)
+
+    # One real (available) starter line so the list has a stored window to patch.
+    ok_item = (await client.post("/items", headers=_h(t), json={
+        "status": "available", "sku": "OK-1", "name": "Widget",
+        "quantity": 5, "sell_by": "piece"})).json()["id"]
+    starter = {"item_id": ok_item, "sku": "OK-1", "description": "Widget",
+               "quantity": 1, "unit_price": 10.0}
+    v = await _set_lines(client, t, q, [starter])
+
+    # A genuine DRAFT item: it is not stock yet and must never reach a list.
+    draft_item = (await client.post("/items", headers=_h(t), json={
+        "status": "draft", "sku": "DRAFT-1", "name": "Unfinished",
+        "quantity": 0, "sell_by": "piece"})).json()["id"]
+
+    before = (await _state(client, t, q))["line_items"]
+    # Save a page that appends the draft line onto the list.
+    page = [dict(before[0]),
+            {"item_id": draft_item, "sku": "DRAFT-1", "description": "Unfinished",
+             "quantity": 1, "unit_price": 10.0}]
+    r = await client.patch(f"/lists/{q}/line-page", headers=_h(t),
+                           json={"line_items": page, "offset": 0, "expected_version": v})
+
+    after = (await _state(client, t, q))["line_items"]
+    if r.status_code == 200:
+        assert draft_item not in _ids(after), (
+            f"a draft item must never persist on a list via the line-page path; "
+            f"persisted identities were {_ids(after)}")
+    else:
+        assert 400 <= r.status_code < 500, r.text
+        assert after == before, "a rejected draft save must write nothing"
+        assert draft_item not in _ids(after)

--- a/default_modules/celerp-docs/tests/test_list_page_no_full_state.py
+++ b/default_modules/celerp-docs/tests/test_list_page_no_full_state.py
@@ -1,0 +1,151 @@
+# Copyright (c) 2026 Noah Severs
+# SPDX-License-Identifier: MIT
+"""Regression: the paged-read hot path must not materialize the whole list document.
+
+`GET /lists/{id}/page` returns a small window of line_items. It must obtain the
+header/version/total via bounded SQL only. If it also does a by-primary-key fetch of
+the projection row (SQLAlchemy `session.get(Projection, pk)`), it drags the entire
+`state` JSON (every line_item) back into Python on every page request, which is the
+wasted DB round-trip this test pins out of existence.
+
+The observable behavior asserted is DB TRAFFIC: during one small-page request against
+a large list we capture every SQL statement executed on the engine and assert that the
+unbounded by-PK full-row fetch of the projection (the SELECT whose select-list carries
+the raw `projections.state` column for this list's entity_id) is ABSENT. The bounded
+window/total queries (which reference `state -> ...` / `json_array_length`, never the
+bare `state` column) may be present.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import re
+import uuid
+
+import pytest
+from sqlalchemy import event
+from sqlalchemy.engine import Engine
+
+
+# ── helpers (mirror test_list_query_pushdown conventions) ──────────────────────
+
+async def _register(client) -> str:
+    addr = f"admin-{uuid.uuid4().hex[:8]}@nofullstate.test"
+    r = await client.post("/auth/register", json={
+        "company_name": "No Full State Co", "email": addr, "name": "A", "password": "pw"})
+    assert r.status_code == 200, r.text
+    return r.json()["access_token"]
+
+
+def _h(t):
+    return {"Authorization": f"Bearer {t}"}
+
+
+async def _quotation(client, t) -> str:
+    r = await client.post("/lists", headers=_h(t), json={"list_type": "quotation"})
+    assert r.status_code == 200, r.text
+    return r.json()["id"]
+
+
+def _lines(n: int) -> list[dict]:
+    return [{"item_id": f"item:{i}", "sku": f"SKU{i}", "description": f"Item {i}",
+             "quantity": 1, "unit_price": 1.0} for i in range(n)]
+
+
+async def _set_lines(client, t, list_id, lines: list[dict]) -> int:
+    v = (await client.get(f"/lists/{list_id}", headers=_h(t))).json()["version"]
+    r = await client.patch(f"/lists/{list_id}", headers=_h(t),
+                           json={"fields_changed": {"line_items": {"new": lines}},
+                                 "expected_version": v})
+    assert r.status_code == 200, r.text
+    return r.json()["version"]
+
+
+@contextlib.contextmanager
+def _sql_spy():
+    """Capture (statement, parameters) for every SQL statement executed on any engine
+    during the block. Attaches to the Engine class so it catches the sync engine backing
+    the async one, exactly as the pushdown tests do; this is the honest DB-traffic probe
+    (a before_cursor_execute listener), not a monkeypatch of any application function."""
+    captured: list[tuple[str, object]] = []
+
+    def _before(conn, cursor, statement, parameters, context, executemany):
+        captured.append((statement, parameters))
+
+    event.listen(Engine, "before_cursor_execute", _before)
+    try:
+        yield captured
+    finally:
+        event.remove(Engine, "before_cursor_execute", _before)
+
+
+# The select-list of `session.get(Projection, pk)` carries the raw projection columns,
+# among them the bare `projections.state` column. The bounded page queries never place
+# the bare state column in their select list (they select json_array_length(...) and a
+# positional subscript over state -> 'line_items'). So "a SELECT whose select-list, up to
+# its FROM clause, contains the bare projections.state column reference" is precisely the
+# full-document fetch being removed.
+_BARE_STATE_COL = re.compile(r"\bprojections\.state\b")
+
+
+def _full_state_fetches(captured, entity_id: str) -> list[str]:
+    """The captured statements that are a by-PK full-row read of the projection: a SELECT
+    over the projections table whose select-list (text before FROM) contains the bare
+    projections.state column, scoped to this list's entity_id in its parameters."""
+    hits: list[str] = []
+    for statement, parameters in captured:
+        low = statement.lower()
+        if not low.lstrip().startswith("select"):
+            continue
+        if "from projections" not in low:
+            continue
+        select_list = statement[:low.index("from projections")]
+        if not _BARE_STATE_COL.search(select_list):
+            continue
+        # This list's row is the target: the entity_id appears in the bound parameters.
+        flat = _param_values(parameters)
+        if any(entity_id == v for v in flat):
+            hits.append(statement)
+    return hits
+
+
+def _param_values(parameters) -> list:
+    if parameters is None:
+        return []
+    if isinstance(parameters, dict):
+        return list(parameters.values())
+    if isinstance(parameters, (list, tuple)):
+        out = []
+        for p in parameters:
+            if isinstance(p, dict):
+                out.extend(p.values())
+            elif isinstance(p, (list, tuple)):
+                out.extend(p)
+            else:
+                out.append(p)
+        return out
+    return [parameters]
+
+
+@pytest.mark.asyncio
+async def test_get_list_page_issues_no_full_state_query_on_large_list(client):
+    """A small page of a large list must not trigger a by-PK fetch of the whole projection
+    state row. Behavioral proof: the page request's captured DB traffic contains no
+    unbounded full-`state` SELECT for the target list id (the wasted round-trip)."""
+    t = await _register(client)
+    q = await _quotation(client, t)
+    await _set_lines(client, t, q, _lines(300))
+
+    with _sql_spy() as captured:
+        r = await client.get(f"/lists/{q}/page?offset=0&limit=50", headers=_h(t))
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["total"] == 300, "total is the full array length"
+    assert len(body["items"]) == 50, "one bounded page only"
+
+    full_fetches = _full_state_fetches(captured, q)
+    assert not full_fetches, (
+        "the page hot path must not fetch the whole list document: a by-primary-key "
+        "SELECT returning the projection's full `state` row for this list ran during "
+        f"the small-page request (wasted round-trip). Offending statements:\n"
+        + "\n".join(full_fetches))

--- a/default_modules/celerp-docs/tests/test_list_query_pushdown.py
+++ b/default_modules/celerp-docs/tests/test_list_query_pushdown.py
@@ -1,0 +1,345 @@
+# Copyright (c) 2026 Noah Severs
+# SPDX-License-Identifier: MIT
+"""WP1 list-query pushdown and paged read/write (post-#318 stability).
+
+A single large-list request used to load, filter, sort, count, and slice the whole
+list in Python and buffer the whole CSV before streaming. These tests pin the
+bounded contract: the index, summary, and export push filter/sort/count/pagination
+into SQL (asserted with a statement spy on the executed SQL), and two new endpoints
+read one bounded page (`GET /lists/{id}/page`) and write one page under the existing
+optimistic-version lock without touching off-page rows (`PATCH /lists/{id}/line-page`).
+"""
+
+from __future__ import annotations
+
+import contextlib
+import uuid
+
+import pytest
+from sqlalchemy import event
+from sqlalchemy.engine import Engine
+
+
+# ── helpers (mirror test_audits/test_writeoffs conventions) ────────────────────
+
+async def _register(client) -> str:
+    addr = f"admin-{uuid.uuid4().hex[:8]}@pushdown.test"
+    r = await client.post("/auth/register", json={
+        "company_name": "Pushdown Co", "email": addr, "name": "A", "password": "pw"})
+    assert r.status_code == 200, r.text
+    return r.json()["access_token"]
+
+
+def _h(t):
+    return {"Authorization": f"Bearer {t}"}
+
+
+async def _user_with_role(client, session, admin_token: str, role: str) -> str:
+    addr = f"{role}-{uuid.uuid4().hex[:8]}@pushdown.test"
+    r = await client.post("/companies/me/users",
+                          json={"name": role.title(), "email": addr,
+                                "password": "testpass123", "role": role},
+                          headers=_h(admin_token))
+    assert r.status_code == 200, r.text
+    from celerp.services.session_tracker import clear as _clear_tracker
+    await _clear_tracker(session)
+    r2 = await client.post("/auth/login", json={"email": addr, "password": "testpass123"})
+    assert r2.status_code == 200, r2.text
+    return r2.json()["access_token"]
+
+
+async def _quotation(client, t, ref_id: str | None = None) -> str:
+    body = {"list_type": "quotation"}
+    if ref_id:
+        body["ref_id"] = ref_id
+    r = await client.post("/lists", headers=_h(t), json=body)
+    assert r.status_code == 200, r.text
+    return r.json()["id"]
+
+
+async def _state(client, t, list_id) -> dict:
+    return (await client.get(f"/lists/{list_id}", headers=_h(t))).json()
+
+
+async def _version(client, t, list_id) -> int:
+    return (await client.get(f"/lists/{list_id}", headers=_h(t))).json()["version"]
+
+
+async def _set_lines(client, t, list_id, lines: list[dict]) -> int:
+    """Replace the whole line_items array (mandatory version pin) and return the new version."""
+    v = await _version(client, t, list_id)
+    r = await client.patch(f"/lists/{list_id}", headers=_h(t),
+                           json={"fields_changed": {"line_items": {"new": lines}},
+                                 "expected_version": v})
+    assert r.status_code == 200, r.text
+    return r.json()["version"]
+
+
+def _lines(n: int, *, start: int = 0) -> list[dict]:
+    return [{"item_id": f"item:{i}", "sku": f"SKU{i}", "description": f"Item {i}",
+             "quantity": 1, "unit_price": 1.0} for i in range(start, start + n)]
+
+
+@contextlib.contextmanager
+def _sql_spy():
+    """Capture every SQL statement executed on any engine for the duration of the block.
+
+    Attaches to the Engine class so it catches the sync engine backing the async one
+    (SQLAlchemy fires cursor events on that underlying engine)."""
+    stmts: list[str] = []
+
+    def _after(conn, cursor, statement, parameters, context, executemany):
+        stmts.append(statement)
+
+    event.listen(Engine, "after_cursor_execute", _after)
+    try:
+        yield stmts
+    finally:
+        event.remove(Engine, "after_cursor_execute", _after)
+
+
+def _proj_selects(stmts: list[str]) -> list[str]:
+    """The SELECTs that read the list projection (company + entity_type='list' scope)."""
+    return [s for s in stmts
+            if "from projections" in s.lower() and "entity_type" in s.lower()
+            and s.lower().lstrip().startswith("select")]
+
+
+# ── index / summary / export: pushed into SQL (statement-spy red lever) ────────
+
+@pytest.mark.asyncio
+async def test_list_index_pushdown_paginates_in_sql(client):
+    """GET /lists returns one bounded page + correct total; pagination is a SQL LIMIT,
+    not a full Python load then slice."""
+    t = await _register(client)
+    for i in range(7):
+        await _quotation(client, t, ref_id=f"IDX-{i:03d}")
+
+    with _sql_spy() as sql:
+        r = await client.get("/lists?limit=3&offset=0", headers=_h(t))
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert len(body["items"]) <= 3
+    assert body["total"] == 7                       # count reflects the whole set, not the page
+    sel = _proj_selects(sql)
+    assert sel, "the index must query the list projection"
+    assert any("limit" in s.lower() for s in sel), (
+        "pagination must be a SQL LIMIT (no full-array Python load then slice); "
+        f"projection selects were: {sel}")
+
+
+@pytest.mark.asyncio
+async def test_list_index_sql_order_matches_python(client):
+    """The SQL ORDER BY reproduces the newest-first Python sort (issue_date > created_at
+    > date, entity_id tiebreak)."""
+    t = await _register(client)
+    ids = [await _quotation(client, t, ref_id=f"ORD-{i:03d}") for i in range(5)]
+
+    with _sql_spy() as sql:
+        r = await client.get("/lists?limit=100", headers=_h(t))
+    assert r.status_code == 200, r.text
+    returned = [it["id"] for it in r.json()["items"]]
+    # Same-day rows: deterministic newest-first is the entity_id tiebreak (descending).
+    expected = sorted(ids, reverse=True)
+    assert returned == expected, f"order {returned} != expected {expected}"
+    sel = _proj_selects(sql)
+    assert any("order by" in s.lower() for s in sel), (
+        f"ordering must be a SQL ORDER BY, not a Python sort; selects: {sel}")
+
+
+@pytest.mark.asyncio
+async def test_list_index_filters_equivalence(client):
+    """q / all_issued / exclude_status / converted_to_type are SQL predicates over the
+    JSON state, returning the identical id set the Python filters returned."""
+    t = await _register(client)
+    keep = await _quotation(client, t, ref_id="MATCH-ONE")
+    other = await _quotation(client, t, ref_id="NOPE-TWO")
+
+    with _sql_spy() as sql:
+        r = await client.get("/lists?q=match", headers=_h(t))
+    assert r.status_code == 200, r.text
+    got = {it["id"] for it in r.json()["items"]}
+    assert got == {keep}, f"q filter returned {got}"
+    assert other not in got
+    sel = _proj_selects(sql)
+    assert any("->>" in s for s in sel), (
+        f"filters must be SQL predicates over state (JSON ->> access); selects: {sel}")
+
+
+@pytest.mark.asyncio
+async def test_list_summary_sql_aggregates(client):
+    """The 7 summary keys are computed by SQL aggregates, not a Python row loop."""
+    t = await _register(client)
+    for i in range(4):
+        await _quotation(client, t, ref_id=f"SUM-{i:03d}")
+
+    with _sql_spy() as sql:
+        r = await client.get("/lists/summary", headers=_h(t))
+    assert r.status_code == 200, r.text
+    body = r.json()
+    for k in ("total_count", "draft_count", "all_issued_count", "total_value",
+              "converted_to_memo_count", "converted_to_invoice_count", "count_by_status"):
+        assert k in body, f"summary missing {k}"
+    assert body["total_count"] == 4 and body["draft_count"] == 4  # all drafts here
+    sel = _proj_selects(sql)
+    assert any(("count(" in s.lower() or "sum(" in s.lower() or "group by" in s.lower())
+               for s in sel), (
+        f"summary must aggregate in SQL; projection selects: {sel}")
+
+
+@pytest.mark.asyncio
+async def test_list_export_csv_streams(client):
+    """CSV export fetches rows in bounded SQL batches and streams them, never buffering
+    the whole projection in one unbounded query."""
+    t = await _register(client)
+    for i in range(6):
+        await _quotation(client, t, ref_id=f"CSV-{i:03d}")
+
+    with _sql_spy() as sql:
+        r = await client.get("/lists/export/csv", headers=_h(t))
+    assert r.status_code == 200, r.text
+    text = r.text
+    assert text.splitlines()[0].startswith("id,ref_id"), text.splitlines()[:1]
+    assert "CSV-000" in text
+    sel = _proj_selects(sql)
+    assert any("limit" in s.lower() for s in sel), (
+        f"export must read the projection in bounded SQL batches (LIMIT); selects: {sel}")
+
+
+# ── GET /lists/{id}/page : new bounded paged read ──────────────────────────────
+
+@pytest.mark.asyncio
+async def test_list_page_endpoint_bounded(client):
+    """GET /lists/{id}/page hard-caps limit at 100, returns the page items + total +
+    version, and rejects a negative offset with 400."""
+    t = await _register(client)
+    q = await _quotation(client, t)
+    await _set_lines(client, t, q, _lines(250))
+
+    r = await client.get(f"/lists/{q}/page?offset=0&limit=500", headers=_h(t))
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert len(body["items"]) == 100, "limit must be hard-capped at 100"
+    assert body["total"] == 250, "total is the full array length"
+    assert "version" in body
+
+    assert (await client.get(f"/lists/{q}/page?offset=-1&limit=10",
+                             headers=_h(t))).status_code == 400
+    assert (await client.get("/lists/list:does-not-exist/page?offset=0&limit=10",
+                             headers=_h(t))).status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_list_page_slice_no_full_expansion(client):
+    """The page read slices in SQL (json_array_length for total, positional subscript
+    over generate_series for the window) rather than loading the whole array in Python."""
+    t = await _register(client)
+    q = await _quotation(client, t)
+    await _set_lines(client, t, q, _lines(120))
+
+    with _sql_spy() as sql:
+        r = await client.get(f"/lists/{q}/page?offset=100&limit=50", headers=_h(t))
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["total"] == 120
+    assert len(body["items"]) == 20           # positions 100..119 only
+    assert body["items"][0]["description"] == "Item 100"
+    joined = " ".join(sql).lower()
+    assert "json_array_length" in joined, (
+        f"total must come from json_array_length in SQL; SQL was: {sql}")
+
+
+# ── PATCH /lists/{id}/line-page : new version-guarded slice write ───────────────
+
+@pytest.mark.asyncio
+async def test_line_page_patch_preserves_offpage(client):
+    """Saving one page overwrites only positions [offset:offset+len(page)] and leaves
+    off-page rows byte-identical, including duplicate and id-less free-text rows."""
+    t = await _register(client)
+    q = await _quotation(client, t)
+    lines = [
+        {"item_id": "item:a", "sku": "A", "description": "Alpha", "quantity": 1, "unit_price": 1.0},
+        {"description": "Free text one", "quantity": 1, "unit_price": 2.0},   # id-less free text
+        {"description": "Dup", "quantity": 1, "unit_price": 3.0},             # duplicate desc
+        {"description": "Dup", "quantity": 1, "unit_price": 3.0},             # duplicate desc
+        {"item_id": "item:e", "sku": "E", "description": "Echo", "quantity": 1, "unit_price": 5.0},
+    ]
+    v = await _set_lines(client, t, q, lines)
+    before = (await _state(client, t, q))["line_items"]
+
+    page = [dict(before[1]), dict(before[2])]
+    page[0]["description"] = "Free text EDITED"
+    r = await client.patch(f"/lists/{q}/line-page", headers=_h(t),
+                           json={"line_items": page, "offset": 1, "expected_version": v})
+    assert r.status_code == 200, r.text
+
+    after = (await _state(client, t, q))["line_items"]
+    assert len(after) == 5, "off-page rows must not be dropped"
+    assert after[0] == before[0]              # off-page, untouched
+    assert after[3] == before[3]              # off-page duplicate, untouched
+    assert after[4] == before[4]              # off-page, untouched
+    assert after[1]["description"] == "Free text EDITED"
+    assert after[2]["description"] == "Dup"
+
+
+@pytest.mark.asyncio
+async def test_line_page_patch_stale_version_409(client):
+    """A slice PATCH pinned to a superseded version is rejected 409 and writes nothing."""
+    t = await _register(client)
+    q = await _quotation(client, t)
+    stale = await _set_lines(client, t, q, _lines(4))
+    # Advance the version so `stale` no longer matches.
+    await _set_lines(client, t, q, _lines(4))
+    before = (await _state(client, t, q))["line_items"]
+
+    page = [{"item_id": "item:0", "sku": "SKU0", "description": "CLOBBER",
+             "quantity": 9, "unit_price": 9.0}]
+    r = await client.patch(f"/lists/{q}/line-page", headers=_h(t),
+                           json={"line_items": page, "offset": 0, "expected_version": stale})
+    assert r.status_code == 409, r.text
+    assert (await _state(client, t, q))["line_items"] == before, "stale save must write nothing"
+
+
+@pytest.mark.asyncio
+async def test_line_page_patch_rejects_non_draft(client, session):
+    """A slice PATCH on a non-draft list is 409, and a caller lacking edit_documents is
+    403; neither writes."""
+    t = await _register(client)
+
+    # Non-draft: finalize then attempt a slice save.
+    q = await _quotation(client, t)
+    v = await _set_lines(client, t, q, _lines(3))
+    assert (await client.post(f"/lists/{q}/finalize", headers=_h(t))).status_code == 200
+    page = [{"item_id": "item:0", "sku": "SKU0", "description": "X", "quantity": 1, "unit_price": 1.0}]
+    r_nondraft = await client.patch(f"/lists/{q}/line-page", headers=_h(t),
+                                    json={"line_items": page, "offset": 0, "expected_version": v})
+    assert r_nondraft.status_code == 409, r_nondraft.text
+
+    # No edit_documents permission: a viewer on a fresh draft.
+    q2 = await _quotation(client, t)
+    v2 = await _set_lines(client, t, q2, _lines(3))
+    viewer = await _user_with_role(client, session, t, "viewer")
+    r_perm = await client.patch(f"/lists/{q2}/line-page", headers=_h(viewer),
+                                json={"line_items": page, "offset": 0, "expected_version": v2})
+    assert r_perm.status_code == 403, r_perm.text
+
+
+@pytest.mark.asyncio
+async def test_line_page_patch_recomputes_totals_from_full_array(client):
+    """After a slice save the list total reflects the full merged array, not just the
+    saved page."""
+    t = await _register(client)
+    q = await _quotation(client, t)
+    # 5 lines, each qty*unit_price = 10 -> full-array total 50.
+    lines = [{"item_id": f"item:{i}", "sku": f"S{i}", "description": f"Item {i}",
+              "quantity": 2, "unit_price": 5.0} for i in range(5)]
+    v = await _set_lines(client, t, q, lines)
+
+    # Edit only page [0:1], raising line 0 to qty*price = 40 (+30). Full total -> 80.
+    page = [{"item_id": "item:0", "sku": "S0", "description": "Item 0",
+             "quantity": 4, "unit_price": 10.0}]
+    r = await client.patch(f"/lists/{q}/line-page", headers=_h(t),
+                           json={"line_items": page, "offset": 0, "expected_version": v})
+    assert r.status_code == 200, r.text
+    total = float((await _state(client, t, q)).get("total") or 0)
+    assert total == pytest.approx(80.0), f"total {total} must sum the full array (80), not the page (40)"

--- a/default_modules/celerp-docs/tests/test_list_query_pushdown.py
+++ b/default_modules/celerp-docs/tests/test_list_query_pushdown.py
@@ -2,17 +2,26 @@
 # SPDX-License-Identifier: MIT
 """WP1 list-query pushdown and paged read/write (post-#318 stability).
 
-A single large-list request used to load, filter, sort, count, and slice the whole
-list in Python and buffer the whole CSV before streaming. These tests pin the
-bounded contract: the index, summary, and export push filter/sort/count/pagination
-into SQL (asserted with a statement spy on the executed SQL), and two new endpoints
-read one bounded page (`GET /lists/{id}/page`) and write one page under the existing
-optimistic-version lock without touching off-page rows (`PATCH /lists/{id}/line-page`).
+A single large-list request used to load, count, weigh, and slice the whole list in
+Python and buffer the whole CSV before streaming. These tests pin the bounded contract
+behaviourally: the index and export never drag each list's whole `state` document back
+into Python (the count and per-line weight are computed in SQL and only the header
+columns are read), the index response carries counts rather than the raw line array,
+and two endpoints read one bounded page (`GET /lists/{id}/page`) and write one page
+under the existing optimistic-version lock without touching off-page rows
+(`PATCH /lists/{id}/line-page`).
+
+The materialisation proof is DB traffic, not SQL spelling: a `before_cursor_execute`
+listener captures every executed statement and we assert that no full-`state`
+projection read runs on the hot path. Asserting a keyword like `LIMIT` appears in the
+SQL proves nothing (the pre-pushdown code already used `LIMIT`); asserting the whole
+`state` column is never selected proves the array is never loaded.
 """
 
 from __future__ import annotations
 
 import contextlib
+import re
 import uuid
 
 import pytest
@@ -82,35 +91,56 @@ def _lines(n: int, *, start: int = 0) -> list[dict]:
 
 @contextlib.contextmanager
 def _sql_spy():
-    """Capture every SQL statement executed on any engine for the duration of the block.
+    """Capture (statement, parameters) for every SQL statement executed on any engine during
+    the block via a `before_cursor_execute` listener - an honest DB-traffic probe, never a
+    monkeypatch of an application function. Attaches to the Engine class so it catches the sync
+    engine backing the async one (SQLAlchemy fires cursor events on that underlying engine)."""
+    captured: list[tuple[str, object]] = []
 
-    Attaches to the Engine class so it catches the sync engine backing the async one
-    (SQLAlchemy fires cursor events on that underlying engine)."""
-    stmts: list[str] = []
+    def _before(conn, cursor, statement, parameters, context, executemany):
+        captured.append((statement, parameters))
 
-    def _after(conn, cursor, statement, parameters, context, executemany):
-        stmts.append(statement)
-
-    event.listen(Engine, "after_cursor_execute", _after)
+    event.listen(Engine, "before_cursor_execute", _before)
     try:
-        yield stmts
+        yield captured
     finally:
-        event.remove(Engine, "after_cursor_execute", _after)
+        event.remove(Engine, "before_cursor_execute", _before)
 
 
-def _proj_selects(stmts: list[str]) -> list[str]:
-    """The SELECTs that read the list projection (company + entity_type='list' scope)."""
-    return [s for s in stmts
-            if "from projections" in s.lower() and "entity_type" in s.lower()
-            and s.lower().lstrip().startswith("select")]
+# A `select(Projection)` puts every ORM column - the bare `projections.state` among them - in
+# its select-list, dragging each row's whole document into Python. The pushed-down index/export
+# selects place only labelled sub-fields (`state ->> 'x'`) and aggregates
+# (`json_array_length(state -> ...)`, a `json_array_elements` weight sum) there, never the bare
+# column. So "a SELECT over projections whose select-list carries the bare `projections.state`
+# column" is exactly the full-document read the pushdown removes. The negative lookahead keeps a
+# `state ->` / `state ::` / `state[` subscript from counting as the bare column.
+_BARE_STATE_COL = re.compile(r"\bprojections\.state\b(?!\s*(?:->|::|\[))")
 
 
-# ── index / summary / export: pushed into SQL (statement-spy red lever) ────────
+def _full_state_reads(captured) -> list[str]:
+    """The captured statements that read the whole projection `state` document: a SELECT over the
+    projections table whose select-list (the text before its FROM clause) contains the bare
+    `projections.state` column."""
+    hits: list[str] = []
+    for statement, _parameters in captured:
+        low = statement.lower()
+        if not low.lstrip().startswith("select"):
+            continue
+        i = low.find("from projections")
+        if i < 0:
+            continue
+        if _BARE_STATE_COL.search(statement[:i]):
+            hits.append(statement)
+    return hits
+
+
+# ── index / summary / export: no whole-document read on the hot path ───────────
 
 @pytest.mark.asyncio
 async def test_list_index_pushdown_paginates_in_sql(client):
-    """GET /lists returns one bounded page + correct total; pagination is a SQL LIMIT,
-    not a full Python load then slice."""
+    """GET /lists returns one bounded page + the full-set total without loading each list's whole
+    document: the response carries no raw line_items array and the request issues no full-`state`
+    projection read (the pre-pushdown code did both)."""
     t = await _register(client)
     for i in range(7):
         await _quotation(client, t, ref_id=f"IDX-{i:03d}")
@@ -121,17 +151,19 @@ async def test_list_index_pushdown_paginates_in_sql(client):
     body = r.json()
     assert len(body["items"]) <= 3
     assert body["total"] == 7                       # count reflects the whole set, not the page
-    sel = _proj_selects(sql)
-    assert sel, "the index must query the list projection"
-    assert any("limit" in s.lower() for s in sel), (
-        "pagination must be a SQL LIMIT (no full-array Python load then slice); "
-        f"projection selects were: {sel}")
+    # Behavioural: an index row is a header plus counts, never the whole line array.
+    assert all("line_items" not in it for it in body["items"]), (
+        "the index must not carry each list's whole line_items array back to the client")
+    full = _full_state_reads(sql)
+    assert not full, (
+        "the index hot path must not read each list's whole projection state row "
+        "(the pre-pushdown full-array load). Offending statements:\n" + "\n".join(full))
 
 
 @pytest.mark.asyncio
 async def test_list_index_sql_order_matches_python(client):
-    """The SQL ORDER BY reproduces the newest-first Python sort (issue_date > created_at
-    > date, entity_id tiebreak)."""
+    """The index returns rows newest-first (issue_date > created_at > date, entity_id tiebreak),
+    the same order the Python sort produced, and does so without a full-document read."""
     t = await _register(client)
     ids = [await _quotation(client, t, ref_id=f"ORD-{i:03d}") for i in range(5)]
 
@@ -142,15 +174,13 @@ async def test_list_index_sql_order_matches_python(client):
     # Same-day rows: deterministic newest-first is the entity_id tiebreak (descending).
     expected = sorted(ids, reverse=True)
     assert returned == expected, f"order {returned} != expected {expected}"
-    sel = _proj_selects(sql)
-    assert any("order by" in s.lower() for s in sel), (
-        f"ordering must be a SQL ORDER BY, not a Python sort; selects: {sel}")
+    assert _full_state_reads(sql) == [], "ordering must not require loading each whole document"
 
 
 @pytest.mark.asyncio
 async def test_list_index_filters_equivalence(client):
-    """q / all_issued / exclude_status / converted_to_type are SQL predicates over the
-    JSON state, returning the identical id set the Python filters returned."""
+    """q / all_issued / exclude_status / converted_to_type return the identical id set the Python
+    filters returned, computed without loading each list's whole document."""
     t = await _register(client)
     keep = await _quotation(client, t, ref_id="MATCH-ONE")
     other = await _quotation(client, t, ref_id="NOPE-TWO")
@@ -161,14 +191,14 @@ async def test_list_index_filters_equivalence(client):
     got = {it["id"] for it in r.json()["items"]}
     assert got == {keep}, f"q filter returned {got}"
     assert other not in got
-    sel = _proj_selects(sql)
-    assert any("->>" in s for s in sel), (
-        f"filters must be SQL predicates over state (JSON ->> access); selects: {sel}")
+    assert _full_state_reads(sql) == [], "filtering must not require loading each whole document"
 
 
 @pytest.mark.asyncio
 async def test_list_summary_sql_aggregates(client):
-    """The 7 summary keys are computed by SQL aggregates, not a Python row loop."""
+    """The 7 summary keys are correct and computed without loading each list's whole document
+    (the aggregation is a grouped SQL pass, pre-existing at the baseline - this pins it against
+    regressing back to a Python row loop)."""
     t = await _register(client)
     for i in range(4):
         await _quotation(client, t, ref_id=f"SUM-{i:03d}")
@@ -181,16 +211,42 @@ async def test_list_summary_sql_aggregates(client):
               "converted_to_memo_count", "converted_to_invoice_count", "count_by_status"):
         assert k in body, f"summary missing {k}"
     assert body["total_count"] == 4 and body["draft_count"] == 4  # all drafts here
-    sel = _proj_selects(sql)
-    assert any(("count(" in s.lower() or "sum(" in s.lower() or "group by" in s.lower())
-               for s in sel), (
-        f"summary must aggregate in SQL; projection selects: {sel}")
+    assert _full_state_reads(sql) == [], (
+        "summary must aggregate in SQL, never load each list's whole state row")
+
+
+@pytest.mark.asyncio
+async def test_list_index_counts_and_weights_utf8(client):
+    """The index carries item_count (a json_array_length) and total_weight (a json_array_elements
+    sum) computed in SQL, equal to the Python-side truth even when line descriptions carry
+    multibyte UTF-8 - the encoding-sensitive weight path reads the same JSON the app round-trips,
+    and never loads the whole array to do it."""
+    t = await _register(client)
+    q = await _quotation(client, t, ref_id="WT-001")
+    lines = [
+        {"item_id": "item:1", "sku": "S1", "description": "Rubĩes \U0001F48E ê",
+         "quantity": 1, "unit_price": 1.0, "weight_ct": "2.5"},
+        {"item_id": "item:2", "sku": "S2", "description": "钻石 gems",
+         "quantity": 1, "unit_price": 1.0, "weight_ct": "3.5"},
+        {"description": "Free 문자열", "quantity": 1, "unit_price": 1.0, "weight": "4"},
+    ]
+    await _set_lines(client, t, q, lines)
+
+    with _sql_spy() as sql:
+        r = await client.get("/lists?q=WT-001", headers=_h(t))
+    assert r.status_code == 200, r.text
+    row = next(it for it in r.json()["items"] if it["id"] == q)
+    assert row["item_count"] == 3, "item_count is json_array_length of the stored array"
+    assert row["total_weight"] == pytest.approx(10.0), (
+        "total_weight sums weight_ct (falling back to weight) across the UTF-8 rows")
+    assert _full_state_reads(sql) == [], (
+        "count and weight must come from SQL, never a full-array load")
 
 
 @pytest.mark.asyncio
 async def test_list_export_csv_streams(client):
-    """CSV export fetches rows in bounded SQL batches and streams them, never buffering
-    the whole projection in one unbounded query."""
+    """CSV export reads only the emitted columns in bounded SQL batches and streams them, never
+    loading each list's whole document to write its header row."""
     t = await _register(client)
     for i in range(6):
         await _quotation(client, t, ref_id=f"CSV-{i:03d}")
@@ -201,9 +257,10 @@ async def test_list_export_csv_streams(client):
     text = r.text
     assert text.splitlines()[0].startswith("id,ref_id"), text.splitlines()[:1]
     assert "CSV-000" in text
-    sel = _proj_selects(sql)
-    assert any("limit" in s.lower() for s in sel), (
-        f"export must read the projection in bounded SQL batches (LIMIT); selects: {sel}")
+    full = _full_state_reads(sql)
+    assert not full, (
+        "export must read only its CSV columns from SQL, never each list's whole state row. "
+        "Offending statements:\n" + "\n".join(full))
 
 
 # ── GET /lists/{id}/page : new bounded paged read ──────────────────────────────
@@ -231,22 +288,19 @@ async def test_list_page_endpoint_bounded(client):
 
 @pytest.mark.asyncio
 async def test_list_page_slice_no_full_expansion(client):
-    """The page read slices in SQL (json_array_length for total, positional subscript
-    over generate_series for the window) rather than loading the whole array in Python."""
+    """The page read returns exactly the requested window (positions 100..119 of a 120-line list)
+    and the full total, proving the slice is positional and bounded. That it reads that window
+    without loading the whole document is pinned behaviourally in test_list_page_no_full_state."""
     t = await _register(client)
     q = await _quotation(client, t)
     await _set_lines(client, t, q, _lines(120))
 
-    with _sql_spy() as sql:
-        r = await client.get(f"/lists/{q}/page?offset=100&limit=50", headers=_h(t))
+    r = await client.get(f"/lists/{q}/page?offset=100&limit=50", headers=_h(t))
     assert r.status_code == 200, r.text
     body = r.json()
     assert body["total"] == 120
     assert len(body["items"]) == 20           # positions 100..119 only
     assert body["items"][0]["description"] == "Item 100"
-    joined = " ".join(sql).lower()
-    assert "json_array_length" in joined, (
-        f"total must come from json_array_length in SQL; SQL was: {sql}")
 
 
 # ── PATCH /lists/{id}/line-page : new version-guarded slice write ───────────────

--- a/default_modules/first_party.lock.json
+++ b/default_modules/first_party.lock.json
@@ -6,7 +6,7 @@
   "celerp-connectors": "50a4a7e40e5d667462b805c4993741edc4125d71be04bbf1abbdaba56ee710b9",
   "celerp-contacts": "899cf9febb388356290f6eb8c8ab6d67f1f92a9c9fa8377ebb6d46bf04cedbc3",
   "celerp-dashboard": "1b813cb8756ac600f06f0c061b7e7c507ad8ede0e49901e98df6231fdb28ec46",
-  "celerp-docs": "f4a40aea9e30f1bf15ee412636906c4ee0e00ddce4853fb243ccc758033549a0",
+  "celerp-docs": "760e60b4e37acdd1dc114048cbfb4b85a9d29fc17c83f16269b426c7451545f8",
   "celerp-inventory": "553026656fe83dbc0dc7bf13bdf01a2e055a728783c384d74fa9101293c1ff35",
   "celerp-labels": "ec12cae73b1e37fbeb18dd25671cc8903be55a7aab9d448de8aef1f6f9f8882a",
   "celerp-manufacturing": "f1d90823286b6815e2c4ca88d4e86e9de7feb568c6540c84d1d342bc051283ee",

--- a/default_modules/first_party.lock.json
+++ b/default_modules/first_party.lock.json
@@ -6,7 +6,7 @@
   "celerp-connectors": "50a4a7e40e5d667462b805c4993741edc4125d71be04bbf1abbdaba56ee710b9",
   "celerp-contacts": "899cf9febb388356290f6eb8c8ab6d67f1f92a9c9fa8377ebb6d46bf04cedbc3",
   "celerp-dashboard": "1b813cb8756ac600f06f0c061b7e7c507ad8ede0e49901e98df6231fdb28ec46",
-  "celerp-docs": "56e8887fe6e6c63acfbc4ae1bc43c95415fd5eca1ca1c1ad515b76594331df9a",
+  "celerp-docs": "836f5f08d138051f8391ef7f7ca2099dea5273369227512540d5402a1ea513ba",
   "celerp-inventory": "553026656fe83dbc0dc7bf13bdf01a2e055a728783c384d74fa9101293c1ff35",
   "celerp-labels": "ec12cae73b1e37fbeb18dd25671cc8903be55a7aab9d448de8aef1f6f9f8882a",
   "celerp-manufacturing": "f1d90823286b6815e2c4ca88d4e86e9de7feb568c6540c84d1d342bc051283ee",

--- a/default_modules/first_party.lock.json
+++ b/default_modules/first_party.lock.json
@@ -6,7 +6,7 @@
   "celerp-connectors": "50a4a7e40e5d667462b805c4993741edc4125d71be04bbf1abbdaba56ee710b9",
   "celerp-contacts": "899cf9febb388356290f6eb8c8ab6d67f1f92a9c9fa8377ebb6d46bf04cedbc3",
   "celerp-dashboard": "1b813cb8756ac600f06f0c061b7e7c507ad8ede0e49901e98df6231fdb28ec46",
-  "celerp-docs": "760e60b4e37acdd1dc114048cbfb4b85a9d29fc17c83f16269b426c7451545f8",
+  "celerp-docs": "88777fc95b20a6235f69f20e4afd2341dc47fdeceb533045e1d8b2ed9bce264e",
   "celerp-inventory": "553026656fe83dbc0dc7bf13bdf01a2e055a728783c384d74fa9101293c1ff35",
   "celerp-labels": "ec12cae73b1e37fbeb18dd25671cc8903be55a7aab9d448de8aef1f6f9f8882a",
   "celerp-manufacturing": "f1d90823286b6815e2c4ca88d4e86e9de7feb568c6540c84d1d342bc051283ee",

--- a/default_modules/first_party.lock.json
+++ b/default_modules/first_party.lock.json
@@ -6,7 +6,7 @@
   "celerp-connectors": "50a4a7e40e5d667462b805c4993741edc4125d71be04bbf1abbdaba56ee710b9",
   "celerp-contacts": "899cf9febb388356290f6eb8c8ab6d67f1f92a9c9fa8377ebb6d46bf04cedbc3",
   "celerp-dashboard": "1b813cb8756ac600f06f0c061b7e7c507ad8ede0e49901e98df6231fdb28ec46",
-  "celerp-docs": "88777fc95b20a6235f69f20e4afd2341dc47fdeceb533045e1d8b2ed9bce264e",
+  "celerp-docs": "e811f0b77b5241923dd661018950eae84dc66f017586b17cbe068c590617555f",
   "celerp-inventory": "553026656fe83dbc0dc7bf13bdf01a2e055a728783c384d74fa9101293c1ff35",
   "celerp-labels": "ec12cae73b1e37fbeb18dd25671cc8903be55a7aab9d448de8aef1f6f9f8882a",
   "celerp-manufacturing": "f1d90823286b6815e2c4ca88d4e86e9de7feb568c6540c84d1d342bc051283ee",

--- a/default_modules/first_party.lock.json
+++ b/default_modules/first_party.lock.json
@@ -6,7 +6,7 @@
   "celerp-connectors": "50a4a7e40e5d667462b805c4993741edc4125d71be04bbf1abbdaba56ee710b9",
   "celerp-contacts": "899cf9febb388356290f6eb8c8ab6d67f1f92a9c9fa8377ebb6d46bf04cedbc3",
   "celerp-dashboard": "1b813cb8756ac600f06f0c061b7e7c507ad8ede0e49901e98df6231fdb28ec46",
-  "celerp-docs": "29c65f3ca41a89b7e4ebfce45c8c66c3bc6248cec54f448d5e1882e788f1a35f",
+  "celerp-docs": "40621efc4e105b545ed231e1b96346806a007d5b9bb64974a7e3645884d3e7a1",
   "celerp-inventory": "553026656fe83dbc0dc7bf13bdf01a2e055a728783c384d74fa9101293c1ff35",
   "celerp-labels": "ec12cae73b1e37fbeb18dd25671cc8903be55a7aab9d448de8aef1f6f9f8882a",
   "celerp-manufacturing": "f1d90823286b6815e2c4ca88d4e86e9de7feb568c6540c84d1d342bc051283ee",

--- a/default_modules/first_party.lock.json
+++ b/default_modules/first_party.lock.json
@@ -6,7 +6,7 @@
   "celerp-connectors": "50a4a7e40e5d667462b805c4993741edc4125d71be04bbf1abbdaba56ee710b9",
   "celerp-contacts": "899cf9febb388356290f6eb8c8ab6d67f1f92a9c9fa8377ebb6d46bf04cedbc3",
   "celerp-dashboard": "1b813cb8756ac600f06f0c061b7e7c507ad8ede0e49901e98df6231fdb28ec46",
-  "celerp-docs": "e811f0b77b5241923dd661018950eae84dc66f017586b17cbe068c590617555f",
+  "celerp-docs": "d69d14fe2c87800f3fc767bd03d8b55e6fabe53ce4b97e957192f87727a20ee1",
   "celerp-inventory": "553026656fe83dbc0dc7bf13bdf01a2e055a728783c384d74fa9101293c1ff35",
   "celerp-labels": "ec12cae73b1e37fbeb18dd25671cc8903be55a7aab9d448de8aef1f6f9f8882a",
   "celerp-manufacturing": "f1d90823286b6815e2c4ca88d4e86e9de7feb568c6540c84d1d342bc051283ee",

--- a/default_modules/first_party.lock.json
+++ b/default_modules/first_party.lock.json
@@ -6,7 +6,7 @@
   "celerp-connectors": "50a4a7e40e5d667462b805c4993741edc4125d71be04bbf1abbdaba56ee710b9",
   "celerp-contacts": "899cf9febb388356290f6eb8c8ab6d67f1f92a9c9fa8377ebb6d46bf04cedbc3",
   "celerp-dashboard": "1b813cb8756ac600f06f0c061b7e7c507ad8ede0e49901e98df6231fdb28ec46",
-  "celerp-docs": "836f5f08d138051f8391ef7f7ca2099dea5273369227512540d5402a1ea513ba",
+  "celerp-docs": "29c65f3ca41a89b7e4ebfce45c8c66c3bc6248cec54f448d5e1882e788f1a35f",
   "celerp-inventory": "553026656fe83dbc0dc7bf13bdf01a2e055a728783c384d74fa9101293c1ff35",
   "celerp-labels": "ec12cae73b1e37fbeb18dd25671cc8903be55a7aab9d448de8aef1f6f9f8882a",
   "celerp-manufacturing": "f1d90823286b6815e2c4ca88d4e86e9de7feb568c6540c84d1d342bc051283ee",

--- a/default_modules/first_party.lock.json
+++ b/default_modules/first_party.lock.json
@@ -6,7 +6,7 @@
   "celerp-connectors": "50a4a7e40e5d667462b805c4993741edc4125d71be04bbf1abbdaba56ee710b9",
   "celerp-contacts": "899cf9febb388356290f6eb8c8ab6d67f1f92a9c9fa8377ebb6d46bf04cedbc3",
   "celerp-dashboard": "1b813cb8756ac600f06f0c061b7e7c507ad8ede0e49901e98df6231fdb28ec46",
-  "celerp-docs": "4a249416af9fa5382fd30cb3a16cfca0c238b2a028df7903e56017201b2ca858",
+  "celerp-docs": "cab62296c1168f714216cff789ad289a05acf567ad2ed6cd0fbd173b4ad68a8b",
   "celerp-inventory": "553026656fe83dbc0dc7bf13bdf01a2e055a728783c384d74fa9101293c1ff35",
   "celerp-labels": "ec12cae73b1e37fbeb18dd25671cc8903be55a7aab9d448de8aef1f6f9f8882a",
   "celerp-manufacturing": "f1d90823286b6815e2c4ca88d4e86e9de7feb568c6540c84d1d342bc051283ee",

--- a/default_modules/first_party.lock.json
+++ b/default_modules/first_party.lock.json
@@ -6,7 +6,7 @@
   "celerp-connectors": "50a4a7e40e5d667462b805c4993741edc4125d71be04bbf1abbdaba56ee710b9",
   "celerp-contacts": "899cf9febb388356290f6eb8c8ab6d67f1f92a9c9fa8377ebb6d46bf04cedbc3",
   "celerp-dashboard": "1b813cb8756ac600f06f0c061b7e7c507ad8ede0e49901e98df6231fdb28ec46",
-  "celerp-docs": "e040cf9c03c86e1bb1f223d5acdbcb05d620f13a506003d9d5819788d7364be2",
+  "celerp-docs": "4a249416af9fa5382fd30cb3a16cfca0c238b2a028df7903e56017201b2ca858",
   "celerp-inventory": "553026656fe83dbc0dc7bf13bdf01a2e055a728783c384d74fa9101293c1ff35",
   "celerp-labels": "ec12cae73b1e37fbeb18dd25671cc8903be55a7aab9d448de8aef1f6f9f8882a",
   "celerp-manufacturing": "f1d90823286b6815e2c4ca88d4e86e9de7feb568c6540c84d1d342bc051283ee",

--- a/default_modules/first_party.lock.json
+++ b/default_modules/first_party.lock.json
@@ -6,7 +6,7 @@
   "celerp-connectors": "50a4a7e40e5d667462b805c4993741edc4125d71be04bbf1abbdaba56ee710b9",
   "celerp-contacts": "899cf9febb388356290f6eb8c8ab6d67f1f92a9c9fa8377ebb6d46bf04cedbc3",
   "celerp-dashboard": "1b813cb8756ac600f06f0c061b7e7c507ad8ede0e49901e98df6231fdb28ec46",
-  "celerp-docs": "cab62296c1168f714216cff789ad289a05acf567ad2ed6cd0fbd173b4ad68a8b",
+  "celerp-docs": "f4a40aea9e30f1bf15ee412636906c4ee0e00ddce4853fb243ccc758033549a0",
   "celerp-inventory": "553026656fe83dbc0dc7bf13bdf01a2e055a728783c384d74fa9101293c1ff35",
   "celerp-labels": "ec12cae73b1e37fbeb18dd25671cc8903be55a7aab9d448de8aef1f6f9f8882a",
   "celerp-manufacturing": "f1d90823286b6815e2c4ca88d4e86e9de7feb568c6540c84d1d342bc051283ee",

--- a/default_modules/first_party.lock.json
+++ b/default_modules/first_party.lock.json
@@ -6,7 +6,7 @@
   "celerp-connectors": "50a4a7e40e5d667462b805c4993741edc4125d71be04bbf1abbdaba56ee710b9",
   "celerp-contacts": "899cf9febb388356290f6eb8c8ab6d67f1f92a9c9fa8377ebb6d46bf04cedbc3",
   "celerp-dashboard": "1b813cb8756ac600f06f0c061b7e7c507ad8ede0e49901e98df6231fdb28ec46",
-  "celerp-docs": "40621efc4e105b545ed231e1b96346806a007d5b9bb64974a7e3645884d3e7a1",
+  "celerp-docs": "e040cf9c03c86e1bb1f223d5acdbcb05d620f13a506003d9d5819788d7364be2",
   "celerp-inventory": "553026656fe83dbc0dc7bf13bdf01a2e055a728783c384d74fa9101293c1ff35",
   "celerp-labels": "ec12cae73b1e37fbeb18dd25671cc8903be55a7aab9d448de8aef1f6f9f8882a",
   "celerp-manufacturing": "f1d90823286b6815e2c4ca88d4e86e9de7feb568c6540c84d1d342bc051283ee",

--- a/tests/test_browser/test_backup_poll_single_flight.py
+++ b/tests/test_browser/test_backup_poll_single_flight.py
@@ -1,0 +1,52 @@
+# Copyright (c) 2026 Noah Severs. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-Proprietary
+"""The backup-banner poll must be single-flight.
+
+The banner polled /backup/active on a fixed interval with no guard, so when a
+response was slow the next interval fired anyway and requests stacked up. The
+poll must instead collapse concurrent polls to one in-flight request: while a
+poll is outstanding, a new interval tick must not start a second fetch.
+"""
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.browser
+
+
+def test_poll_single_flight_backup_banner(page, ui_server):
+    """With /backup/active held open (the response never arrives), a single-flight
+    poller issues exactly one request across many interval ticks. A poller with no
+    single-flight guard fires one request per tick, stacking overlapping fetches."""
+    requests: list[str] = []
+    page.on("request",
+            lambda req: requests.append(req.url) if "/backup/active" in req.url else None)
+
+    # Speed the poll cadence so many ticks elapse within the test window: shrink the
+    # banner poll interval before the page's own script installs it.
+    page.add_init_script(
+        "window.setInterval = (function(orig){"
+        "  return function(fn, ms){ return orig(fn, ms > 300 ? 200 : ms); };"
+        "})(window.setInterval);"
+    )
+    # Hold every backup poll open (never fulfilled) so the first in-flight request
+    # stays outstanding across the whole window; the count is read before teardown.
+    held: list = []
+    page.route("**/backup/active", lambda route: held.append(route))
+
+    page.goto(f"{ui_server}/", wait_until="domcontentloaded")
+    # Let many shortened intervals elapse while the first request is still open.
+    page.wait_for_timeout(3000)
+
+    issued = len(requests)
+    # Release the held routes so teardown does not block on outstanding requests.
+    page.unroute("**/backup/active")
+    for route in held:
+        try:
+            route.abort()
+        except Exception:
+            pass
+
+    assert issued == 1, (
+        "the backup poll must be single-flight: exactly one request may be in flight "
+        f"across many interval ticks, but {issued} were issued")

--- a/tests/test_browser/test_poll_wedge_recovery.py
+++ b/tests/test_browser/test_poll_wedge_recovery.py
@@ -1,0 +1,58 @@
+# Copyright (c) 2026 Noah Severs. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-Proprietary
+"""A wedged poll fetch must not permanently kill the poller.
+
+The single-flight guard collapses concurrent polls to one in-flight request, but a
+fetch that wedges (a half-open socket that never settles) then leaves inFlight true
+forever, so every later interval tick is skipped and the poller stops polling until a
+page reload. Each fetch must instead carry an abort deadline: a request that has not
+settled within it is aborted, flows through the error/backoff branch, and the next
+tick starts a fresh request. This drives the shared production poller (window.celerpPoll)
+directly against a probe URL that never responds and asserts it keeps polling.
+"""
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.browser
+
+
+def test_poll_recovers_from_wedged_fetch(page, ui_server):
+    """With the probe endpoint held open (every response wedged), a poller that bounds
+    each fetch with an abort deadline keeps issuing requests across the window. A poller
+    with no deadline issues exactly one request and then wedges forever on the first
+    unsettled fetch."""
+    requests: list[str] = []
+    page.on("request",
+            lambda req: requests.append(req.url) if "/poll-probe" in req.url else None)
+
+    # Hold every probe request open (never fulfilled) so each fetch wedges; the fix must
+    # abort each at its deadline and try again.
+    held: list = []
+    page.route("**/poll-probe", lambda route: held.append(route))
+
+    page.goto(f"{ui_server}/", wait_until="domcontentloaded")
+
+    # Start the shared production poller with a short interval and a short fetch deadline
+    # against the wedged probe URL. celerpPoll is the exact function the backup banner
+    # uses; interval and fetchDeadline are its public knobs.
+    page.evaluate(
+        "window.celerpPoll('probe', '/poll-probe', function(){}, "
+        "{ interval: 150, fetchDeadline: 120 }).start();")
+
+    # Let many shortened intervals elapse while every request wedges.
+    page.wait_for_timeout(2000)
+
+    issued = len(requests)
+    # Release the held routes so teardown does not block on outstanding requests.
+    page.unroute("**/poll-probe")
+    for route in held:
+        try:
+            route.abort()
+        except Exception:
+            pass
+
+    assert issued >= 2, (
+        "a wedged poll fetch must be aborted at its deadline so the poller keeps polling; "
+        f"only {issued} request(s) issued across a 2s window, so the first hung fetch left "
+        "the poller wedged")

--- a/tests/test_browser/test_post318_stability.py
+++ b/tests/test_browser/test_post318_stability.py
@@ -1,0 +1,210 @@
+# Copyright (c) 2026 Noah Severs. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-Proprietary
+"""Post-318 stability regressions, asserted as observable browser behavior.
+
+Two independent defects on the shipped-broken baseline:
+
+TEST 1 (P0#2): the list-detail lines section declares bare `const`/`let`
+globals in an inline script. HTMX outerHTML-swaps that whole section when the
+pager is used, re-evaluating the inline script; the second evaluation
+re-declares the same `const`/`let` and throws a SyntaxError, which kills the
+follow-on pager so a second page navigation no longer changes the page.
+
+TEST 2 (P1#8): the shared `celerpPoll` fire() calls `r.json()` with no `r.ok`
+check and zeroes the error counters on any parsed body, so a poll endpoint that
+answers with a non-OK status is treated as success and the client never backs
+off - it keeps polling at the base interval instead of slowing down.
+"""
+from __future__ import annotations
+
+import json
+import time
+
+import pytest
+
+pytestmark = pytest.mark.browser
+
+
+# ── Seeding ────────────────────────────────────────────────────────────────
+
+def _seed_paged_list(api, n_lines: int = 60) -> str:
+    """Create a draft quotation list with enough stored lines to paginate.
+
+    A draft quotation renders the editable line table with the pager whose page
+    controls route through celerpPageNav (documents.py:586) - the HTMX
+    outerHTML re-swap path the first defect lives on. Lines render from their
+    stored values, so no catalog item has to exist.
+    """
+    line_items = [
+        {"name": f"Line item {i:03d}", "description": f"row {i}",
+         "quantity": 1, "unit_price": 10 + i}
+        for i in range(n_lines)
+    ]
+    r = api.post("/lists", json={
+        "list_type": "quotation",
+        "status": "draft",
+        "line_items": line_items,
+    })
+    assert r.status_code in (200, 201), f"create list failed: {r.status_code} {r.text}"
+    entity_id = r.json().get("entity_id") or r.json().get("id")
+    assert entity_id and str(entity_id).startswith("list:"), f"unexpected id: {r.text[:200]}"
+    return entity_id
+
+
+def _active_page(page) -> str:
+    """The page number the pager currently marks active, inside the lines section."""
+    active = page.locator("#list-line-detail .btn--active, [id^=list-line-section-] .btn--active").last
+    active.wait_for(state="visible", timeout=6000)
+    return active.inner_text().strip()
+
+
+# ── TEST 1 ───────────────────────────────────────────────────────────────────
+
+def test_inline_script_survives_htmx_outerhtml_reswap(page, ui_server, api):
+    """Paging a draft list twice must keep working: the outerHTML re-swap of the
+    lines section must not throw a redeclaration SyntaxError that kills the pager.
+
+    Observable behavior: after the first pager navigation, a SECOND navigation
+    still changes the visible active page. At HEAD the second inline-script eval
+    throws `Identifier '_CELERP_EID' has already been declared` and the pager
+    dies, so the active page never advances past the first swap.
+    """
+    entity_id = _seed_paged_list(api, n_lines=60)
+
+    console_errors: list[str] = []
+    page.on("console", lambda m: console_errors.append(m.text) if m.type == "error" else None)
+    page_errors: list[str] = []
+    page.on("pageerror", lambda e: page_errors.append(str(e)))
+
+    # limit=25 over 60 lines => 3 pages, so the editable (celerpPageNav) pager renders.
+    page.goto(f"{ui_server}/lists/{entity_id}?limit=25", wait_until="domcontentloaded")
+
+    section = page.locator("[id^=list-line-section-]").first
+    section.wait_for(state="visible", timeout=8000)
+
+    # Pager present and on page 1.
+    assert _active_page(page) == "1", "expected to start on page 1"
+
+    # First navigation: page 1 -> page 2. This is the HTMX outerHTML re-swap of the
+    # lines section that re-evaluates the inline script.
+    page.get_by_role("button", name="2", exact=True).click()
+    page.wait_for_function(
+        "() => {const a=document.querySelector('[id^=list-line-section-] .btn--active');"
+        " return a && a.textContent.trim() === '2';}",
+        timeout=8000,
+    )
+    assert _active_page(page) == "2", "first navigation did not reach page 2"
+
+    # Second navigation: page 2 -> page 3. At HEAD the pager is already dead after
+    # the first re-swap threw, so the active page stays on 2.
+    page.get_by_role("button", name="3", exact=True).click()
+    page.wait_for_function(
+        "() => {const a=document.querySelector('[id^=list-line-section-] .btn--active');"
+        " return a && a.textContent.trim() === '3';}",
+        timeout=8000,
+    )
+    reached = _active_page(page)
+
+    redeclare = [
+        m for m in (console_errors + page_errors)
+        if "already been declared" in m or ("SyntaxError" in m and "_CELERP" in m)
+        or "Identifier '_CELERP" in m or "redeclaration" in m.lower()
+    ]
+    assert not redeclare, f"inline-script redeclaration SyntaxError fired: {redeclare}"
+    assert reached == "3", (
+        f"second pager navigation did not change the page (stuck on {reached}); "
+        "the re-swapped inline script threw and killed the pager"
+    )
+
+
+# ── TEST 2 ───────────────────────────────────────────────────────────────────
+
+def test_poll_backoff_not_reset_by_non_ok_response(page, ui_server):
+    """A sustained non-OK poll response must make celerpPoll back off (grow the
+    gap between requests), not keep firing at the base interval.
+
+    Exercises the real shared client poller (window.celerpPoll from shell.py) in
+    isolation: the poll URL is forced to answer 503 for the whole test, request
+    timestamps are recorded, and the cadence is measured. At HEAD fire() does
+    r.json() with no r.ok check and zeroes errorCount/skipTicks on any parsed
+    body, so every 503 is treated as success and the client never slows down.
+    """
+    poll_url_marker = "/backup/active"
+
+    # Force the poll endpoint to a non-OK status with a small JSON body for the
+    # whole test. Both the banner poller and our probe poller hit this route.
+    def _handle(route):
+        route.fulfill(status=503, content_type="application/json",
+                      body=json.dumps({"state": "error"}))
+    page.route(f"**{poll_url_marker}**", _handle)
+
+    request_times: list[float] = []
+    inflight_overlap = {"count": 0, "open": 0}
+
+    def _on_request(req):
+        if poll_url_marker in req.url and "probe=post318" in req.url:
+            request_times.append(time.monotonic())
+            if inflight_overlap["open"] > 0:
+                inflight_overlap["count"] += 1
+            inflight_overlap["open"] += 1
+
+    def _on_response(resp):
+        if poll_url_marker in resp.url and "probe=post318" in resp.url:
+            if inflight_overlap["open"] > 0:
+                inflight_overlap["open"] -= 1
+
+    page.on("request", _on_request)
+    page.on("response", _on_response)
+
+    # Any shelled authed page defines window.celerpPoll.
+    page.goto(f"{ui_server}/lists", wait_until="domcontentloaded")
+    page.wait_for_function("() => typeof window.celerpPoll === 'function'", timeout=8000)
+
+    # Drive the real client poller against a probe URL (routed to 503 above) at a
+    # short interval so a modest window covers several ticks. A backing-off client
+    # spaces requests out under sustained errors; the broken client does not.
+    interval_ms = 250
+    page.evaluate(
+        "(ms) => { window.__p318 = window.celerpPoll("
+        "'post318', '/backup/active?probe=post318', function(){}, {interval: ms});"
+        " window.__p318.start(); }",
+        interval_ms,
+    )
+
+    # Observe for a fixed window of several base intervals.
+    window_ticks = 40
+    page.wait_for_timeout(interval_ms * window_ticks)
+    page.evaluate("() => { if (window.__p318 && window.__p318.stop) window.__p318.stop(); }")
+
+    n = len(request_times)
+    assert n >= 3, f"probe poller never fired enough to measure (got {n} requests)"
+
+    # A non-backing-off client fires ~ once per tick: ~ window_ticks requests over
+    # the window. A backing-off client (skipTicks grows 1,2,3,... capped at 8)
+    # fires far fewer. With backoff the count over `window_ticks` ticks is bounded
+    # well under half the ticks; without it the count tracks the tick count.
+    #   backing off: fires at ticks 0,2,5,9,14,20,27,35,... -> ~8-9 over 40 ticks.
+    #   broken (base interval): ~1 per tick -> ~35-40 over 40 ticks.
+    max_if_backing_off = window_ticks // 2  # 20; genuine backoff stays well below
+    assert n <= max_if_backing_off, (
+        f"poll cadence did not back off under sustained non-OK responses: "
+        f"{n} requests over {window_ticks} base intervals (a backing-off client "
+        f"would fire well under {max_if_backing_off})"
+    )
+
+    # The gap between consecutive polls must be growing, not flat at the base
+    # interval - the direct signature of backoff.
+    gaps = [request_times[i + 1] - request_times[i] for i in range(len(request_times) - 1)]
+    if len(gaps) >= 4:
+        first_two = sum(gaps[:2]) / 2
+        last_two = sum(gaps[-2:]) / 2
+        assert last_two > first_two * 1.5, (
+            f"poll gaps did not grow (first~{first_two:.3f}s, last~{last_two:.3f}s); "
+            "the client is not backing off under non-OK responses"
+        )
+
+    # Single-flight guard (green at HEAD, must stay green): no two probe polls
+    # overlap in flight.
+    assert inflight_overlap["count"] == 0, (
+        f"single-flight violated: {inflight_overlap['count']} overlapping in-flight polls"
+    )

--- a/tests/test_csv_export_streaming.py
+++ b/tests/test_csv_export_streaming.py
@@ -1,0 +1,76 @@
+# Copyright (c) 2026 Noah Severs
+# SPDX-License-Identifier: LicenseRef-Proprietary
+
+"""The docs and lists CSV export client methods must stream, not buffer.
+
+Prod incident context (#319): the UI client read each export fully into memory with
+`.content` and the UI route re-sent that buffer, so a large export sat twice in the UI
+process and pinned a pooled connection for the whole read - a contributor to the
+connection-pool pressure the stability work targets. The backend already streams these
+exports row by row; the UI must hand the chunks straight through.
+
+These assert the OBSERVABLE streaming behaviour of the client method: it returns a
+(chunk_iterator, headers) pair, the body is NOT read until the caller iterates, and the
+streamed bytes match the backend body intact - never a symbol-existence or type-name
+surface check."""
+from __future__ import annotations
+
+import httpx
+import pytest
+
+import ui.api_client as api
+
+
+def _mock_transport(expected_path, chunks, started):
+    async def _body():
+        started["read"] = True
+        for ch in chunks:
+            yield ch
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == expected_path, request.url.path
+        return httpx.Response(
+            200,
+            headers={
+                "content-type": "text/csv",
+                "content-length": str(sum(len(c) for c in chunks)),
+            },
+            content=_body(),
+        )
+
+    return httpx.MockTransport(handler)
+
+
+async def _assert_streams_lazily(monkeypatch, export_coro, expected_path):
+    chunks = [b"col_a,col_b\n"] + [b"row-%d,value\n" % i for i in range(500)]
+    total = sum(len(c) for c in chunks)
+    started = {"read": False}
+    monkeypatch.setattr(
+        api, "_get_transport", lambda: _mock_transport(expected_path, chunks, started))
+
+    result = await export_coro()
+    # A buffered export reads the whole CSV into a bytes object; a streaming one returns
+    # (iterator, headers). The buffered shape is the exact regression under test.
+    assert not isinstance(result, (bytes, bytearray)), (
+        "the export was buffered into bytes; it must stream a (chunk_iterator, headers) pair")
+    stream, headers = result
+    assert started["read"] is False, (
+        "the export body must not be read into UI memory before the caller iterates; "
+        "a buffered export drains the whole response first")
+    body = b"".join([chunk async for chunk in stream])
+    assert started["read"] is True, "iterating the stream must actually pull the backend body"
+    assert body == b"".join(chunks), "the streamed bytes must match the backend export intact"
+    assert headers.get("content-length") == str(total), (
+        "Content-Length must be forwarded so the browser shows real download progress")
+
+
+@pytest.mark.asyncio
+async def test_export_docs_csv_streams_and_does_not_buffer(monkeypatch):
+    await _assert_streams_lazily(
+        monkeypatch, lambda: api.export_docs_csv("tok", {}), "/docs/export/csv")
+
+
+@pytest.mark.asyncio
+async def test_export_lists_csv_streams_and_does_not_buffer(monkeypatch):
+    await _assert_streams_lazily(
+        monkeypatch, lambda: api.export_lists_csv("tok", {}), "/lists/export/csv")

--- a/tests/test_gateway/test_proxy_lifecycle.py
+++ b/tests/test_gateway/test_proxy_lifecycle.py
@@ -207,3 +207,117 @@ async def test_gateway_shared_client_bounded(client, monkeypatch):
         f"the gateway must reuse one shared httpx client, constructed {len(constructed)}")
     assert any(isinstance(lim, httpx.Limits) for lim in seen_limits), (
         "the shared client must be built with explicit httpx.Limits")
+
+
+class _AbnormalWS:
+    """A fake gateway websocket whose message iteration raises a disconnect-style
+    exception mid-stream, exactly as a silently-dropped socket does at runtime.
+
+    `async with websockets.connect(...)` yields this object; `async for raw in ws`
+    then enters __anext__ and raises ConnectionClosedError before any frame is read.
+    """
+
+    def __init__(self, exc):
+        self._exc = exc
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *a):
+        return False
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        raise self._exc
+
+
+def _drive_abnormal_disconnect(client, monkeypatch):
+    """Patch out the network so _connect_and_serve runs the real async-with / async-for
+    path against a socket that drops abnormally on the first iteration. The teardown
+    statements (line 360/363/370) are siblings of the async-with, not in a finally, so
+    at HEAD the raised ConnectionClosedError skips them."""
+    import websockets
+    from websockets.exceptions import ConnectionClosedError
+
+    def _fake_connect(*a, **k):
+        return _AbnormalWS(ConnectionClosedError(None, None))
+
+    monkeypatch.setattr(websockets, "connect", _fake_connect)
+
+    # The hello handshake sends before the async-for; make it a no-op so the drive
+    # reaches the iteration that raises.
+    async def _noop_send(ws, msg):
+        pass
+    monkeypatch.setattr(client.__class__, "_send", staticmethod(_noop_send))
+
+    from celerp import config as _cfg
+    monkeypatch.setattr(_cfg, "read_config", lambda: {})
+
+
+@pytest.mark.asyncio
+async def test_gateway_teardown_runs_on_abnormal_disconnect(client, monkeypatch):
+    """When the message stream raises a disconnect-style exception mid-serve, the
+    connection teardown must still run: the generation is fenced (bumped), `_ws` is
+    cleared, and status returns to inactive. At HEAD these are siblings of the
+    async-with rather than in a finally, so the exception skips them and the state
+    is left dangling."""
+    from websockets.exceptions import ConnectionClosedError
+
+    _drive_abnormal_disconnect(client, monkeypatch)
+
+    gen_before = client._generation
+
+    # The abnormal disconnect propagates out of _connect_and_serve at HEAD (no finally
+    # swallows it); run()'s backoff loop is what catches it in production. Either way
+    # the observable post-disconnect state must be the fenced/torn-down one.
+    with pytest.raises(ConnectionClosedError):
+        await client._connect_and_serve()
+
+    assert client._generation == gen_before + 1, (
+        "an abnormal disconnect must bump the connection generation so in-flight "
+        f"handlers keyed to the old generation are fenced (was {gen_before}, "
+        f"now {client._generation})")
+    assert client._ws is None, (
+        "an abnormal disconnect must clear _ws; a dangling dead socket must not survive")
+    assert client._relay_status == "inactive", (
+        f"an abnormal disconnect must return status to inactive, got {client._relay_status!r}")
+
+
+@pytest.mark.asyncio
+async def test_gateway_cancels_inflight_tasks_on_abnormal_disconnect(client, monkeypatch):
+    """An in-flight proxy task keyed to the pre-disconnect generation must be cancelled
+    by teardown when the socket drops abnormally: once the socket that carried it is
+    dead, its response can never be delivered, so leaving it running leaks a task and
+    an unfenced handler. At HEAD teardown is skipped, so the task keeps running."""
+    from websockets.exceptions import ConnectionClosedError
+
+    _drive_abnormal_disconnect(client, monkeypatch)
+
+    started = asyncio.Event()
+
+    async def _never_finishes():
+        started.set()
+        await asyncio.sleep(3600)
+
+    inflight = asyncio.create_task(_never_finishes())
+    await asyncio.wait_for(started.wait(), timeout=1)
+    client._inflight["req-inflight"] = inflight
+
+    try:
+        with pytest.raises(ConnectionClosedError):
+            await client._connect_and_serve()
+
+        # Give any teardown-scheduled cancellation a turn to take effect.
+        await asyncio.sleep(0)
+        assert inflight.cancelled() or (inflight.done() and inflight.exception() is not None), (
+            "an in-flight proxy task keyed to the dead connection must be cancelled on "
+            "abnormal disconnect; at HEAD teardown is skipped so it is still running")
+    finally:
+        if not inflight.done():
+            inflight.cancel()
+            try:
+                await inflight
+            except (asyncio.CancelledError, Exception):
+                pass

--- a/tests/test_gateway/test_proxy_lifecycle.py
+++ b/tests/test_gateway/test_proxy_lifecycle.py
@@ -1,0 +1,209 @@
+# Copyright (c) 2026 Noah Severs
+# SPDX-License-Identifier: LicenseRef-Proprietary
+
+"""Proxied-request lifecycle on the gateway client: cancel, deadline, generation
+fencing, and one bounded shared httpx client.
+
+A relayed request was fire-and-forget with a fixed 180s timeout, a fresh httpx
+client per request, and no way to abort an in-flight proxy task or to drop a
+response that arrived after the connection had already been rebuilt. These tests
+pin the bounded contract:
+
+  * `http.cancel` cancels the keyed in-flight proxy task for that request id.
+  * `http.request` carrying `timeout_ms` cancels past that deadline and emits an
+    error response rather than hanging to the fixed cap.
+  * a response tagged with a prior connection generation is ignored after a
+    reconnect, so a slow response from a dead socket can't clobber the live one.
+  * the client forwards through one shared httpx client with explicit connection
+    limits, not a new client constructed per request.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from celerp.gateway.client import GatewayClient
+
+
+@pytest.fixture
+def client():
+    return GatewayClient(
+        gateway_token="test-gateway-token",
+        instance_id="test-instance-id",
+        gateway_url="wss://relay.celerp.com/ws/connect",
+    )
+
+
+def _keyed_tasks(client) -> dict:
+    """The in-flight proxy tasks keyed by request id, whatever attribute holds them."""
+    for name in ("_inflight", "_proxy_tasks", "_inflight_tasks", "_requests"):
+        val = getattr(client, name, None)
+        if isinstance(val, dict):
+            return val
+    return {}
+
+
+@pytest.mark.asyncio
+async def test_gateway_http_cancel_aborts_inflight(client, monkeypatch):
+    """An http.cancel frame cancels the keyed in-flight proxy task for its id."""
+    started = asyncio.Event()
+
+    async def _never_finishes(payload):
+        started.set()
+        await asyncio.sleep(3600)
+
+    monkeypatch.setattr(client, "_handle_proxy_request", _never_finishes)
+
+    async def _noop_send(ws, msg):
+        pass
+    monkeypatch.setattr(client.__class__, "_send", staticmethod(_noop_send))
+    client._ws = object()
+
+    await client._dispatch({"type": "http.request",
+                            "payload": {"id": "req-1", "method": "GET", "path": "/x"}})
+    await asyncio.wait_for(started.wait(), timeout=1)
+
+    keyed = _keyed_tasks(client)
+    assert "req-1" in keyed, "an in-flight proxy task must be keyed by its request id"
+    task = keyed["req-1"]
+
+    await client._dispatch({"type": "http.cancel", "payload": {"id": "req-1"}})
+    await asyncio.sleep(0)
+    assert task.cancelled() or task.done(), "http.cancel must cancel the keyed in-flight task"
+
+
+@pytest.mark.asyncio
+async def test_gateway_timeout_ms_deadline(client, monkeypatch):
+    """A proxied request carrying timeout_ms is cancelled past that deadline and an
+    error response is emitted, rather than hanging to the fixed 180s cap."""
+    import httpx
+
+    class _HangingClient:
+        def __init__(self, *a, **k):
+            pass
+        async def __aenter__(self):
+            return self
+        async def __aexit__(self, *a):
+            return False
+        async def request(self, *a, **k):
+            await asyncio.sleep(3600)  # never returns within the deadline
+
+    monkeypatch.setattr(httpx, "AsyncClient", _HangingClient)
+
+    sent = []
+
+    async def _capture_send(ws, msg):
+        sent.append(msg)
+    monkeypatch.setattr(client.__class__, "_send", staticmethod(_capture_send))
+    client._ws = object()
+
+    await asyncio.wait_for(
+        client._handle_proxy_request({
+            "id": "req-timeout", "method": "GET", "path": "/slow",
+            "query": "", "headers": {}, "body_b64": "", "timeout_ms": 50,
+        }),
+        timeout=5,
+    )
+
+    assert sent, "a request past its deadline must emit a response, not hang silently"
+    payload = sent[-1]["payload"]
+    assert payload["id"] == "req-timeout"
+    assert payload["status"] >= 500, (
+        f"a deadline overrun must surface as an error status, got {payload['status']}")
+
+
+@pytest.mark.asyncio
+async def test_gateway_stale_generation_dropped(client, monkeypatch):
+    """A response tagged with a prior connection generation is dropped after a
+    reconnect: a slow response from a dead socket must not be sent on the new one."""
+    import httpx
+
+    resume = asyncio.Event()
+
+    class _SlowClient:
+        def __init__(self, *a, **k):
+            pass
+        async def __aenter__(self):
+            return self
+        async def __aexit__(self, *a):
+            return False
+        async def request(self, *a, **k):
+            await resume.wait()
+
+            class _R:
+                status_code = 200
+                content = b"stale"
+                headers = httpx.Headers()
+            return _R()
+
+    monkeypatch.setattr(httpx, "AsyncClient", _SlowClient)
+
+    sent = []
+
+    async def _capture_send(ws, msg):
+        sent.append(msg)
+    monkeypatch.setattr(client.__class__, "_send", staticmethod(_capture_send))
+    client._ws = object()
+
+    gen_before = getattr(client, "_generation", None)
+    assert gen_before is not None, "the client must tag proxy work with a connection generation"
+
+    task = asyncio.create_task(client._handle_proxy_request({
+        "id": "req-stale", "method": "GET", "path": "/x",
+        "query": "", "headers": {}, "body_b64": "",
+    }))
+    await asyncio.sleep(0.05)
+
+    # Reconnect happens while the request is still in flight: bump the generation.
+    client._generation = gen_before + 1
+    resume.set()
+    await asyncio.wait_for(task, timeout=5)
+
+    stale = [m for m in sent
+             if m.get("type") == "http.response" and m["payload"].get("id") == "req-stale"]
+    assert not stale, "a response from a superseded connection generation must be dropped"
+
+
+@pytest.mark.asyncio
+async def test_gateway_shared_client_bounded(client, monkeypatch):
+    """Two proxied requests forward through ONE shared httpx client with explicit
+    connection limits, not a fresh client constructed per request."""
+    import httpx
+
+    constructed = []
+    seen_limits = []
+
+    class _CountingClient:
+        def __init__(self, *a, **k):
+            constructed.append(self)
+            seen_limits.append(k.get("limits"))
+        async def __aenter__(self):
+            return self
+        async def __aexit__(self, *a):
+            return False
+        async def request(self, *a, **k):
+            class _R:
+                status_code = 200
+                content = b"ok"
+                headers = httpx.Headers()
+            return _R()
+
+    monkeypatch.setattr(httpx, "AsyncClient", _CountingClient)
+
+    async def _noop_send(ws, msg):
+        pass
+    monkeypatch.setattr(client.__class__, "_send", staticmethod(_noop_send))
+    client._ws = object()
+
+    for i in range(2):
+        await client._handle_proxy_request({
+            "id": f"req-{i}", "method": "GET", "path": "/x",
+            "query": "", "headers": {}, "body_b64": "",
+        })
+
+    assert len(constructed) == 1, (
+        f"the gateway must reuse one shared httpx client, constructed {len(constructed)}")
+    assert any(isinstance(lim, httpx.Limits) for lim in seen_limits), (
+        "the shared client must be built with explicit httpx.Limits")

--- a/tests/test_gateway/test_proxy_lifecycle.py
+++ b/tests/test_gateway/test_proxy_lifecycle.py
@@ -321,3 +321,41 @@ async def test_gateway_cancels_inflight_tasks_on_abnormal_disconnect(client, mon
                 await inflight
             except (asyncio.CancelledError, Exception):
                 pass
+
+
+@pytest.mark.asyncio
+async def test_gateway_send_self_terminates_on_wedged_socket(client, monkeypatch):
+    """A websocket send that never drains must not hang forever. The send is bounded by a
+    deadline: on a wedged socket it raises TimeoutError so the proxy task is freed and the
+    socket can be rebuilt, rather than pinning a relay slot indefinitely.
+
+    Observable: send_message returns control (raises) on its own deadline, well before the
+    outer guard. At head there is no deadline, so send_message never returns and only the
+    outer wait_for trips - which the elapsed-time assertion catches."""
+    import time
+    import celerp.gateway.client as gw
+
+    # Shrink the deadline so the test is fast; the behaviour under test is that a deadline
+    # fires, not its production seconds value. raising=False so that without a deadline the
+    # send still hangs and the elapsed assertion below is what fails - the red is the hang,
+    # never a missing symbol.
+    monkeypatch.setattr(gw, "_SEND_DEADLINE", 0.1, raising=False)
+
+    entered = asyncio.Event()
+
+    class _WedgedWS:
+        async def send(self, _data):
+            entered.set()
+            await asyncio.Event().wait()  # the frame never drains
+
+    client._ws = _WedgedWS()
+
+    t0 = time.monotonic()
+    with pytest.raises(TimeoutError):
+        await asyncio.wait_for(client.send_message("hello_ack"), timeout=5)
+    elapsed = time.monotonic() - t0
+
+    assert entered.is_set(), "the send must have been attempted"
+    assert elapsed < 2.0, (
+        f"a wedged send must self-terminate on its own ~0.1s deadline, not hang to the "
+        f"outer 5s guard; took {elapsed:.2f}s")

--- a/tests/test_gateway/test_send_deadline_py310.py
+++ b/tests/test_gateway/test_send_deadline_py310.py
@@ -1,0 +1,42 @@
+# Copyright (c) 2026 Noah Severs
+# SPDX-License-Identifier: LicenseRef-Proprietary
+"""The gateway send deadline must work on Python 3.10, the package's floor.
+
+pyproject sets requires-python >=3.10, but asyncio.timeout only exists on 3.11+. A
+send deadline built on asyncio.timeout raises AttributeError on 3.10 instead of
+bounding the send, so every gateway send fails on the minimum supported interpreter.
+The deadline must use asyncio.wait_for, which exists on 3.10.
+
+This drives the real _send against a stalled websocket under a 3.10-like runtime
+(asyncio.timeout removed) and asserts it surfaces TimeoutError - the honest deadline
+behaviour - never an AttributeError from a missing 3.11 primitive. It asserts the
+observable outcome of the send, not the name of the timeout primitive in the source.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+import celerp.gateway.client as gw
+
+
+class _StalledWS:
+    """A websocket whose send never settles - a backpressured or half-open peer."""
+
+    async def send(self, _data: str) -> None:
+        await asyncio.sleep(3600)
+
+
+@pytest.mark.asyncio
+async def test_send_bounds_on_py310_runtime(monkeypatch):
+    """On a 3.10-like runtime (asyncio.timeout absent), a send to a stalled peer must
+    still hit its deadline and raise TimeoutError. On the broken code the missing
+    asyncio.timeout raises AttributeError before the deadline can fire."""
+    # Simulate Python 3.10: asyncio.timeout does not exist there.
+    monkeypatch.delattr(asyncio, "timeout", raising=False)
+    # Shrink the deadline so the test does not wait the full production window.
+    monkeypatch.setattr(gw, "_SEND_DEADLINE", 0.05)
+
+    with pytest.raises(TimeoutError):
+        await gw.GatewayClient._send(_StalledWS(), {"type": "ping", "id": "x"})

--- a/tests/test_routers/test_backup_active_503.py
+++ b/tests/test_routers/test_backup_active_503.py
@@ -1,0 +1,45 @@
+# Copyright (c) 2026 Noah Severs
+# SPDX-License-Identifier: LicenseRef-Proprietary
+
+"""The backup-banner poll must surface an upstream failure as HTTP 503.
+
+`/backup/active` catches any upstream backup-status error and returns a body of
+{"state": "error"} with a DEFAULT 200 status. To the poller, a failed backend
+read is then indistinguishable from a healthy 200 response, so an outage looks
+healthy at the HTTP layer. The route must return 503 on upstream failure so the
+observable status the client sees reflects the outage.
+"""
+
+from __future__ import annotations
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+from unittest.mock import AsyncMock, patch
+
+from test_helpers import make_test_token
+
+
+@pytest.fixture
+def ui_app():
+    from ui.app import app as _app
+    return _app
+
+
+def _cookies() -> dict:
+    return {"celerp_token": make_test_token(role="owner")}
+
+
+@pytest.mark.asyncio
+async def test_backup_active_returns_503_on_upstream_failure(ui_app):
+    """With a valid owner token (past the token gate) but a failing upstream
+    backup-status read, /backup/active must respond 503 - the status the client
+    observes - not a bare 200 that reads as a healthy backend."""
+    failing = AsyncMock(side_effect=RuntimeError("backup service unreachable"))
+    with patch("ui.api_client.get_backup_status", new=failing):
+        async with AsyncClient(transport=ASGITransport(app=ui_app),
+                               base_url="http://ui", follow_redirects=False) as c:
+            r = await c.get("/backup/active", cookies=_cookies())
+
+    assert r.status_code == 503, (
+        f"an upstream backup-status failure must surface as HTTP 503, not "
+        f"{r.status_code}; body={r.text}")

--- a/tests/test_routers/test_backup_active_state.py
+++ b/tests/test_routers/test_backup_active_state.py
@@ -1,0 +1,48 @@
+# Copyright (c) 2026 Noah Severs
+# SPDX-License-Identifier: LicenseRef-Proprietary
+
+"""The backup-banner poll must tell the truth about an upstream failure.
+
+`/backup/active` collapsed any upstream error into {"active": false}, which is
+indistinguishable from a healthy idle backend. The banner then silently hides an
+outage. The endpoint must surface an upstream failure as a distinct state so the
+client can tell "no backup running" apart from "could not reach the backup
+service".
+"""
+
+from __future__ import annotations
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+from unittest.mock import AsyncMock, patch
+
+from test_helpers import make_test_token
+
+
+@pytest.fixture
+def ui_app():
+    from ui.app import app as _app
+    return _app
+
+
+def _cookies() -> dict:
+    return {"celerp_token": make_test_token(role="owner")}
+
+
+@pytest.mark.asyncio
+async def test_backup_active_reports_error_state(ui_app):
+    """When the upstream backup-status call raises, /backup/active must report a
+    distinct error/unknown state, never a bare {"active": false} that reads as a
+    healthy idle backend."""
+    failing = AsyncMock(side_effect=RuntimeError("backup service unreachable"))
+    with patch("ui.api_client.get_backup_status", new=failing):
+        async with AsyncClient(transport=ASGITransport(app=ui_app),
+                               base_url="http://ui", follow_redirects=False) as c:
+            r = await c.get("/backup/active", cookies=_cookies())
+
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body != {"active": False}, (
+        "an upstream failure must not masquerade as a healthy idle backend")
+    assert body.get("error") or body.get("state") in ("error", "unknown"), (
+        f"the failure must surface as a distinct error/unknown state, got {body}")

--- a/tests/test_routers/test_backup_active_state.py
+++ b/tests/test_routers/test_backup_active_state.py
@@ -40,7 +40,7 @@ async def test_backup_active_reports_error_state(ui_app):
                                base_url="http://ui", follow_redirects=False) as c:
             r = await c.get("/backup/active", cookies=_cookies())
 
-    assert r.status_code == 200, r.text
+    assert r.status_code == 503, r.text
     body = r.json()
     assert body != {"active": False}, (
         "an upstream failure must not masquerade as a healthy idle backend")

--- a/tests/test_routers/test_list_detail_metadata_fanout.py
+++ b/tests/test_routers/test_list_detail_metadata_fanout.py
@@ -1,14 +1,14 @@
 # Copyright (c) 2026 Noah Severs
 # SPDX-License-Identifier: LicenseRef-Proprietary
 
-"""list_detail item-metadata must be bounded: ONE bulk call, never one per line.
+"""list_detail item-metadata must be bounded: enriched server-side, never fetched per line.
 
 A large list rendered the item-metadata map by fanning out one internal item
 fetch per line, so a 2000-line list issued ~2000 authenticated requests and
-exhausted the API DB pool. The renderer must instead issue a single bulk
-metadata call whose count is constant regardless of line count, and when that
-bulk call fails it must degrade to the stored line values (empty meta map), never
-fabricate metadata and never crash the page.
+exhausted the API DB pool. The page endpoint now enriches the visible slice and
+returns it as item_meta in the same body, so the renderer issues ZERO UI-side
+metadata calls regardless of line count; when the body carries no item_meta it
+degrades to the stored line values, never fabricating metadata and never crashing.
 """
 
 from __future__ import annotations
@@ -45,30 +45,37 @@ def _audit_list(n_lines: int) -> dict:
     }
 
 
-def _page_side_effect(list_payload: dict):
+def _page_side_effect(list_payload: dict, include_meta: bool = True):
     """Serve one bounded page from the stored array, mirroring the /page endpoint:
-    the list header (stored state without line_items) plus the requested slice."""
+    the list header (stored state without line_items), the requested slice, and (as the
+    real server now does) an item_meta map for the slice unless include_meta is False."""
     lines = list_payload.get("line_items", [])
     header = {k: v for k, v in list_payload.items() if k != "line_items"}
 
     async def _page(token, entity_id, offset: int = 0, limit: int = 100):
         off = max(0, int(offset))
         lim = max(1, min(int(limit), 100))
-        return {
+        page_items = lines[off:off + lim]
+        body = {
             "list": header,
-            "items": lines[off:off + lim],
+            "items": page_items,
             "total": len(lines),
             "version": list_payload.get("version", 1),
         }
+        if include_meta:
+            body["item_meta"] = {li["item_id"]: _item_meta(li["item_id"])
+                                 for li in page_items if li.get("item_id")}
+        return body
 
     return _page
 
 
-def _base_stubs(list_payload: dict) -> dict:
+def _base_stubs(list_payload: dict, include_meta: bool = True) -> dict:
     """The api.* stubs list_detail touches, all safe defaults so the render reaches
     (and completes) the metadata block without external calls."""
     return {
-        "ui.api_client.get_list_page": AsyncMock(side_effect=_page_side_effect(list_payload)),
+        "ui.api_client.get_list_page": AsyncMock(
+            side_effect=_page_side_effect(list_payload, include_meta)),
         "ui.api_client.get_company": AsyncMock(return_value={"name": "Co", "settings": {}}),
         "ui.api_client.get_price_lists": AsyncMock(return_value=[]),
         "ui.api_client.get_taxes": AsyncMock(return_value=[]),
@@ -102,8 +109,9 @@ def _item_meta(eid: str) -> dict:
 
 @pytest.mark.asyncio
 async def test_list_detail_bounded_metadata_calls(ui_app):
-    """A 2000-line list issues EXACTLY ONE bulk metadata call and never calls the
-    per-item get_item; the call count is constant, not proportional to line count."""
+    """A 2000-line list issues ZERO UI-side metadata calls: the enrichment arrives in the
+    page body's item_meta, so neither the per-item get_item nor a bulk get_items_metadata
+    runs, whatever the line count."""
     n = 2000
     get_item_spy = AsyncMock(side_effect=lambda token, eid: _item_meta(eid))
     bulk_spy = AsyncMock(side_effect=lambda token, eids: {e: _item_meta(e) for e in eids})
@@ -120,18 +128,20 @@ async def test_list_detail_bounded_metadata_calls(ui_app):
     assert r.status_code == 200, r.text
     assert get_item_spy.call_count == 0, (
         f"per-line fan-out must be gone; get_item called {get_item_spy.call_count} times")
-    assert bulk_spy.call_count == 1, (
-        f"exactly one bulk metadata call expected, got {bulk_spy.call_count}")
+    assert bulk_spy.call_count == 0, (
+        f"UI-side metadata fetching must be gone (the server enriches the page body); "
+        f"get_items_metadata called {bulk_spy.call_count} times")
 
 
 @pytest.mark.asyncio
-async def test_list_detail_bulk_failure_degrades_to_stored_values(ui_app):
-    """When the bulk metadata call raises, the page still renders (200) from stored
-    line values with an empty meta map; no fabricated metadata, no crash."""
-    bulk_spy = AsyncMock(side_effect=RuntimeError("bulk metadata unavailable"))
+async def test_list_detail_missing_item_meta_degrades_to_stored_values(ui_app):
+    """When the page body carries no item_meta (server enrichment unavailable), the page
+    still renders (200) from the stored line values; no fabricated metadata, no per-line
+    or bulk fallback fetch, no crash."""
+    bulk_spy = AsyncMock(side_effect=lambda token, eids: {e: _item_meta(e) for e in eids})
     get_item_spy = AsyncMock(side_effect=lambda token, eid: _item_meta(eid))
 
-    stubs = _base_stubs(_audit_list(5))
+    stubs = _base_stubs(_audit_list(5), include_meta=False)
     stubs["ui.api_client.get_item"] = get_item_spy
     stubs["ui.api_client.get_items_metadata"] = bulk_spy
 
@@ -141,7 +151,6 @@ async def test_list_detail_bulk_failure_degrades_to_stored_values(ui_app):
             r = await c.get("/lists/list:big", cookies=_cookies())
 
     assert r.status_code == 200, r.text
-    assert bulk_spy.call_count == 1, (
-        f"the single bulk call must be attempted, got {bulk_spy.call_count}")
-    assert get_item_spy.call_count == 0, (
-        "the failed bulk call must not fall back to per-line fan-out")
+    assert "Item 0" in r.text, "stored line description must still render when item_meta is absent"
+    assert get_item_spy.call_count == 0 and bulk_spy.call_count == 0, (
+        "an absent item_meta must degrade to stored values, never fall back to a UI-side fetch")

--- a/tests/test_routers/test_list_detail_metadata_fanout.py
+++ b/tests/test_routers/test_list_detail_metadata_fanout.py
@@ -45,11 +45,30 @@ def _audit_list(n_lines: int) -> dict:
     }
 
 
+def _page_side_effect(list_payload: dict):
+    """Serve one bounded page from the stored array, mirroring the /page endpoint:
+    the list header (stored state without line_items) plus the requested slice."""
+    lines = list_payload.get("line_items", [])
+    header = {k: v for k, v in list_payload.items() if k != "line_items"}
+
+    async def _page(token, entity_id, offset: int = 0, limit: int = 100):
+        off = max(0, int(offset))
+        lim = max(1, min(int(limit), 100))
+        return {
+            "list": header,
+            "items": lines[off:off + lim],
+            "total": len(lines),
+            "version": list_payload.get("version", 1),
+        }
+
+    return _page
+
+
 def _base_stubs(list_payload: dict) -> dict:
     """The api.* stubs list_detail touches, all safe defaults so the render reaches
     (and completes) the metadata block without external calls."""
     return {
-        "ui.api_client.get_list": AsyncMock(return_value=list_payload),
+        "ui.api_client.get_list_page": AsyncMock(side_effect=_page_side_effect(list_payload)),
         "ui.api_client.get_company": AsyncMock(return_value={"name": "Co", "settings": {}}),
         "ui.api_client.get_price_lists": AsyncMock(return_value=[]),
         "ui.api_client.get_taxes": AsyncMock(return_value=[]),

--- a/tests/test_routers/test_list_detail_pagination.py
+++ b/tests/test_routers/test_list_detail_pagination.py
@@ -1,0 +1,133 @@
+# Copyright (c) 2026 Noah Severs
+# SPDX-License-Identifier: LicenseRef-Proprietary
+
+"""list_detail must render one bounded page of lines, not the whole array.
+
+A large list rendered every stored line in one pass, so a 2000-line list built
+2000 editable rows in the response. The renderer must instead render at most one
+page of rows with a pager, and a finalized-row field edit on a later page must
+address the page-absolute stored index (offset + in-page position), not the
+in-page position alone, so the correct stored line is edited.
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+from unittest.mock import AsyncMock, patch
+
+from test_helpers import make_test_token
+
+
+_PAGE_LIMIT = 100
+
+
+@pytest.fixture
+def ui_app():
+    from ui.app import app as _app
+    return _app
+
+
+def _cookies() -> dict:
+    return {"celerp_token": make_test_token(role="owner")}
+
+
+def _finalized_list(n_lines: int) -> dict:
+    """A finalized (non-draft) list with n_lines lines; finalized rows render the
+    double-click-to-edit cells whose edit URL carries the stored line index."""
+    return {
+        "entity_id": "list:big",
+        "id": "list:big",
+        "list_type": "quotation",
+        "doc_type": "list",
+        "status": "finalized",
+        "created_at": "2026-01-01",
+        "version": 3,
+        "line_items": [
+            {"item_id": f"item:{i}", "entity_id": f"item:{i}",
+             "sku": f"SKU{i}", "description": f"Item {i}",
+             "quantity": 1, "unit_price": 1.0}
+            for i in range(n_lines)
+        ],
+    }
+
+
+def _base_stubs(list_payload: dict) -> dict:
+    """The api.* calls list_detail makes, stubbed to safe defaults so the render
+    reaches (and completes) the line-table block without external calls."""
+    return {
+        "ui.api_client.get_list": AsyncMock(return_value=list_payload),
+        "ui.api_client.get_company": AsyncMock(return_value={"name": "Co", "settings": {}}),
+        "ui.api_client.get_price_lists": AsyncMock(return_value=[]),
+        "ui.api_client.get_taxes": AsyncMock(return_value=[]),
+        "ui.api_client.list_list_notes": AsyncMock(return_value=[]),
+        "ui.api_client.get_locations": AsyncMock(return_value={"items": [], "total": 0}),
+        "ui.api_client.get_units": AsyncMock(return_value=[]),
+        "ui.api_client.get_chart": AsyncMock(return_value={"items": [], "total": 0}),
+        "ui.api_client.get_relay_status": AsyncMock(return_value={}),
+        "ui.api_client.get_share_state": AsyncMock(return_value={}),
+        "ui.api_client.get_items_metadata": AsyncMock(return_value={}),
+        "ui.api_client.get_item": AsyncMock(return_value={}),
+    }
+
+
+class _Patches:
+    def __init__(self, mocks: dict):
+        self._patches = [patch(k, new=v) for k, v in mocks.items()]
+
+    def __enter__(self):
+        for p in self._patches:
+            p.start()
+        return self
+
+    def __exit__(self, *a):
+        for p in self._patches:
+            p.stop()
+
+
+async def _get_list_detail(ui_app, path: str) -> str:
+    with _Patches(_base_stubs(_finalized_list(250))):
+        async with AsyncClient(transport=ASGITransport(app=ui_app),
+                               base_url="http://ui", follow_redirects=False) as c:
+            r = await c.get(path, cookies=_cookies())
+    assert r.status_code == 200, r.text
+    return r.text
+
+
+def _line_edit_indices(html: str) -> list[int]:
+    """Every stored line index referenced by a finalized field-edit cell URL."""
+    return [int(m) for m in re.findall(r"/(?:docs|lists)/list:big/line/(\d+)/field/", html)]
+
+
+def _row_count(html: str) -> int:
+    """Editable finalized cells are keyed one per (line, field); the distinct line
+    indices they reference is the count of rendered line rows."""
+    return len(set(_line_edit_indices(html)))
+
+
+@pytest.mark.asyncio
+async def test_list_detail_renders_one_page(ui_app):
+    """A 250-line finalized list renders at most one page of line rows and a pager,
+    not the full array."""
+    html = await _get_list_detail(ui_app, "/lists/list:big")
+    rendered = _row_count(html)
+    assert 0 < rendered <= _PAGE_LIMIT, (
+        f"the render must be bounded to one page (<= {_PAGE_LIMIT} rows), "
+        f"got {rendered} distinct line rows")
+    assert "line-pager" in html or "list-line-pager" in html, (
+        "a large list must render a pager to reach off-page lines")
+
+
+@pytest.mark.asyncio
+async def test_list_detail_field_edit_page_absolute_idx(ui_app):
+    """A finalized-row field edit on page 2 addresses the page-absolute offset+i
+    stored index, so the correct stored line is edited."""
+    html = await _get_list_detail(ui_app, "/lists/list:big?offset=100&limit=100")
+    indices = _line_edit_indices(html)
+    assert indices, "page 2 must render finalized-row edit cells"
+    assert min(indices) >= 100, (
+        "page-2 edit cells must address page-absolute stored indices (offset+i); "
+        f"got indices starting at {min(indices)}")
+    assert max(indices) < 200, f"page 2 must not run past its window; got up to {max(indices)}"

--- a/tests/test_routers/test_list_detail_pagination.py
+++ b/tests/test_routers/test_list_detail_pagination.py
@@ -4,9 +4,9 @@
 """list_detail must render one bounded page of lines, not the whole array.
 
 A large list rendered every stored line in one pass, so a 2000-line list built
-2000 editable rows in the response. The renderer must instead render at most one
-page of rows with a pager, and a finalized-row field edit on a later page must
-address the page-absolute stored index (offset + in-page position), not the
+2000 editable rows in the response. The renderer must instead fetch and render at
+most one page of rows with a pager, and a finalized-row field edit on a later page
+must address the page-absolute stored index (offset + in-page position), not the
 in-page position alone, so the correct stored line is edited.
 """
 
@@ -54,10 +54,32 @@ def _finalized_list(n_lines: int) -> dict:
     }
 
 
-def _base_stubs(list_payload: dict) -> dict:
+def _page_side_effect(list_payload: dict):
+    """Serve one bounded page from the stored array, mirroring the /page endpoint:
+    the list header (stored state without line_items) plus the requested slice."""
+    lines = list_payload.get("line_items", [])
+    header = {k: v for k, v in list_payload.items() if k != "line_items"}
+
+    async def _page(token, entity_id, offset: int = 0, limit: int = 100):
+        off = max(0, int(offset))
+        lim = max(1, min(int(limit), _PAGE_LIMIT))
+        return {
+            "list": header,
+            "items": lines[off:off + lim],
+            "total": len(lines),
+            "version": list_payload.get("version", 3),
+        }
+
+    return _page
+
+
+def _base_stubs(list_payload: dict, page_mock: AsyncMock) -> dict:
     """The api.* calls list_detail makes, stubbed to safe defaults so the render
-    reaches (and completes) the line-table block without external calls."""
+    reaches (and completes) the line-table block without external calls. get_list is
+    kept stubbed so no real network call happens and the unchanged pre-fix code (which
+    reads the full array from it) renders without error."""
     return {
+        "ui.api_client.get_list_page": page_mock,
         "ui.api_client.get_list": AsyncMock(return_value=list_payload),
         "ui.api_client.get_company": AsyncMock(return_value={"name": "Co", "settings": {}}),
         "ui.api_client.get_price_lists": AsyncMock(return_value=[]),
@@ -75,7 +97,8 @@ def _base_stubs(list_payload: dict) -> dict:
 
 class _Patches:
     def __init__(self, mocks: dict):
-        self._patches = [patch(k, new=v) for k, v in mocks.items()]
+        # create=True because get_list_page does not exist at merge-base; the fix adds it.
+        self._patches = [patch(k, create=True, new=v) for k, v in mocks.items()]
 
     def __enter__(self):
         for p in self._patches:
@@ -87,13 +110,15 @@ class _Patches:
             p.stop()
 
 
-async def _get_list_detail(ui_app, path: str) -> str:
-    with _Patches(_base_stubs(_finalized_list(250))):
+async def _get_list_detail(ui_app, path: str) -> tuple[str, AsyncMock]:
+    payload = _finalized_list(250)
+    page_mock = AsyncMock(side_effect=_page_side_effect(payload))
+    with _Patches(_base_stubs(payload, page_mock)):
         async with AsyncClient(transport=ASGITransport(app=ui_app),
                                base_url="http://ui", follow_redirects=False) as c:
             r = await c.get(path, cookies=_cookies())
     assert r.status_code == 200, r.text
-    return r.text
+    return r.text, page_mock
 
 
 def _line_edit_indices(html: str) -> list[int]:
@@ -110,21 +135,24 @@ def _row_count(html: str) -> int:
 @pytest.mark.asyncio
 async def test_list_detail_renders_one_page(ui_app):
     """A 250-line finalized list renders at most one page of line rows and a pager,
-    not the full array."""
-    html = await _get_list_detail(ui_app, "/lists/list:big")
+    not the full array, and fetches that page through the bounded endpoint."""
+    html, page_mock = await _get_list_detail(ui_app, "/lists/list:big")
     rendered = _row_count(html)
     assert 0 < rendered <= _PAGE_LIMIT, (
         f"the render must be bounded to one page (<= {_PAGE_LIMIT} rows), "
         f"got {rendered} distinct line rows")
     assert "line-pager" in html or "list-line-pager" in html, (
         "a large list must render a pager to reach off-page lines")
+    assert page_mock.await_count >= 1, (
+        "the detail view must fetch its page through the bounded endpoint, "
+        "not load the whole list")
 
 
 @pytest.mark.asyncio
 async def test_list_detail_field_edit_page_absolute_idx(ui_app):
     """A finalized-row field edit on page 2 addresses the page-absolute offset+i
     stored index, so the correct stored line is edited."""
-    html = await _get_list_detail(ui_app, "/lists/list:big?offset=100&limit=100")
+    html, _ = await _get_list_detail(ui_app, "/lists/list:big?offset=100&limit=100")
     indices = _line_edit_indices(html)
     assert indices, "page 2 must render finalized-row edit cells"
     assert min(indices) >= 100, (

--- a/tests/test_routers/test_list_detail_roundtrips.py
+++ b/tests/test_routers/test_list_detail_roundtrips.py
@@ -1,0 +1,255 @@
+# Copyright (c) 2026 Noah Severs
+# SPDX-License-Identifier: LicenseRef-Proprietary
+
+"""list_detail / audit refresh must not make extra unbounded UI-to-API round trips.
+
+The incident: rendering a list detail issued three backend round trips per view
+(the bounded page, then a units read, then a bulk item-metadata read), and the
+audit scan / set-scanned tbody swaps each re-fetched the WHOLE list through the
+unbounded /lists/{id} endpoint and enriched every stored line, not the visible
+page. On a large list that is a burst of avoidable authenticated requests into the
+shared API pool.
+
+These tests measure OBSERVABLE BEHAVIOR at the transport boundary: they install an
+httpx.MockTransport at ui.api_client._get_transport (the single hook every UI-to-API
+request is driven through) and record the method+path of every outbound round trip
+the real api_client functions make while a route renders. The assertions are about
+the wire traffic, not about which python helper was called.
+
+Fix direction (green): the vendored server /lists/{id}/page returns enriched
+`item_meta` in the same body, list_detail consumes it and drops the units +
+items/metadata follow-ups, and the audit scan / set-scanned tbody uses the bounded
+page path so the unbounded /lists/{id} is never requested.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import threading
+
+import httpx
+import pytest
+from unittest.mock import patch
+
+from httpx import ASGITransport, AsyncClient
+
+from test_helpers import make_test_token
+
+
+_PAGE_CAP = 100
+
+
+@pytest.fixture
+def ui_app():
+    from ui.app import app as _app
+    return _app
+
+
+def _cookies() -> dict:
+    return {"celerp_token": make_test_token(role="owner")}
+
+
+class _RecordingBackend:
+    """An httpx.MockTransport handler that records every outbound (method, path) the
+    UI client drives and answers each known backend path with valid-enough JSON so the
+    route proceeds through its whole render. Thread-safe: httpx may hand off requests
+    across the event-loop thread pool.
+
+    ``page_items`` is the slice served by /lists/{id}/page; ``full_lines`` is the whole
+    stored array served by the unbounded /lists/{id}. ``page_has_item_meta`` controls
+    whether /page embeds enriched item_meta (green shape) or omits it (HEAD shape, so
+    the handler falls through to the units + metadata follow-ups)."""
+
+    def __init__(self, list_header: dict, page_items: list[dict],
+                 full_lines: list[dict], *, page_has_item_meta: bool):
+        self._lock = threading.Lock()
+        self.requests: list[tuple[str, str]] = []
+        self.page_request_limits: list[int] = []
+        self._header = list_header
+        self._page_items = page_items
+        self._full_lines = full_lines
+        self._page_has_item_meta = page_has_item_meta
+
+    def transport(self) -> httpx.MockTransport:
+        return httpx.MockTransport(self._handle)
+
+    def count(self, method: str, path: str) -> int:
+        with self._lock:
+            return sum(1 for m, p in self.requests if m == method and p == path)
+
+    def _handle(self, request: httpx.Request) -> httpx.Response:
+        method = request.method
+        path = request.url.path
+        with self._lock:
+            self.requests.append((method, path))
+
+        # --- list data endpoints (the ones under test) ---
+        if method == "GET" and path.endswith("/page"):
+            try:
+                lim = int(request.url.params.get("limit", _PAGE_CAP))
+            except (TypeError, ValueError):
+                lim = _PAGE_CAP
+            with self._lock:
+                self.page_request_limits.append(lim)
+            body: dict = {
+                "list": dict(self._header),
+                "items": self._page_items[:lim],
+                "total": len(self._full_lines),
+                "version": self._header.get("version", 1),
+            }
+            if self._page_has_item_meta:
+                body["item_meta"] = {}
+            return _json(body)
+
+        if method == "GET" and re.fullmatch(r"/lists/[^/]+", path):
+            # The UNBOUNDED full-list read. Green code must never request this from a
+            # detail render or an audit tbody swap.
+            return _json({**self._header, "line_items": self._full_lines})
+
+        # --- side reads the render/tbody touches; all safe empties ---
+        if method == "GET" and path == "/companies/me/units":
+            return _json([])
+        if method == "POST" and path == "/items/metadata":
+            return _json({"items": {}})
+        if method == "GET" and path == "/companies/me":
+            return _json({"name": "Co", "settings": {}})
+        if method == "GET" and path == "/companies/me/price-lists":
+            return _json([])
+        if method == "GET" and path == "/companies/me/taxes":
+            return _json([])
+        if method == "GET" and path == "/companies/me/locations":
+            return _json({"items": [], "total": 0})
+        if method == "GET" and path == "/accounting/chart":
+            return _json({"items": [], "total": 0})
+        if method == "GET" and re.fullmatch(r"/lists/[^/]+/notes", path):
+            return _json([])
+        if method == "GET" and re.fullmatch(r"/lists/[^/]+/share.*", path):
+            return _json({})
+        if method == "GET" and re.fullmatch(r"/crm/contacts.*", path):
+            return _json({"items": [], "total": 0})
+        if method == "GET" and path.startswith("/relay"):
+            return _json({})
+
+        # --- scan / set-scanned writes ---
+        if method == "POST" and re.fullmatch(r"/lists/[^/]+/scan", path):
+            return _json({"scanned": 1, "failed": []})
+        if method == "POST" and re.fullmatch(r"/lists/[^/]+/set-scanned", path):
+            return _json({"ok": True})
+
+        # Anything else the render happens to touch: an empty object keeps the page
+        # rendering rather than 500ing, and it is still RECORDED so an unexpected
+        # extra round trip is never silently absorbed.
+        return _json({})
+
+
+def _json(payload) -> httpx.Response:
+    return httpx.Response(200, content=json.dumps(payload).encode(),
+                          headers={"content-type": "application/json"})
+
+
+def _install(backend: _RecordingBackend):
+    """Patch the shared-transport hook so every UI-to-API request runs through the
+    recording MockTransport. Patching _get_transport (not the api.* functions) keeps
+    the real api_client round-trip logic in the loop, which is what we are measuring."""
+    return patch("ui.api_client._get_transport", return_value=backend.transport())
+
+
+def _line(i: int) -> dict:
+    return {"item_id": f"item:{i}", "entity_id": f"item:{i}",
+            "sku": f"SKU{i}", "description": f"Item {i}",
+            "quantity": 1, "unit_price": 1.0}
+
+
+def _audit_header(status: str = "finalized") -> dict:
+    return {
+        "entity_id": "list:big", "id": "list:big",
+        "list_type": "audit", "doc_type": "list",
+        "status": status, "created_at": "2026-01-01", "version": 3,
+    }
+
+
+@pytest.mark.asyncio
+async def test_list_detail_single_outbound_request(ui_app):
+    """Rendering list_detail must issue exactly ONE list-data round trip - the bounded
+    /lists/{id}/page - and ZERO round trips to the units and item-metadata endpoints.
+
+    At HEAD the /page body carries no enriched item_meta, so list_detail follows up
+    with GET /companies/me/units and POST /items/metadata: three list-render round
+    trips instead of one. Observable signal: the recorded outbound requests."""
+    full = [_line(i) for i in range(250)]
+    backend = _RecordingBackend(_audit_header(), page_items=full[:_PAGE_CAP],
+                                full_lines=full, page_has_item_meta=False)
+
+    with _install(backend):
+        async with AsyncClient(transport=ASGITransport(app=ui_app),
+                               base_url="http://ui", follow_redirects=False) as c:
+            r = await c.get("/lists/list:big", cookies=_cookies())
+
+    assert r.status_code == 200, r.text
+
+    page_calls = backend.count("GET", "/lists/list:big/page")
+    units_calls = backend.count("GET", "/companies/me/units")
+    meta_calls = backend.count("POST", "/items/metadata")
+
+    assert page_calls == 1, f"expected exactly one bounded page fetch, got {page_calls}"
+    assert units_calls == 0 and meta_calls == 0, (
+        "list_detail must enrich from the page body, not extra round trips; recorded "
+        f"{units_calls} units + {meta_calls} items/metadata requests: "
+        f"{[rq for rq in backend.requests if rq[1] in ('/companies/me/units', '/items/metadata')]}")
+
+
+@pytest.mark.asyncio
+async def test_audit_scan_tbody_never_requests_unbounded_list(ui_app):
+    """The finalized-audit scan tbody swap must NOT pull the whole list through the
+    unbounded /lists/{id}, and no single list-data request may exceed the page cap.
+
+    At HEAD list_scan reads api.get_list (unbounded) and _audit_line_tbody reads it
+    again, enriching all 250 lines. Observable signal: recorded GET /lists/list:big
+    (no /page suffix) requests."""
+    full = [_line(i) for i in range(250)]
+    backend = _RecordingBackend(_audit_header("finalized"), page_items=full[:_PAGE_CAP],
+                                full_lines=full, page_has_item_meta=True)
+
+    with _install(backend):
+        async with AsyncClient(transport=ASGITransport(app=ui_app),
+                               base_url="http://ui", follow_redirects=False) as c:
+            r = await c.post("/lists/list:big/scan",
+                             data={"barcode": "CODE1"}, cookies=_cookies())
+
+    assert r.status_code == 200, r.text
+
+    unbounded = backend.count("GET", "/lists/list:big")
+    assert unbounded == 0, (
+        "the scan tbody swap must use the bounded page path, never the unbounded "
+        f"full-list read; recorded {unbounded} GET /lists/list:big request(s)")
+    over_cap = [n for n in backend.page_request_limits if n > _PAGE_CAP]
+    assert not over_cap, f"a page request exceeded the cap: limits={backend.page_request_limits}"
+
+
+@pytest.mark.asyncio
+async def test_set_scanned_tbody_never_requests_unbounded_list(ui_app):
+    """The set-scanned tbody swap must not pull the whole list through the unbounded
+    /lists/{id} either, and no list-data request may exceed the page cap.
+
+    At HEAD list_set_scanned renders _audit_line_tbody, which reads api.get_list
+    (unbounded) and enriches all 250 lines. Observable signal: recorded
+    GET /lists/list:big (no /page suffix) requests."""
+    full = [_line(i) for i in range(250)]
+    backend = _RecordingBackend(_audit_header("finalized"), page_items=full[:_PAGE_CAP],
+                                full_lines=full, page_has_item_meta=True)
+
+    with _install(backend):
+        async with AsyncClient(transport=ASGITransport(app=ui_app),
+                               base_url="http://ui", follow_redirects=False) as c:
+            r = await c.post("/lists/list:big/set-scanned",
+                             data={"scanned": "1"}, cookies=_cookies())
+
+    assert r.status_code == 200, r.text
+
+    unbounded = backend.count("GET", "/lists/list:big")
+    assert unbounded == 0, (
+        "the set-scanned tbody swap must use the bounded page path, never the "
+        f"unbounded full-list read; recorded {unbounded} GET /lists/list:big request(s)")
+    over_cap = [n for n in backend.page_request_limits if n > _PAGE_CAP]
+    assert not over_cap, f"a page request exceeded the cap: limits={backend.page_request_limits}"

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -55,6 +55,26 @@ def _authed(token: str | None = None, role: str = "owner") -> dict:
     return {"celerp_token": token or make_test_token(role=role)}
 
 
+def _list_page_stub(payload: dict) -> AsyncMock:
+    """Stub for api.get_list_page, the sole list read used by list_detail. It serves one
+    bounded page from the same stored payload the test already builds: the list header
+    (stored state minus line_items) plus the requested slice, with the total and version."""
+    lines = payload.get("line_items", [])
+    header = {k: v for k, v in payload.items() if k != "line_items"}
+
+    async def _page(token, entity_id, offset=0, limit=100):
+        off = max(0, int(offset))
+        lim = max(1, min(int(limit), 100))
+        return {
+            "list": header,
+            "items": lines[off:off + lim],
+            "total": len(lines),
+            "version": payload.get("version", 1),
+        }
+
+    return AsyncMock(side_effect=_page)
+
+
 async def _inventory_import_with_mapping(ui_client, csv_bytes: bytes):
     """Post CSV to preview, then apply default column mapping and return response."""
     r = await ui_client.post(
@@ -2789,6 +2809,7 @@ class TestDocumentPolish:
         }
         with (
             patch("ui.api_client.get_list", new=AsyncMock(return_value=quotation)),
+            patch("ui.api_client.get_list_page", create=True, new=_list_page_stub(quotation)),
             patch("ui.api_client.get_relay_status", new=AsyncMock(
                 return_value={"connected": False, "relay_status": "error",
                               "gateway_token_set": True,
@@ -2886,8 +2907,10 @@ class TestWriteoffListDetail:
     @pytest.mark.asyncio
     async def test_draft_writeoff_renders_entry_cells_filtered_and_aligned(self, ui_client):
         from bs4 import BeautifulSoup
+        lst = self._wo_list()
         with (
-            patch("ui.api_client.get_list", new=AsyncMock(return_value=self._wo_list())),
+            patch("ui.api_client.get_list", new=AsyncMock(return_value=lst)),
+            patch("ui.api_client.get_list_page", create=True, new=_list_page_stub(lst)),
             patch("ui.api_client.get_chart",
                   new=AsyncMock(return_value={"items": self._WO_CHART, "total": len(self._WO_CHART)})),
         ):
@@ -2922,6 +2945,7 @@ class TestWriteoffListDetail:
         lst = {**self._wo_list(), "status": "finalized"}
         with (
             patch("ui.api_client.get_list", new=AsyncMock(return_value=lst)),
+            patch("ui.api_client.get_list_page", create=True, new=_list_page_stub(lst)),
             patch("ui.api_client.get_chart",
                   new=AsyncMock(return_value={"items": self._WO_CHART, "total": len(self._WO_CHART)})),
         ):
@@ -2937,6 +2961,7 @@ class TestWriteoffListDetail:
         lst = {**self._wo_list(), "status": "closed", "result": "written_off"}
         with (
             patch("ui.api_client.get_list", new=AsyncMock(return_value=lst)),
+            patch("ui.api_client.get_list_page", create=True, new=_list_page_stub(lst)),
             patch("ui.api_client.get_chart",
                   new=AsyncMock(return_value={"items": self._WO_CHART, "total": len(self._WO_CHART)})),
         ):
@@ -4073,11 +4098,12 @@ class TestListsCreateBlank:
 
     @pytest.mark.asyncio
     async def test_save_list_lines_forwards_expected_version_and_returns_new(self, ui_client):
-        """POST /lists/{id}/lines forwards expected_version to api.patch_list and returns the
-        new version from the save, so the page can advance its cached token (optimistic
-        concurrency). Without the plumbing the route neither forwards the token nor returns it."""
+        """POST /lists/{id}/lines saves only the submitted page slice via
+        api.patch_list_line_page(token, entity_id, page, offset, expected_version) and returns
+        the new version from the save, so the page can advance its cached token (optimistic
+        concurrency). The expected_version travels as the 5th positional argument."""
         mock = AsyncMock(return_value={"event_id": 42, "version": 42})
-        with patch("ui.api_client.patch_list", new=mock):
+        with patch("ui.api_client.patch_list_line_page", create=True, new=mock):
             r = await ui_client.post(
                 "/lists/list:WO-1/lines",
                 json={"line_items": [], "subtotal": 0, "tax": 0, "total": 0, "expected_version": 7},
@@ -4086,15 +4112,16 @@ class TestListsCreateBlank:
         assert r.status_code == 200
         assert r.json()["ok"] is True
         assert r.json()["version"] == 42
-        assert mock.await_args.kwargs.get("expected_version") == 7
+        assert mock.await_args.args[4] == 7
 
     @pytest.mark.asyncio
     async def test_save_list_lines_stale_version_returns_structured_409(self, ui_client):
-        """A stale expected_version (backend 409) surfaces as a structured {code: stale_version}
-        body with status 409, so the page branches on the code, never on English message text."""
+        """A stale expected_version (backend 409 from the slice PATCH) surfaces as a structured
+        {code: stale_version} body with status 409, so the page branches on the code, never on
+        English message text."""
         from ui.api_client import APIError
         mock = AsyncMock(side_effect=APIError(409, "This list was changed by someone else; reload to get the latest before saving"))
-        with patch("ui.api_client.patch_list", new=mock):
+        with patch("ui.api_client.patch_list_line_page", create=True, new=mock):
             r = await ui_client.post(
                 "/lists/list:WO-1/lines",
                 json={"line_items": [], "subtotal": 0, "tax": 0, "total": 0, "expected_version": 1},
@@ -10536,7 +10563,11 @@ class TestAuditHighlightScoping:
 
     @pytest.mark.asyncio
     async def test_audit_renders_scanned_highlight(self, ui_client):
-        with patch("ui.api_client.get_list", new=AsyncMock(return_value=self._list("audit"))):
+        lst = self._list("audit")
+        with (
+            patch("ui.api_client.get_list", new=AsyncMock(return_value=lst)),
+            patch("ui.api_client.get_list_page", create=True, new=_list_page_stub(lst)),
+        ):
             r = await ui_client.get("/lists/list:1", cookies=_authed())
         assert r.status_code == 200
         assert "data-row--audited" in r.text
@@ -10656,9 +10687,16 @@ class TestAuditColumnAlignment:
     async def test_draft_audit_shows_add_item_but_counting_hides_it(self, ui_client):
         # A draft audit is editable, so it keeps the Add item affordance; a finalized (counting) audit
         # locks the manifest and hides it.
-        with patch("ui.api_client.get_list", new=AsyncMock(return_value=self._AUDIT)):
+        counting_list = {**self._AUDIT, "status": "finalized"}
+        with (
+            patch("ui.api_client.get_list", new=AsyncMock(return_value=self._AUDIT)),
+            patch("ui.api_client.get_list_page", create=True, new=_list_page_stub(self._AUDIT)),
+        ):
             draft = await ui_client.get("/lists/list:1", cookies=_authed())
-        with patch("ui.api_client.get_list", new=AsyncMock(return_value={**self._AUDIT, "status": "finalized"})):
+        with (
+            patch("ui.api_client.get_list", new=AsyncMock(return_value=counting_list)),
+            patch("ui.api_client.get_list_page", create=True, new=_list_page_stub(counting_list)),
+        ):
             counting = await ui_client.get("/lists/list:1", cookies=_authed())
         assert draft.status_code == 200 and counting.status_code == 200
         # Match the button's onclick (the celerpAddLine() helper is always defined in the page script).

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -3782,10 +3782,27 @@ class TestCSVExport:
 
     @pytest.mark.asyncio
     async def test_docs_export_csv_returns_csv(self, ui_client):
-        csv_bytes = b"entity_id,doc_number,status\ndoc:1,INV-1,paid\n"
-        with patch("ui.api_client.export_docs_csv", new=AsyncMock(return_value=csv_bytes)):
+        """#319: the documents CSV export streams a chunked body straight through to the
+        browser instead of buffering it into UI memory, and forwards Content-Length so the
+        download shows real progress. A buffered route cannot pipe a lazily-yielded
+        generator through, so this is red until the route streams."""
+        chunks = [b"entity_id,doc_number,status\n", b"doc:1,INV-1,paid\n" * 300]
+        total = sum(len(c) for c in chunks)
+
+        async def _fake_stream():
+            for ch in chunks:
+                yield ch
+
+        async def _fake_export(token, params=None):
+            return _fake_stream(), {"content-length": str(total), "content-type": "text/csv"}
+
+        with patch("ui.api_client.export_docs_csv", _fake_export):
             r = await ui_client.get("/docs/export/csv", cookies=_authed())
         assert r.status_code == 200
+        assert r.content == b"".join(chunks)                    # streamed through intact
+        assert r.headers["content-length"] == str(total)        # browser progress bar
+        assert "attachment" in r.headers.get("content-disposition", "")
+        assert r.headers["content-disposition"].endswith("documents.csv")
 
     @pytest.mark.asyncio
     async def test_crm_export_csv_returns_csv(self, ui_client):
@@ -17454,6 +17471,31 @@ async def test_backup_export_streams_with_progress_headers(ui_client):
     assert r.headers["content-length"] == str(total)  # browser progress bar
     assert r.headers["content-disposition"] == "attachment; filename=backup.celerp-backup"
     assert r.headers["content-type"].startswith("application/gzip")
+
+
+@pytest.mark.asyncio
+async def test_lists_export_csv_streams_with_progress_header(ui_client):
+    """#319: the lists CSV export streams the chunked body straight through to the browser
+    rather than buffering it in UI memory, and forwards Content-Length for a real progress
+    bar. A large lists export is exactly the payload the buffered path pinned a pooled
+    connection on; red until the route streams."""
+    chunks = [b"entity_id,ref,customer\n", b"list:1,Q-1,Acme\n" * 400]
+    total = sum(len(c) for c in chunks)
+
+    async def _fake_stream():
+        for ch in chunks:
+            yield ch
+
+    async def _fake_export(token, params=None):
+        return _fake_stream(), {"content-length": str(total), "content-type": "text/csv"}
+
+    with patch("ui.api_client.export_lists_csv", _fake_export):
+        r = await ui_client.get("/lists/export/csv", cookies=_authed())
+    assert r.status_code == 200
+    assert r.content == b"".join(chunks)                    # streamed through intact
+    assert r.headers["content-length"] == str(total)        # browser progress bar
+    assert "attachment" in r.headers.get("content-disposition", "")
+    assert r.headers["content-disposition"].endswith("lists.csv")
 
 
 def test_compact_pages_shows_full_count_and_last():

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -4099,9 +4099,10 @@ class TestListsCreateBlank:
     @pytest.mark.asyncio
     async def test_save_list_lines_forwards_expected_version_and_returns_new(self, ui_client):
         """POST /lists/{id}/lines saves only the submitted page slice via
-        api.patch_list_line_page(token, entity_id, page, offset, expected_version) and returns
-        the new version from the save, so the page can advance its cached token (optimistic
-        concurrency). The expected_version travels as the 5th positional argument."""
+        api.patch_list_line_page(token, entity_id, page, offset, original_count, expected_version)
+        and returns the new version from the save, so the page can advance its cached token
+        (optimistic concurrency). original_count is the 5th positional argument (defaulting to the
+        submitted page's length when the body omits it) and expected_version the 6th."""
         mock = AsyncMock(return_value={"event_id": 42, "version": 42})
         with patch("ui.api_client.patch_list_line_page", create=True, new=mock):
             r = await ui_client.post(
@@ -4112,7 +4113,8 @@ class TestListsCreateBlank:
         assert r.status_code == 200
         assert r.json()["ok"] is True
         assert r.json()["version"] == 42
-        assert mock.await_args.args[4] == 7
+        assert mock.await_args.args[4] == 0  # original_count defaults to the empty page's length
+        assert mock.await_args.args[5] == 7
 
     @pytest.mark.asyncio
     async def test_save_list_lines_stale_version_returns_structured_409(self, ui_client):
@@ -10602,7 +10604,8 @@ class TestListScanInPlace:
         # the client refetches the editable tbody itself), never a full-page refresh.
         _res = {"scanned": 1, "results": [{"code": "A1", "state": "added"}], "failed": []}
         with patch("ui.api_client.scan_list", new=AsyncMock(return_value=_res)), \
-             patch("ui.api_client.get_list", new=AsyncMock(return_value=self._DRAFT)):
+             patch("ui.api_client.get_list_page",
+                   new=AsyncMock(return_value={"list": self._DRAFT, "version": 1})):
             r = await ui_client.post("/lists/list:1/scan", data={"barcode": "A1"}, cookies=_authed())
         assert r.status_code == 200
         assert "HX-Refresh" not in r.headers
@@ -10640,7 +10643,8 @@ class TestListScanInPlace:
         _res = {"scanned": 1, "results": [{"code": "A1", "state": "added"}],
                 "failed": [{"code": _bad, "reason": "unknown_code", "label": f"Unknown barcode or SKU: {_bad}"}]}
         with patch("ui.api_client.scan_list", new=AsyncMock(return_value=_res)), \
-             patch("ui.api_client.get_list", new=AsyncMock(return_value=self._DRAFT)):
+             patch("ui.api_client.get_list_page",
+                   new=AsyncMock(return_value={"list": self._DRAFT, "version": 1})):
             r = await ui_client.post("/lists/list:1/scan", data={"barcode": f"A1, {_bad}"}, cookies=_authed())
         assert r.status_code == 200
         assert "X-Scan-Failed-Codes" not in r.headers
@@ -19880,8 +19884,9 @@ async def test_list_scan_proxy_returns_fresh_version(ui_client):
     version, so the client's optimistic-lock token tracks the scan's write and a
     later line save does not 409 on a stale version."""
     scan = AsyncMock(return_value={"scanned": 1, "failed": []})
-    get = AsyncMock(return_value={"list_type": "quotation", "status": "draft", "version": 4242})
-    with patch("ui.api_client.scan_list", new=scan), patch("ui.api_client.get_list", new=get):
+    get = AsyncMock(return_value={"list": {"list_type": "quotation", "status": "draft"},
+                                  "version": 4242})
+    with patch("ui.api_client.scan_list", new=scan), patch("ui.api_client.get_list_page", new=get):
         r = await ui_client.post(
             "/lists/list:L1/scan",
             data={"barcode": "ABC123", "run_key": "run-1"},

--- a/ui/api_client.py
+++ b/ui/api_client.py
@@ -1444,6 +1444,34 @@ async def patch_list(token: str, entity_id: str, data: dict, expected_version: i
         return _raise(await c.patch(f"/lists/{entity_id}", json=body)).json()
 
 
+async def get_list_page(token: str, entity_id: str, offset: int = 0, limit: int = 100) -> dict:
+    """One bounded page of a list's stored lines.
+
+    Returns {"items": [...], "total": int, "version": int} where items is the raw
+    stored slice of positions [offset:offset+limit); the server hard-caps limit at
+    100 and applies the effective value. Enrichment over the page ids is the
+    caller's job.
+    """
+    async with _api_client(token) as c:
+        return _raise(await c.get(
+            f"/lists/{entity_id}/page",
+            params={"offset": offset, "limit": limit},
+        )).json()
+
+
+async def patch_list_line_page(token: str, entity_id: str, page: list[dict], offset: int, expected_version: int | None) -> dict:
+    """Save one page slice of a list's lines by position.
+
+    Overwrites stored positions [offset:offset+len(page)); off-page rows are
+    untouched. Calls the slice endpoint directly rather than through
+    _wrap_fields_changed, so it does not trigger the extra full-list GET that the
+    bare-field patch wrapper performs.
+    """
+    body: dict = {"line_items": page, "offset": offset, "expected_version": expected_version}
+    async with _api_client(token) as c:
+        return _raise(await c.patch(f"/lists/{entity_id}/line-page", json=body)).json()
+
+
 # ── Inventory audits (a list_type=audit on the unified /lists lifecycle) ──────
 async def create_audit(token: str, location_id: str) -> dict:
     async with _api_client(token) as c:

--- a/ui/api_client.py
+++ b/ui/api_client.py
@@ -19,23 +19,71 @@ class APIError(Exception):
         super().__init__(f"API {status}: {detail}")
 
 
+# One shared bounded connection pool for every UI-to-API request. Each call still
+# gets its own cheap AsyncClient wrapper (a per-token Authorization header cannot be
+# shared across tokens), but they all drive requests through this single transport,
+# whose Limits cap how many connections the UI process can open into the API. Before
+# this, every _client()/_anon_client() call built a fresh AsyncClient with its own
+# pool, so a burst of requests opened an unbounded number of pools - a contributor to
+# the connection-pool exhaustion in the incident. A shared transport (not one shared
+# client) is the right shape here because auth differs per request; alt (d) in the
+# plan rejected a single global client for exactly that reason.
+_shared_transport: httpx.AsyncHTTPTransport | None = None
+
+# Lightweight observability for the UI client path: how many requests were driven
+# through the shared pool, logged on shutdown so pool pressure is visible.
+_ui_request_count = 0
+
+
+def _get_transport() -> httpx.AsyncHTTPTransport:
+    """Return the shared bounded transport, building it lazily on first use."""
+    global _shared_transport
+    if _shared_transport is None:
+        _shared_transport = httpx.AsyncHTTPTransport(
+            limits=httpx.Limits(max_connections=32, max_keepalive_connections=8),
+        )
+    return _shared_transport
+
+
+async def close_shared_client() -> None:
+    """Close the shared transport if one was built. Called from the UI app shutdown.
+
+    Safe to call when none was built. Logs the total request count as observability
+    for how much traffic the bounded pool carried this process lifetime."""
+    global _shared_transport
+    transport = _shared_transport
+    _shared_transport = None
+    logger.info("UI API client shutdown: %d requests served via shared pool", _ui_request_count)
+    if transport is not None:
+        try:
+            await transport.aclose()
+        except Exception:
+            pass
+
+
 def _client(token: str, timeout: float = 10.0) -> httpx.AsyncClient:
+    global _ui_request_count
+    _ui_request_count += 1
     from ui.config import API_BASE
     return httpx.AsyncClient(
         base_url=API_BASE,
         headers={"Authorization": f"Bearer {token}"},
         timeout=timeout,
         follow_redirects=True,
+        transport=_get_transport(),
     )
 
 
 def _anon_client(timeout: float = 10.0) -> httpx.AsyncClient:
     """Unauthenticated client (no Authorization header)."""
+    global _ui_request_count
+    _ui_request_count += 1
     from ui.config import API_BASE
     return httpx.AsyncClient(
         base_url=API_BASE,
         timeout=timeout,
         follow_redirects=True,
+        transport=_get_transport(),
     )
 
 
@@ -73,6 +121,8 @@ async def _anon_api_client(timeout: float = 10.0):
 @asynccontextmanager
 async def _ai_api_client(token: str, session_token: str, timeout: float = 10.0):
     """Authenticated client with X-Session-Token header for AI endpoints."""
+    global _ui_request_count
+    _ui_request_count += 1
     from ui.config import API_BASE
     try:
         async with httpx.AsyncClient(
@@ -80,6 +130,7 @@ async def _ai_api_client(token: str, session_token: str, timeout: float = 10.0):
             headers={"Authorization": f"Bearer {token}", "X-Session-Token": session_token},
             timeout=timeout,
             follow_redirects=True,
+            transport=_get_transport(),
         ) as c:
             yield c
     except httpx.TimeoutException as exc:

--- a/ui/api_client.py
+++ b/ui/api_client.py
@@ -19,6 +19,29 @@ class APIError(Exception):
         super().__init__(f"API {status}: {detail}")
 
 
+class _SharedTransport(httpx.AsyncHTTPTransport):
+    """A shared bounded transport reused by every per-token AsyncClient.
+
+    httpx.AsyncClient.aclose() (and __aexit__) unconditionally closes its
+    transport, including one injected and shared across clients. With per-token
+    clients driving this one transport concurrently (asyncio.gather), the first
+    client to leave its `async with` block would close the connection pool out
+    from under a sibling request still reading its response, surfacing as a
+    ReadError. The per-client close is therefore a no-op here: the pool outlives
+    every client and is torn down only by shutdown_pool(), called once from the
+    UI app shutdown.
+    """
+
+    async def aclose(self) -> None:
+        return None
+
+    async def __aexit__(self, *exc_info) -> None:
+        return None
+
+    async def shutdown_pool(self) -> None:
+        await super().aclose()
+
+
 # One shared bounded connection pool for every UI-to-API request. Each call still
 # gets its own cheap AsyncClient wrapper (a per-token Authorization header cannot be
 # shared across tokens), but they all drive requests through this single transport,
@@ -28,18 +51,18 @@ class APIError(Exception):
 # the connection-pool exhaustion in the incident. A shared transport (not one shared
 # client) is the right shape here because auth differs per request; alt (d) in the
 # plan rejected a single global client for exactly that reason.
-_shared_transport: httpx.AsyncHTTPTransport | None = None
+_shared_transport: _SharedTransport | None = None
 
 # Lightweight observability for the UI client path: how many requests were driven
 # through the shared pool, logged on shutdown so pool pressure is visible.
 _ui_request_count = 0
 
 
-def _get_transport() -> httpx.AsyncHTTPTransport:
+def _get_transport() -> _SharedTransport:
     """Return the shared bounded transport, building it lazily on first use."""
     global _shared_transport
     if _shared_transport is None:
-        _shared_transport = httpx.AsyncHTTPTransport(
+        _shared_transport = _SharedTransport(
             limits=httpx.Limits(max_connections=32, max_keepalive_connections=8),
         )
     return _shared_transport
@@ -56,7 +79,7 @@ async def close_shared_client() -> None:
     logger.info("UI API client shutdown: %d requests served via shared pool", _ui_request_count)
     if transport is not None:
         try:
-            await transport.aclose()
+            await transport.shutdown_pool()
         except Exception:
             pass
 

--- a/ui/api_client.py
+++ b/ui/api_client.py
@@ -1467,16 +1467,62 @@ async def update_mfg_settings(token: str, mfg: dict) -> dict:
 # CSV export
 # ---------------------------------------------------------------------------
 
+async def _stream_csv(token: str, path: str, params: dict | None = None):
+    """GET a CSV export endpoint with the body streamed, never buffered. Returns
+    (chunk_iterator, headers).
+
+    The backend already streams these exports row by row; the UI must not re-read the
+    whole body into memory (a large export would then sit in UI RAM and defeat the
+    backend's streaming, pinning a pooled connection for the whole read). The caller
+    pipes the iterator straight into a StreamingResponse, and the httpx client + response
+    stay open until the iterator is exhausted. Content-Length is forwarded so the browser
+    can show a real download progress bar. Mirrors export_backup's streaming shape."""
+    from ui.config import API_BASE
+    client = _client(token, timeout=httpx.Timeout(300.0, connect=10.0))
+    try:
+        resp = await client.send(client.build_request("GET", path, params=params or {}), stream=True)
+    except httpx.TimeoutException as exc:
+        await client.aclose()
+        raise APIError(504, "The export timed out.") from exc
+    except httpx.ConnectError as exc:
+        await client.aclose()
+        raise APIError(503, f"Cannot reach API at {API_BASE}. Is the server running?") from exc
+    if resp.status_code >= 400:
+        body = await resp.aread()
+        await resp.aclose()
+        await client.aclose()
+        try:
+            import json as _json
+            detail = _json.loads(body).get("detail", body.decode("utf-8", "replace"))
+        except Exception:
+            detail = body.decode("utf-8", "replace")
+        raise APIError(resp.status_code, detail)
+    headers = {
+        k: resp.headers[k]
+        for k in ("content-length", "content-disposition", "content-type")
+        if k in resp.headers
+    }
+
+    async def _iter():
+        try:
+            async for chunk in resp.aiter_bytes():
+                yield chunk
+        finally:
+            await resp.aclose()
+            await client.aclose()
+
+    return _iter(), headers
+
+
 async def export_items_csv(token: str, params: dict | None = None) -> bytes:
     async with _api_client(token) as c:
         r = _raise(await c.get("/items/export/csv", params=params or {}))
         return r.content
 
 
-async def export_docs_csv(token: str, params: dict | None = None) -> bytes:
-    async with _api_client(token) as c:
-        r = _raise(await c.get("/docs/export/csv", params=params or {}))
-        return r.content
+async def export_docs_csv(token: str, params: dict | None = None):
+    """GET /docs/export/csv, streamed. Returns (chunk_iterator, headers)."""
+    return await _stream_csv(token, "/docs/export/csv", params)
 
 
 async def export_contacts_csv(token: str, params: dict | None = None) -> bytes:
@@ -1695,10 +1741,9 @@ async def delete_list_note(token: str, entity_id: str, note_id: str) -> dict:
         return _raise(await c.delete(f"/lists/{entity_id}/notes/{note_id}")).json()
 
 
-async def export_lists_csv(token: str, params: dict | None = None) -> bytes:
-    async with _api_client(token) as c:
-        r = _raise(await c.get("/lists/export/csv", params=params or {}))
-        return r.content
+async def export_lists_csv(token: str, params: dict | None = None):
+    """GET /lists/export/csv, streamed. Returns (chunk_iterator, headers)."""
+    return await _stream_csv(token, "/lists/export/csv", params)
 
 
 # ---------------------------------------------------------------------------

--- a/ui/api_client.py
+++ b/ui/api_client.py
@@ -1445,11 +1445,12 @@ async def patch_list(token: str, entity_id: str, data: dict, expected_version: i
 
 
 async def get_list_page(token: str, entity_id: str, offset: int = 0, limit: int = 100) -> dict:
-    """One bounded page of a list's stored lines.
+    """One bounded page of a list's stored lines, with the list header.
 
-    Returns {"items": [...], "total": int, "version": int} where items is the raw
-    stored slice of positions [offset:offset+limit); the server hard-caps limit at
-    100 and applies the effective value. Enrichment over the page ids is the
+    Returns {"list": {...stored header without line_items, plus id and version...},
+    "items": [...raw stored slice...], "total": int, "version": int} where items is
+    the raw stored slice of positions [offset:offset+limit); the server hard-caps
+    limit at 100 and applies the effective value. Enrichment over the page ids is the
     caller's job.
     """
     async with _api_client(token) as c:

--- a/ui/api_client.py
+++ b/ui/api_client.py
@@ -1519,13 +1519,16 @@ async def patch_list(token: str, entity_id: str, data: dict, expected_version: i
 
 
 async def get_list_page(token: str, entity_id: str, offset: int = 0, limit: int = 100) -> dict:
-    """One bounded page of a list's stored lines, with the list header.
+    """One bounded page of a list's stored lines, with the list header and page metadata.
 
     Returns {"list": {...stored header without line_items, plus id and version...},
-    "items": [...raw stored slice...], "total": int, "version": int} where items is
-    the raw stored slice of positions [offset:offset+limit); the server hard-caps
-    limit at 100 and applies the effective value. Enrichment over the page ids is the
-    caller's job.
+    "items": [...raw stored slice...], "total": int, "version": int,
+    "item_meta": {entity_id: flattened item dict}} where items is the raw stored slice
+    of positions [offset:offset+limit) and item_meta is the catalog metadata for exactly
+    the page's ids (the server enriches it in the same call, so the detail view needs no
+    follow-up metadata read). The server hard-caps limit at 100 and applies the effective
+    value. An older server that omits item_meta leaves it absent and the caller degrades
+    to each line's stored values.
     """
     async with _api_client(token) as c:
         return _raise(await c.get(
@@ -1534,15 +1537,17 @@ async def get_list_page(token: str, entity_id: str, offset: int = 0, limit: int 
         )).json()
 
 
-async def patch_list_line_page(token: str, entity_id: str, page: list[dict], offset: int, expected_version: int | None) -> dict:
+async def patch_list_line_page(token: str, entity_id: str, page: list[dict], offset: int,
+                               original_count: int, expected_version: int | None) -> dict:
     """Save one page slice of a list's lines by position.
 
-    Overwrites stored positions [offset:offset+len(page)); off-page rows are
-    untouched. Calls the slice endpoint directly rather than through
-    _wrap_fields_changed, so it does not trigger the extra full-list GET that the
-    bare-field patch wrapper performs.
+    Replaces the stored window [offset:offset+original_count) the client loaded with the
+    submitted page: a shorter page deletes tail rows, a longer one inserts. off-window rows
+    are untouched. Calls the slice endpoint directly rather than through _wrap_fields_changed,
+    so it does not trigger the extra full-list GET that the bare-field patch wrapper performs.
     """
-    body: dict = {"line_items": page, "offset": offset, "expected_version": expected_version}
+    body: dict = {"line_items": page, "offset": offset, "original_count": original_count,
+                  "expected_version": expected_version}
     async with _api_client(token) as c:
         return _raise(await c.patch(f"/lists/{entity_id}/line-page", json=body)).json()
 

--- a/ui/app.py
+++ b/ui/app.py
@@ -224,9 +224,17 @@ class TokenRefreshMiddleware:
             await self._app(scope, receive, send)
 
 
+async def _close_ui_api_client() -> None:
+    """Close the shared bounded httpx pool the UI uses to reach the API, so its
+    connections are released cleanly on shutdown rather than left to the event loop."""
+    from ui.api_client import close_shared_client
+    await close_shared_client()
+
+
 app = FastHTML(
     before=Beforeware(_auth_guard, skip=[r"/login", r"/login-force", r"/setup.*", r"/logout", r"/static/.*", r"/health"]),
     secret_key=os.environ.get("JWT_SECRET", "dev-secret"),
+    on_shutdown=[_close_ui_api_client],
 )
 
 app.add_middleware(TokenRefreshMiddleware)

--- a/ui/components/shell.py
+++ b/ui/components/shell.py
@@ -602,21 +602,78 @@ _HEALTH_BANNER_HTML = Div(
     style="display:none;align-items:center;justify-content:space-between;padding:0.5rem 1rem;font-weight:500;",
 )
 
-_BACKUP_BANNER_JS = """
-(function() {
-  function poll() {
-    fetch('/backup/active')
+_POLL_CONTROLLER_JS = """
+// One shared single-flight adaptive poller for every raw-JS fetch-poll surface.
+// A plain setInterval fires a new fetch every tick even while the previous one is
+// still open, so a slow endpoint stacks overlapping requests and can exhaust the
+// connection pool. celerpPoll collapses that to one in-flight request: a tick that
+// arrives while a request is outstanding is skipped, never started as a second
+// fetch. On success it polls at the normal interval; on repeated errors it backs
+// off (doubling up to a cap) so a failing endpoint is not hammered. onData is
+// called with the parsed body on success and with null on error, letting the caller
+// hold its last known state on failure rather than clearing it.
+window.celerpPoll = window.celerpPoll || function(name, url, onData, opts) {
+  opts = opts || {};
+  var interval = opts.interval || 8000;
+  var maxErrorSkips = opts.maxErrorSkips || 8;
+  var inFlight = false;
+  var errorCount = 0;   // consecutive errors, drives the backoff
+  var skipTicks = 0;    // ticks to skip before the next attempt (backoff)
+
+  function fire() {
+    inFlight = true;
+    fetch(url, { cache: 'no-store' })
       .then(function(r) { return r.json(); })
       .then(function(d) {
-        var b = document.getElementById('backup-progress-banner');
-        if (!b) return;
-        b.style.display = d.active ? 'flex' : 'none';
+        inFlight = false;
+        errorCount = 0;
+        skipTicks = 0;
+        try { onData(d); } catch (e) {}
       })
-      .catch(function() {});
+      .catch(function() {
+        inFlight = false;
+        try { onData(null); } catch (e) {}
+        // Adaptive backoff: after each error wait an extra tick, capped, so a
+        // failing endpoint is polled less often rather than every tick.
+        errorCount = errorCount + 1;
+        skipTicks = Math.min(errorCount, maxErrorSkips);
+      });
   }
+
+  function tick() {
+    // Single-flight: a tick arriving while a request is still open is skipped,
+    // never started as a second overlapping fetch.
+    if (inFlight) { return; }
+    if (skipTicks > 0) { skipTicks = skipTicks - 1; return; }
+    fire();
+  }
+
+  return {
+    start: function() {
+      fire();               // one immediate poll on start
+      setInterval(tick, interval);
+    }
+  };
+};
+"""
+
+_BACKUP_BANNER_JS = """
+(function() {
   document.addEventListener('DOMContentLoaded', function() {
-    poll();
-    setInterval(poll, 8000);
+    var poller = window.celerpPoll('backup', '/backup/active', function(d) {
+      var b = document.getElementById('backup-progress-banner');
+      if (!b) return;
+      // On an error/unknown state (or a request failure, d === null) hold the
+      // banner's last known state and mark it as stale; never flip to inactive on
+      // a failed poll, which would read as a false "no backup running".
+      if (!d || d.state === 'error' || d.state === 'unknown') {
+        b.setAttribute('data-poll-stale', '1');
+        return;
+      }
+      b.removeAttribute('data-poll-stale');
+      b.style.display = d.active ? 'flex' : 'none';
+    }, { interval: 8000 });
+    poller.start();
   });
 })();
 """
@@ -1398,6 +1455,7 @@ async def base_shell(*content, title: str = "Celerp", nav_active: str = "", comp
         Script(_CLIENT_JS),
         Script(_IDLE_LOGOUT_JS),
         Script(_HEALTH_BANNER_JS),
+        Script(_POLL_CONTROLLER_JS),
         Script(_BACKUP_BANNER_JS),
         Script(_NOTIFICATION_JS),
         Script(_USER_MENU_JS),

--- a/ui/components/shell.py
+++ b/ui/components/shell.py
@@ -616,13 +616,23 @@ window.celerpPoll = window.celerpPoll || function(name, url, onData, opts) {
   opts = opts || {};
   var interval = opts.interval || 8000;
   var maxErrorSkips = opts.maxErrorSkips || 8;
+  // Bound every fetch: a socket that wedges and never settles would otherwise leave
+  // inFlight true forever, and the single-flight guard would then skip every future
+  // tick, silently killing the poller until a page reload. Abort a fetch that has not
+  // settled within the deadline so it flows through the error/backoff branch and the
+  // next tick can start a fresh request. Default to just under one interval.
+  var fetchDeadline = opts.fetchDeadline || Math.max(interval - 1000, 4000);
   var inFlight = false;
   var errorCount = 0;   // consecutive errors, drives the backoff
   var skipTicks = 0;    // ticks to skip before the next attempt (backoff)
 
   function fire() {
     inFlight = true;
-    fetch(url, { cache: 'no-store' })
+    var controller = (typeof AbortController !== 'undefined') ? new AbortController() : null;
+    var deadline = setTimeout(function() {
+      if (controller) { try { controller.abort(); } catch (e) {} }
+    }, fetchDeadline);
+    fetch(url, { cache: 'no-store', signal: controller ? controller.signal : undefined })
       .then(function(r) {
         // A non-ok response (e.g. the server's 503 when its backend read fails) is an
         // error, not healthy data: reject so it flows through the same error/backoff
@@ -631,12 +641,14 @@ window.celerpPoll = window.celerpPoll || function(name, url, onData, opts) {
         return r.json();
       })
       .then(function(d) {
+        clearTimeout(deadline);
         inFlight = false;
         errorCount = 0;
         skipTicks = 0;
         try { onData(d); } catch (e) {}
       })
       .catch(function() {
+        clearTimeout(deadline);
         inFlight = false;
         try { onData(null); } catch (e) {}
         // Adaptive backoff: after each error wait an extra tick, capped, so a

--- a/ui/components/shell.py
+++ b/ui/components/shell.py
@@ -623,7 +623,13 @@ window.celerpPoll = window.celerpPoll || function(name, url, onData, opts) {
   function fire() {
     inFlight = true;
     fetch(url, { cache: 'no-store' })
-      .then(function(r) { return r.json(); })
+      .then(function(r) {
+        // A non-ok response (e.g. the server's 503 when its backend read fails) is an
+        // error, not healthy data: reject so it flows through the same error/backoff
+        // branch below and the counters are not reset.
+        if (!r.ok) { throw new Error('poll response not ok: ' + r.status); }
+        return r.json();
+      })
       .then(function(d) {
         inFlight = false;
         errorCount = 0;

--- a/ui/locales/am.json
+++ b/ui/locales/am.json
@@ -2322,6 +2322,7 @@
   "documents.revert_return_tooltip": "የተቀበለውን መመለስ ይመልሱ። የተመለሱትን ክምችት እቃዎች ያስወግዳል እና COGS የጆርናል ግቤትን ይቀለብሳል።",
   "documents.rows_selected": "ረድፎች ተመርጠዋል፡{n}",
   "documents.save_failed": "ማስቀመጥ አልተሳካም",
+  "documents.save_reload_action": "እንደገና ይጫኑ",
   "documents.scan_add_btn": "ያክሉ",
   "documents.scan_add_count": "እቃዎችን ይቃኙ፣ ከዚያ ለመቁጠር ያክሉ",
   "documents.scan_added_prefix": "ታክሏል",

--- a/ui/locales/ar.json
+++ b/ui/locales/ar.json
@@ -2219,6 +2219,7 @@
   "documents.revert_return_tooltip": "التراجع عن الإرجاع المستلم. يؤدي ذلك إلى التخلص من بنود المخزون المرتجعة وإلغاء القيد اليومي لتكلفة البضائع المباعة.",
   "documents.rows_selected": "الصفوف المحددة: {n}",
   "documents.save_failed": "فشل الحفظ",
+  "documents.save_reload_action": "إعادة التحميل",
   "documents.scan_add_btn": "إضافة",
   "documents.scan_add_count": "امسح العناصر، ثم اضغط على «إضافة» لإدراجها في الجرد",
   "documents.scan_added_prefix": "تمت الإضافة",

--- a/ui/locales/de.json
+++ b/ui/locales/de.json
@@ -2220,6 +2220,7 @@
   "documents.revert_return_tooltip": "Eingegangene Rücksendung stornieren. Die zurückgesendeten Lagerartikel werden entsorgt und die Journalbuchung für die Herstellungskosten storniert.",
   "documents.rows_selected": "Ausgewählte Zeilen: {n}",
   "documents.save_failed": "Speichern fehlgeschlagen",
+  "documents.save_reload_action": "Neu laden",
   "documents.scan_add_btn": "Hinzufügen",
   "documents.scan_add_count": "Artikel scannen und dann „Hinzufügen“ auswählen, um sie in die Zählung aufzunehmen",
   "documents.scan_added_prefix": "Hinzugefügt",

--- a/ui/locales/en.json
+++ b/ui/locales/en.json
@@ -2322,6 +2322,7 @@
   "documents.revert_return_tooltip": "Revert the received return. Disposes the returned inventory items and reverses the COGS journal entry.",
   "documents.rows_selected": "Rows selected: {n}",
   "documents.save_failed": "Save failed",
+  "documents.save_reload_action": "Reload",
   "documents.scan_add_btn": "Add",
   "documents.scan_add_count": "Scan items, then Add to count them",
   "documents.scan_added_prefix": "Added",

--- a/ui/locales/es.json
+++ b/ui/locales/es.json
@@ -2219,6 +2219,7 @@
   "documents.revert_return_tooltip": "Revertir la devolución recibida. Elimina los artículos devueltos y revierte el asiento contable de costes de ventas.",
   "documents.rows_selected": "Filas seleccionadas: {n}",
   "documents.save_failed": "Error al guardar",
+  "documents.save_reload_action": "Recargar",
   "documents.scan_add_btn": "Añadir",
   "documents.scan_add_count": "Escanee los artículos y seleccione «Añadir» para incluirlos en el recuento",
   "documents.scan_added_prefix": "Añadido",

--- a/ui/locales/fr.json
+++ b/ui/locales/fr.json
@@ -2220,6 +2220,7 @@
   "documents.revert_return_tooltip": "Annuler le retour reçu. Élimine les articles retournés et annule l'écriture comptable du coût des ventes.",
   "documents.rows_selected": "Lignes sélectionnées : {n}",
   "documents.save_failed": "Échec de l'enregistrement",
+  "documents.save_reload_action": "Recharger",
   "documents.scan_add_btn": "Ajouter",
   "documents.scan_add_count": "Scannez les articles, puis sélectionnez « Ajouter » pour les inclure dans le comptage",
   "documents.scan_added_prefix": "Ajouté",

--- a/ui/locales/id.json
+++ b/ui/locales/id.json
@@ -2219,6 +2219,7 @@
   "documents.revert_return_tooltip": "Membatalkan pengembalian yang telah diterima. Membuang item persediaan yang dikembalikan dan membalikkan entri jurnal COGS.",
   "documents.rows_selected": "Baris yang dipilih: {n}",
   "documents.save_failed": "Gagal menyimpan",
+  "documents.save_reload_action": "Muat ulang",
   "documents.scan_add_btn": "Tambah",
   "documents.scan_add_count": "Pindai barang, lalu Tambah untuk menghitungnya",
   "documents.scan_added_prefix": "Ditambahkan",

--- a/ui/locales/it.json
+++ b/ui/locales/it.json
@@ -2220,6 +2220,7 @@
   "documents.revert_return_tooltip": "Annullare il reso ricevuto. Elimina gli articoli di magazzino restituiti e storna la registrazione contabile del costo del venduto.",
   "documents.rows_selected": "Righe selezionate: {n}",
   "documents.save_failed": "Salvataggio non riuscito",
+  "documents.save_reload_action": "Ricarica",
   "documents.scan_add_btn": "Aggiungi",
   "documents.scan_add_count": "Scansiona gli articoli, poi Aggiungi per contarli",
   "documents.scan_added_prefix": "Aggiunto",

--- a/ui/locales/ja.json
+++ b/ui/locales/ja.json
@@ -2219,6 +2219,7 @@
   "documents.revert_return_tooltip": "受領済みの返品を取り消します。返品された在庫品を廃棄し、売上原価の仕訳を取り消します。",
   "documents.rows_selected": "選択された行：{n}",
   "documents.save_failed": "保存に失敗しました",
+  "documents.save_reload_action": "再読み込み",
   "documents.scan_add_btn": "追加",
   "documents.scan_add_count": "商品をスキャンし、追加して数えます",
   "documents.scan_added_prefix": "追加しました",

--- a/ui/locales/pt.json
+++ b/ui/locales/pt.json
@@ -2219,6 +2219,7 @@
   "documents.revert_return_tooltip": "Reverter a devolução recebida. Descarte os itens de estoque devolvidos e reverta o lançamento contábil de custo dos produtos vendidos.",
   "documents.rows_selected": "Linhas selecionadas: {n}",
   "documents.save_failed": "Falha ao salvar",
+  "documents.save_reload_action": "Recarregar",
   "documents.scan_add_btn": "Adicionar",
   "documents.scan_add_count": "Digitalize os itens e selecione «Adicionar» para incluí-los na contagem",
   "documents.scan_added_prefix": "Adicionado",

--- a/ui/locales/th.json
+++ b/ui/locales/th.json
@@ -2219,6 +2219,7 @@
   "documents.revert_return_tooltip": "ย้อนกลับการรับคืนสินค้า นำรายการสินค้าคงคลังที่คืนมาออกและย้อนกลับรายการบัญชีต้นทุนขาย (COGS)",
   "documents.rows_selected": "เลือกแล้ว {n} แถว",
   "documents.save_failed": "บันทึกไม่สำเร็จ",
+  "documents.save_reload_action": "โหลดใหม่",
   "documents.scan_add_btn": "เพิ่ม",
   "documents.scan_add_count": "สแกนสินค้า แล้วกดเพิ่มเพื่อนับ",
   "documents.scan_added_prefix": "เพิ่มแล้ว",

--- a/ui/locales/vi.json
+++ b/ui/locales/vi.json
@@ -2219,6 +2219,7 @@
   "documents.revert_return_tooltip": "Hủy giao dịch trả hàng đã nhận. Xử lý các mặt hàng tồn kho bị trả lại và hủy bút toán chi phí hàng bán (COGS).",
   "documents.rows_selected": "Các hàng đã chọn: {n}",
   "documents.save_failed": "Lỗi lưu",
+  "documents.save_reload_action": "Tải lại",
   "documents.scan_add_btn": "Thêm",
   "documents.scan_add_count": "Quét các mặt hàng, rồi Thêm để đếm",
   "documents.scan_added_prefix": "Đã thêm",

--- a/ui/routes/documents.py
+++ b/ui/routes/documents.py
@@ -4312,20 +4312,11 @@ celerpUpdateBulkAlloc();
         token = _token(request)
         if not token:
             return RedirectResponse("/login", status_code=302)
-        try:
-            lst = await api.get_list(token, entity_id)
-        except APIError as e:
-            if e.status == 401:
-                return RedirectResponse("/login", status_code=302)
-            if e.status == 404:
-                from starlette.responses import HTMLResponse as _HR
-                return _HR(f"<h2>{t('documents.list_not_found')}</h2><p><a href='/lists'>{t('documents.back_to_lists')}</a></p>", status_code=404)
-            lst = {}
 
         # One bounded page of lines. A large list rendered every stored line in one
         # pass; instead read the requested window (limit hard-capped at 100) and render
         # only that page, with a pager to reach the rest. Off-page lines stay in place -
-        # this only bounds what is rendered per request.
+        # this only bounds what is fetched and rendered per request.
         _PAGE_CAP = 100
         try:
             _line_offset = max(0, int(request.query_params.get("offset", 0)))
@@ -4336,9 +4327,18 @@ celerpUpdateBulkAlloc();
         except (TypeError, ValueError):
             _line_limit = _PAGE_CAP
         _line_limit = max(1, min(_line_limit, _PAGE_CAP))
-        _all_lines = lst.get("line_items", []) or []
-        _line_total = len(_all_lines)
-        lst["line_items"] = _all_lines[_line_offset:_line_offset + _line_limit]
+        try:
+            resp = await api.get_list_page(token, entity_id, offset=_line_offset, limit=_line_limit)
+        except APIError as e:
+            if e.status == 401:
+                return RedirectResponse("/login", status_code=302)
+            if e.status == 404:
+                from starlette.responses import HTMLResponse as _HR
+                return _HR(f"<h2>{t('documents.list_not_found')}</h2><p><a href='/lists'>{t('documents.back_to_lists')}</a></p>", status_code=404)
+            resp = {}
+        lst = resp.get("list", {}) or {}
+        lst["line_items"] = resp.get("items", []) or []
+        _line_total = resp.get("total", len(lst["line_items"]))
 
         # Inject doc_type so _doc_detail() treats it as a list
         lst.setdefault("doc_type", "list")

--- a/ui/routes/documents.py
+++ b/ui/routes/documents.py
@@ -1316,18 +1316,21 @@ def setup_routes(app):
             params["doc_type"] = doc_type
         if status:
             params["status"] = status
+        from starlette.responses import Response, StreamingResponse
         try:
-            data = await api.export_docs_csv(token, params)
+            stream, headers = await api.export_docs_csv(token, params)
         except APIError as e:
             if e.status == 401:
                 return RedirectResponse("/login", status_code=302)
-            data = b"error\n"
-        from starlette.responses import Response
-        return Response(
-            content=data,
-            media_type="text/csv",
-            headers={"Content-Disposition": "attachment; filename=documents.csv"},
-        )
+            return Response(
+                content=b"error\n",
+                media_type="text/csv",
+                headers={"Content-Disposition": "attachment; filename=documents.csv"},
+            )
+        out_headers = {"Content-Disposition": "attachment; filename=documents.csv"}
+        if "content-length" in headers:
+            out_headers["Content-Length"] = headers["content-length"]
+        return StreamingResponse(stream, media_type="text/csv", headers=out_headers)
 
     @app.post("/docs/create-blank")
     async def create_blank_doc(request: Request):
@@ -4183,14 +4186,17 @@ celerpUpdateBulkAlloc();
         token = _token(request)
         if not token:
             return RedirectResponse("/login", status_code=302)
+        from starlette.responses import Response, StreamingResponse
         try:
-            data = await api.export_lists_csv(token)
+            stream, headers = await api.export_lists_csv(token)
         except APIError as e:
             logger.warning("API error on lists_export_csv: %s", e.detail)
-            data = b"error\n"
-        from starlette.responses import Response
-        return Response(content=data, media_type="text/csv",
-                        headers={"Content-Disposition": "attachment; filename=lists.csv"})
+            return Response(content=b"error\n", media_type="text/csv",
+                            headers={"Content-Disposition": "attachment; filename=lists.csv"})
+        out_headers = {"Content-Disposition": "attachment; filename=lists.csv"}
+        if "content-length" in headers:
+            out_headers["Content-Length"] = headers["content-length"]
+        return StreamingResponse(stream, media_type="text/csv", headers=out_headers)
 
     @app.post("/lists/create-blank")
     async def create_blank_list(request: Request):

--- a/ui/routes/documents.py
+++ b/ui/routes/documents.py
@@ -174,6 +174,43 @@ async def _line_identifier_mode(token: str) -> str:
         return "sku"
 
 
+def _enrich_line_meta(line_items: list[dict], item_meta: dict | None,
+                      company_settings: dict, ident_mode: str = "sku"):
+    """Build the three per-line enrichment maps (measures, item status, status-doc) from the
+    item_meta the page response already carries, and backfill identifiers in place when needed.
+
+    item_meta is {entity_id: flattened item dict} for exactly the page's catalog ids, enriched
+    server-side in the page call. When it is absent (an older server that omits the field) every
+    map stays empty and the lines render from their own stored values ("--" / 0). The unit map is
+    built from the company settings already in hand, so no extra round-trip is made."""
+    from celerp.services.units import DEFAULT_UNITS, build_unit_map
+    item_meta_map: dict[str, dict] = {}
+    item_status_map: dict[str, str] = {}
+    item_status_doc_map: dict[str, tuple[str, str]] = {}
+    if not item_meta:
+        return item_meta_map, item_status_map, item_status_doc_map
+    unit_map = build_unit_map((company_settings or {}).get("units") or DEFAULT_UNITS)
+    for eid, item in item_meta.items():
+        if not item:
+            continue
+        item_meta_map[eid] = item_measure_meta(item, unit_map)
+        if item.get("status"):
+            item_status_map[eid] = item["status"]
+            _sdoc = str(item.get("status_doc_id") or "")
+            if _sdoc:
+                item_status_doc_map[eid] = (
+                    _sdoc,
+                    str(item.get("status_doc_number") or "") or _sdoc.removeprefix("doc:"),
+                )
+    if ident_mode != "sku":
+        # Lines saved before barcodes were stamped: fill from the catalog item.
+        for _li in line_items:
+            _it = item_meta.get(_li.get("item_id") or _li.get("entity_id") or "")
+            if _it:
+                identifier_backfill(_li, _it)
+    return item_meta_map, item_status_map, item_status_doc_map
+
+
 def _picker_item(item: dict, unit_price, unit_map: dict) -> dict:
     """Inventory item -> line-item picker payload, shared by both catalog
     autocomplete endpoints (lookup-by-SKU and typeahead search)."""
@@ -4389,44 +4426,11 @@ celerpUpdateBulkAlloc();
         # Item metadata for the list lines: On-hand (audit/write-off), the Status
         # column (reservable lists) and PCS/WEIGHT measure editability (a list is an
         # invoice-layout doc type, so every line renders its measures from item meta).
-        # ONE bulk call feeds all three maps; on failure they stay empty and the lines
-        # render from their stored values. Mirrors the /docs/{id} block.
-        item_meta_map: dict[str, dict] = {}
-        item_status_map: dict[str, str] = {}
-        item_status_doc_map: dict[str, tuple[str, str]] = {}
-        _line_eids = list(dict.fromkeys(
-            li.get("item_id") or li.get("entity_id") or ""
-            for li in lst.get("line_items", [])
-            if li.get("item_id") or li.get("entity_id")
-        ))
-        if _line_eids:
-            try:
-                from celerp.services.units import build_unit_map
-                try:
-                    _unit_map = build_unit_map(await api.get_units(token))
-                except Exception:
-                    _unit_map = {}
-                _items_by_eid = await api.get_items_metadata(token, _line_eids)
-                for eid, item in _items_by_eid.items():
-                    if not item:
-                        continue
-                    item_meta_map[eid] = item_measure_meta(item, _unit_map)
-                    if item.get("status"):
-                        item_status_map[eid] = item["status"]
-                        _sdoc = str(item.get("status_doc_id") or "")
-                        if _sdoc:
-                            item_status_doc_map[eid] = (
-                                _sdoc,
-                                str(item.get("status_doc_number") or "") or _sdoc.removeprefix("doc:"),
-                            )
-                if _ident_mode != "sku":
-                    # Lines saved before barcodes were stamped: fill from the catalog item.
-                    for _li in lst.get("line_items", []):
-                        _it = _items_by_eid.get(_li.get("item_id") or _li.get("entity_id") or "")
-                        if _it:
-                            identifier_backfill(_li, _it)
-            except Exception:
-                pass
+        # The page response enriches the page's ids in the same call, so no follow-up
+        # metadata round-trip is made; if the server omits item_meta (older server) the
+        # maps stay empty and the lines render from their stored values.
+        item_meta_map, item_status_map, item_status_doc_map = _enrich_line_meta(
+            lst.get("line_items", []), resp.get("item_meta"), _co_settings, _ident_mode)
 
         ref = lst.get("ref_id") or entity_id
         status_label = _list_status_label(lst)
@@ -4586,12 +4590,16 @@ celerpUpdateBulkAlloc();
             offset = max(0, int(body.get("offset", 0)))
         except (TypeError, ValueError):
             offset = 0
+        try:
+            original_count = max(0, int(body.get("original_count", len(page))))
+        except (TypeError, ValueError):
+            original_count = len(page)
         expected_version = body.get("expected_version")
         try:
-            # Save only the submitted page slice: the server overwrites the stored positions
-            # [offset, offset+len(page)) under a row lock and recomputes totals from the full
-            # merged array, so off-page rows are never disturbed by a page save.
-            result = await api.patch_list_line_page(token, entity_id, page, offset, expected_version)
+            # Save only the submitted page slice: the server replaces the stored window
+            # [offset, offset+original_count) under a row lock and recomputes totals from the full
+            # merged array, so off-page rows are never disturbed and a shorter page truncates.
+            result = await api.patch_list_line_page(token, entity_id, page, offset, original_count, expected_version)
         except APIError as e:
             # A stale expected_version means someone else saved this list first; surface it
             # structurally (code, not English text) so the page can prompt a reload.
@@ -4661,31 +4669,18 @@ celerpUpdateBulkAlloc();
     async def _audit_line_tbody(token: str, entity_id: str) -> FT:
         """Render the editable audit tbody for #line-body swap.
 
-        Re-fetches the list (so backend top-insert ordering is preserved per GDR 2.n),
-        rebuilds item_meta_map for On-hand, and emits the shared editable row set.
+        Reads one bounded page (so backend top-insert ordering is preserved per GDR 2.n) and
+        enriches the On-hand column from the item_meta that page carries, never pulling the whole
+        list through the unbounded read. It emits the shared editable row set.
         """
-        from fasthtml.common import to_xml
-        from ui.components.table import EMPTY as _EMPTY
-        lst = await api.get_list(token, entity_id)
-        line_items = lst.get("line_items") or []
-        # Build item_meta_map for On-hand column via ONE bulk metadata call.
-        item_meta_map: dict[str, dict] = {}
-        try:
-            _eids = list(dict.fromkeys(
-                li.get("item_id") or li.get("entity_id") or ""
-                for li in line_items if li.get("item_id") or li.get("entity_id")
-            ))
-            if _eids:
-                from celerp.services.units import build_unit_map
-                try:
-                    _unit_map = build_unit_map(await api.get_units(token))
-                except Exception:
-                    _unit_map = {}
-                for eid, item in (await api.get_items_metadata(token, _eids)).items():
-                    if item:
-                        item_meta_map[eid] = item_measure_meta(item, _unit_map)
-        except Exception:
-            pass
+        _PAGE_CAP = 100
+        resp = await api.get_list_page(token, entity_id, offset=0, limit=_PAGE_CAP)
+        lst = resp.get("list", {}) or {}
+        line_items = resp.get("items", []) or []
+        # On-hand comes from the page's own item_meta (quantity), so no extra metadata round-trip is
+        # made; if the server omits item_meta the map stays empty and On-hand shows "--".
+        item_meta_map, _status_map, _status_doc_map = _enrich_line_meta(
+            line_items, resp.get("item_meta"), {})
 
         # This fast tbody swap only runs for a finalized audit (the locked counting manifest); a draft
         # audit reloads instead. Counts are editable only while finalized.
@@ -4786,14 +4781,17 @@ celerpUpdateBulkAlloc();
             if body.get("code") == "scan_run_conflict":
                 # The conflicting run already committed its batch, so the list projection has advanced.
                 # Hand back the current version so the client can resync its optimistic-lock token after
-                # it reloads the visible lines. If this read fails, the client keeps Add locked and asks
-                # for a page reload rather than submit against stale rows.
+                # it reloads the visible lines. Read the header only (bounded page), never the whole
+                # list. If this read fails, the client keeps Add locked and asks for a page reload
+                # rather than submit against stale rows.
                 try:
-                    body = {**body, "version": (await api.get_list(token, entity_id)).get("version")}
+                    body = {**body, "version": (await api.get_list_page(token, entity_id, limit=1)).get("version")}
                 except APIError:
                     pass
             return _JSON(body, status_code=e.status or 400)
-        lst = await api.get_list(token, entity_id)
+        # Read the header only (bounded page) to decide the swap; the whole list array is never pulled.
+        _page = await api.get_list_page(token, entity_id, limit=1)
+        lst = _page.get("list", {}) or {}
         # Only a finalized audit (the locked counting manifest) gets the fast static tbody swap; a draft
         # audit is editable, so it reloads like every other building list to keep its inputs.
         html = ""
@@ -4803,7 +4801,7 @@ celerpUpdateBulkAlloc();
         # client's optimistic-lock token tracks it (a later line save must not 409 on a stale version).
         return _JSON({"scanned": (res or {}).get("scanned", 0),
                       "failed": (res or {}).get("failed") or [], "html": html,
-                      "version": lst.get("version")})
+                      "version": _page.get("version")})
 
     @app.post("/lists/{entity_id}/set-scanned")
     async def list_set_scanned(request: Request, entity_id: str):
@@ -7218,23 +7216,31 @@ def _doc_detail(doc: dict, locations: list | None = None, ledger: list | None = 
                 cls="line-actions gap-sm",
             ),
             Script(f"""
-const _CELERP_EID = {repr(entity_id)};
-const _CELERP_BASE = {'"/lists/"' if is_list else '"/docs/"'};
+/* HTMX outerHTML-swaps this section (list-line-section-*) and re-evaluates this whole
+   script, so every top-level binding is a window property (idempotent on re-eval); bare
+   `const`/`let` here would throw a redeclaration SyntaxError on the second page and kill
+   the pager. Bare reads elsewhere resolve against these same global properties. */
+window._CELERP_EID = {repr(entity_id)};
+window._CELERP_BASE = {'"/lists/"' if is_list else '"/docs/"'};
 // Did this document render with any line items? Drives whether emptying the table
 // persists (deleting the last line must stick) vs. a blank never-used doc (skip).
-let _celerpHadLines = {'true' if line_items else 'false'};
+window._celerpHadLines = {'true' if line_items else 'false'};
 // Optimistic-concurrency token for lists (null for docs). Sent with every line save and
 // refreshed from the save response, so a tab never false-conflicts against its own last write.
-let _celerpListVersion = {_json.dumps(doc.get("version")) if is_list else 'null'};
+window._celerpListVersion = {_json.dumps(doc.get("version")) if is_list else 'null'};
 /* Stored-array position of the first rendered row. A list renders one bounded page
    of lines, so a save overwrites exactly the positions this page occupies and leaves
    every off-page row untouched. Docs are never paged (offset 0). */
-const _CELERP_LINE_OFFSET = {int(line_offset)};
-const _CELERP_TAXES = {_json.dumps(_taxes_list)};
-const _CELERP_DEFAULT_TAX = {repr(_default_tax_value)};
+window._CELERP_LINE_OFFSET = {int(line_offset)};
+/* Length of the stored window this page loaded. A save REPLACES exactly
+   [offset, offset+original_count) so a shorter submitted page truncates deleted rows and
+   a longer one inserts; after each save it becomes the count just written. */
+window._CELERP_ORIGINAL_COUNT = {len(line_items)};
+window._CELERP_TAXES = {_json.dumps(_taxes_list)};
+window._CELERP_DEFAULT_TAX = {repr(_default_tax_value)};
 /* Currency precision: amounts use _CELERP_CDP decimals, unit prices may use up to _CELERP_RDP. */
-const _CELERP_CDP = {currency_dp(currency)};
-const _CELERP_RDP = {rate_dp(currency)};
+window._CELERP_CDP = {currency_dp(currency)};
+window._CELERP_RDP = {rate_dp(currency)};
 /* Derive a unit price from a target line amount at the FEWEST decimals that still reconciles
    (round(unit * qty) === target). Mirrors the backend money.unit_price_from_total so the stored
    unit price keeps its real precision instead of being truncated to 2 dp (which made qty*price
@@ -7253,11 +7259,11 @@ function _celerpUnitFromTotal(total, qty) {{
     return Math.round(exact * hf) / hf;
 }}
 /* ── Price list / doc-type helpers ── */
-const _CELERP_DOC_TYPE = {repr(doc_type)};
-const _CELERP_IS_LIST = {repr("true" if is_list else "false")};
+window._CELERP_DOC_TYPE = {repr(doc_type)};
+window._CELERP_IS_LIST = {repr("true" if is_list else "false")};
 /* Translated UI strings resolved in Python at render time (R2: never splice
    translated text into JS source; hand it over as one config object). */
-const _L = {_json.dumps({
+window._L = {_json.dumps({
     "scanning": t("documents.scanning"),
     "scan_error": t("documents.scan_error"),
     "scan_add_btn": _scan_btn,
@@ -7299,7 +7305,7 @@ const _L = {_json.dumps({
 """ + (f"""
 /* Item-status badges, serialized from the Python _STATUS_BADGE dict (the
    authoritative source) so the JS-rendered cell can never drift from it. */
-const _CELERP_STATUS_BADGE = {_json.dumps({k: {"label": t(v[0]), "cls": v[1]} for k, v in _STATUS_BADGE.items()})};""" if _draft_show_item_status else "") + f"""
+window._CELERP_STATUS_BADGE = {_json.dumps({k: {"label": t(v[0]), "cls": v[1]} for k, v in _STATUS_BADGE.items()})};""" if _draft_show_item_status else "") + f"""
 function _celerpPriceListParam() {{
     const plSelect = document.getElementById('doc-price-list');
     return plSelect ? '&price_list=' + encodeURIComponent(plSelect.value) : '';
@@ -7659,7 +7665,7 @@ function celerpFillRow(row, data) {{
     }
 """ if _draft_show_item_status else "") + f"""}}
 /* ── Catalog autocomplete ── */
-let _celerpAcTimer = null;
+window._celerpAcTimer = null;
 async function celerpAcSearch(input, field) {{
     const q = input.value.trim();
     const wrap = input.parentElement;
@@ -8198,12 +8204,14 @@ async function _celerpPersist() {{
     const tax = grossTax * hd.ratio;
     const total = hd.taxable + tax;
     const statusEl = document.getElementById('save-status');
-    // Send only the current page's rows plus the stored offset they occupy. The server
-    // overwrites positions [offset, offset+len) and recomputes totals from the full
-    // merged array, so off-page rows are never touched by a page save.
+    // Send the current page's rows, the stored offset they occupy, and the length of the
+    // stored window this page loaded. The server REPLACES positions [offset, offset+original_count)
+    // with the submitted rows (a shorter page truncates deleted rows, a longer one inserts) and
+    // recomputes totals from the full merged array, so off-page rows are never touched by a page save.
     const resp = await fetch(_CELERP_BASE + _CELERP_EID + '/lines', {{
         method: 'POST', headers: {{'Content-Type': 'application/json'}},
         body: JSON.stringify({{line_items: lines, offset: _CELERP_LINE_OFFSET,
+            original_count: _CELERP_ORIGINAL_COUNT,
             subtotal, tax, total,
             discount: hd.value, discount_type: hd.type, discount_amount: hd.amount,
             expected_version: _celerpListVersion}})
@@ -8215,6 +8223,9 @@ async function _celerpPersist() {{
             const data = await resp.json();
             if (data && data.version != null) _celerpListVersion = data.version;
         }} catch (_e) {{}}
+        // The rows just written become this page's stored window, so a follow-up save
+        // in the same view replaces the new window length, not the original one.
+        _CELERP_ORIGINAL_COUNT = lines.length;
         statusEl.textContent = '✓';
         statusEl.style.color = '';
         setTimeout(() => {{ statusEl.textContent = ''; }}, 1500);
@@ -8345,7 +8356,7 @@ function _celerpShowReservedConflicts(conflicts) {{
     dlg.showModal();
 }}
 /* Auto-save on blur away from any row cell */
-let _celerpSaveTimer = null;
+window._celerpSaveTimer = null;
 function celerpAutoSave() {{
     clearTimeout(_celerpSaveTimer);
     _celerpSaveTimer = setTimeout(_celerpPersist, 400);
@@ -9589,14 +9600,19 @@ def _list_table(lists: list[dict], lang: str = "en") -> FT:
     def _row(d: dict) -> FT:
         eid = d.get("entity_id") or d.get("id", "")
         ref = d.get("ref_id") or eid
-        items = d.get("line_items", [])
-        weight = sum(float(li.get("weight_ct") or li.get("weight") or 0) for li in items)
+        # The listing endpoint carries the per-row rollups (item_count, total_weight)
+        # computed in SQL, so the table never materializes the line array. If a row
+        # omits them, degrade honestly to a dash / empty weight rather than a wrong 0.
+        raw_count = d.get("item_count")
+        count_cell = str(int(raw_count)) if raw_count is not None else EMPTY
+        raw_weight = d.get("total_weight")
+        weight = float(raw_weight or 0) if raw_weight is not None else 0.0
         return Tr(
             Td(A(ref, href=f"/lists/{eid}", cls="table-link")),
             Td(format_value(d.get("list_type"), "badge")),
             Td(format_value(d.get("customer_name") or d.get("receiver") or d.get("customer_id"))),
             Td(format_value(d.get("created_at") or d.get("date"), "date")),
-            Td(str(len(items)), cls="cell--number"),
+            Td(count_cell, cls="cell--number"),
             Td(f"{weight:.2f}" if weight else EMPTY, cls="cell--number"),
             Td(format_value(d.get("total"), "money"), cls="cell--number"),
             Td(format_value(d.get("status"), "badge")),

--- a/ui/routes/documents.py
+++ b/ui/routes/documents.py
@@ -557,6 +557,72 @@ def _compact_pages(page: int, total_pages: int) -> list[int | None]:
     return out
 
 
+def _list_line_pager(entity_id: str, offset: int, limit: int, total: int, editable: bool = False) -> FT | None:
+    """Pager for the list-detail line table, reusing the compact-page layout and the
+    HTMX outerHTML-swap shape used by the document history pager. Each control swaps
+    the lines container in place, so paging never reloads the page. Returns None when
+    the whole list fits in one page (nothing to page through).
+
+    On an editable (draft) list, paging must not silently drop unsaved row edits, so
+    each control routes through `celerpPageNav`, which saves the current page first
+    (slice-PATCH under optimistic-concurrency check) and only then swaps. A clean page
+    navigates straight through. On a finalized list there is nothing to save, so the
+    controls swap directly via HTMX."""
+    if total <= limit:
+        return None
+    limit = max(1, limit)
+    total_pages = max(1, (total + limit - 1) // limit)
+    page = (offset // limit) + 1
+    safe_id = entity_id.replace(":", "-").replace("/", "-")
+    target = f"#list-line-section-{safe_id}"
+
+    def _btn(p: int, active: bool = False):
+        target_offset = (p - 1) * limit
+        if editable:
+            return Button(
+                str(p),
+                type="button",
+                cls=f"btn btn--ghost btn--xs{'  btn--active' if active else ''}",
+                onclick=f"celerpPageNav({target_offset}, {limit})",
+            )
+        return Button(
+            str(p),
+            cls=f"btn btn--ghost btn--xs{'  btn--active' if active else ''}",
+            hx_get=f"/lists/{entity_id}?offset={target_offset}&limit={limit}",
+            hx_target=target,
+            hx_select=target,
+            hx_swap="outerHTML",
+        )
+
+    page_btns = [
+        Span("...", cls="text-muted") if p is None else _btn(p, active=(p == page))
+        for p in _compact_pages(page, total_pages)
+    ]
+    if editable:
+        per_page_select = Select(
+            *[Option(str(n), value=str(n), selected=(limit == n)) for n in (25, 50, 100)],
+            cls="per-page-select",
+            onchange="celerpPageNav(0, parseInt(this.value, 10))",
+            name="limit",
+        )
+    else:
+        per_page_select = Select(
+            *[Option(str(n), value=str(n), selected=(limit == n)) for n in (25, 50, 100)],
+            cls="per-page-select",
+            hx_get=f"/lists/{entity_id}?offset=0",
+            hx_target=target,
+            hx_select=target,
+            hx_swap="outerHTML",
+            hx_include="this",
+            name="limit",
+        )
+    return Div(
+        Div(*page_btns, cls="history-page-btns"),
+        Div(Span(t("documents.show_label"), cls="text-muted"), per_page_select, cls="history-per-page"),
+        cls="history-footer list-line-pager",
+    )
+
+
 def _render_receive_return_section(doc: dict):
     """Receive Returns button - shown on credit notes when celerp-inventory is installed.
 
@@ -4256,6 +4322,24 @@ celerpUpdateBulkAlloc();
                 return _HR(f"<h2>{t('documents.list_not_found')}</h2><p><a href='/lists'>{t('documents.back_to_lists')}</a></p>", status_code=404)
             lst = {}
 
+        # One bounded page of lines. A large list rendered every stored line in one
+        # pass; instead read the requested window (limit hard-capped at 100) and render
+        # only that page, with a pager to reach the rest. Off-page lines stay in place -
+        # this only bounds what is rendered per request.
+        _PAGE_CAP = 100
+        try:
+            _line_offset = max(0, int(request.query_params.get("offset", 0)))
+        except (TypeError, ValueError):
+            _line_offset = 0
+        try:
+            _line_limit = int(request.query_params.get("limit", _PAGE_CAP))
+        except (TypeError, ValueError):
+            _line_limit = _PAGE_CAP
+        _line_limit = max(1, min(_line_limit, _PAGE_CAP))
+        _all_lines = lst.get("line_items", []) or []
+        _line_total = len(_all_lines)
+        lst["line_items"] = _all_lines[_line_offset:_line_offset + _line_limit]
+
         # Inject doc_type so _doc_detail() treats it as a list
         lst.setdefault("doc_type", "list")
 
@@ -4381,14 +4465,16 @@ celerpUpdateBulkAlloc();
                 _chart_accounts = (await api.get_chart(token)).get("items", [])
             except Exception:
                 _chart_accounts = []
-        return await base_shell(
-            breadcrumbs([(t("nav.dashboard"), "/dashboard"), (t("nav.lists"), "/lists"), (f"{status_label} {ref}", None)]),
-            page_header(f"{list_type_label} - {status_label} {ref}"),
-            _doc_detail(lst, price_lists=price_lists, tz=tz, company_taxes=company_taxes, role=_get_role(request), settings=_co_settings,
+        _detail = _doc_detail(lst, price_lists=price_lists, tz=tz, company_taxes=company_taxes, role=_get_role(request), settings=_co_settings,
                         notes=list_notes, item_status_map=item_status_map, item_status_doc_map=item_status_doc_map, item_meta_map=item_meta_map, locations=_list_locations,
                         email_used=_ls_used, email_quota=_ls_quota, email_resets_on=_ls_resets_on, share_enabled=_list_share, share_active=_list_share_active,
                         chart_accounts=_chart_accounts,
-                        line_identifier_mode=_ident_mode, relay_error=_ls_error),
+                        line_identifier_mode=_ident_mode, relay_error=_ls_error,
+                        line_offset=_line_offset, line_total=_line_total, line_limit=_line_limit)
+        return await base_shell(
+            breadcrumbs([(t("nav.dashboard"), "/dashboard"), (t("nav.lists"), "/lists"), (f"{status_label} {ref}", None)]),
+            page_header(f"{list_type_label} - {status_label} {ref}"),
+            _detail,
             title=f"{t('documents.doc_list')} {ref} - Celerp",
             nav_active="lists",
             request=request,
@@ -4495,15 +4581,17 @@ celerpUpdateBulkAlloc();
             body = await request.json()
         except Exception:
             return JSONResponse({"error": "Invalid JSON"}, status_code=400)
-        patch_data = {
-            "line_items": body.get("line_items", []),
-            "subtotal": body.get("subtotal", 0),
-            "tax": body.get("tax", 0),
-            "total": body.get("total", 0),
-        }
+        page = body.get("line_items", [])
+        try:
+            offset = max(0, int(body.get("offset", 0)))
+        except (TypeError, ValueError):
+            offset = 0
         expected_version = body.get("expected_version")
         try:
-            result = await api.patch_list(token, entity_id, patch_data, expected_version=expected_version)
+            # Save only the submitted page slice: the server overwrites the stored positions
+            # [offset, offset+len(page)) under a row lock and recomputes totals from the full
+            # merged array, so off-page rows are never disturbed by a page save.
+            result = await api.patch_list_line_page(token, entity_id, page, offset, expected_version)
         except APIError as e:
             # A stale expected_version means someone else saved this list first; surface it
             # structurally (code, not English text) so the page can prompt a reload.
@@ -5862,7 +5950,7 @@ def _li_bulk_toolbar(entity_id: str, is_list: bool, labels_only: bool = False, s
     )
 
 
-def _doc_detail(doc: dict, locations: list | None = None, ledger: list | None = None, price_lists: list | None = None, tc_templates: list | None = None, tz: str = "UTC", company_taxes: list | None = None, bank_accounts: list | None = None, company_locations: list | None = None, role: str = "owner", settings: dict | None = None, item_categories: list | None = None, notes: list | None = None, company_currency: str = "USD", suppress_doc_actions: bool = False, extra_left_actions: list | None = None, extra_right_actions: list | None = None, suppress_pdf: bool = False, free_send_offer: bool = False, email_used: int = 0, email_quota: int = 0, email_resets_on: str | None = None, share_enabled: bool = False, share_active: bool = False, payments_on: bool = False, item_status_map: dict | None = None, item_status_doc_map: dict | None = None, item_meta_map: dict | None = None, chart_accounts: list | None = None, contact_shipping_addresses: list | None = None, line_suggestions: dict | None = None, line_identifier_mode: str = "sku", relay_error: bool = False) -> FT:
+def _doc_detail(doc: dict, locations: list | None = None, ledger: list | None = None, price_lists: list | None = None, tc_templates: list | None = None, tz: str = "UTC", company_taxes: list | None = None, bank_accounts: list | None = None, company_locations: list | None = None, role: str = "owner", settings: dict | None = None, item_categories: list | None = None, notes: list | None = None, company_currency: str = "USD", suppress_doc_actions: bool = False, extra_left_actions: list | None = None, extra_right_actions: list | None = None, suppress_pdf: bool = False, free_send_offer: bool = False, email_used: int = 0, email_quota: int = 0, email_resets_on: str | None = None, share_enabled: bool = False, share_active: bool = False, payments_on: bool = False, item_status_map: dict | None = None, item_status_doc_map: dict | None = None, item_meta_map: dict | None = None, chart_accounts: list | None = None, contact_shipping_addresses: list | None = None, line_suggestions: dict | None = None, line_identifier_mode: str = "sku", relay_error: bool = False, line_offset: int = 0, line_total: int | None = None, line_limit: int = 100) -> FT:
     def _pick(*keys: str):
         for k in keys:
             if k in doc and doc.get(k) is not None:
@@ -7118,6 +7206,9 @@ def _doc_detail(doc: dict, locations: list | None = None, ledger: list | None = 
                 ),
                 cls="table-scroll-wrap",
             ),
+            (_list_line_pager(entity_id, line_offset, line_limit,
+                              line_total if line_total is not None else len(line_items),
+                              editable=True) if is_list else None),
             Div(
                 # Hidden only on a locked (counting) audit manifest. A draft audit is editable like any
                 # other building list, so it keeps the "Add item" affordance alongside scan-to-add.
@@ -7135,6 +7226,10 @@ let _celerpHadLines = {'true' if line_items else 'false'};
 // Optimistic-concurrency token for lists (null for docs). Sent with every line save and
 // refreshed from the save response, so a tab never false-conflicts against its own last write.
 let _celerpListVersion = {_json.dumps(doc.get("version")) if is_list else 'null'};
+/* Stored-array position of the first rendered row. A list renders one bounded page
+   of lines, so a save overwrites exactly the positions this page occupies and leaves
+   every off-page row untouched. Docs are never paged (offset 0). */
+const _CELERP_LINE_OFFSET = {int(line_offset)};
 const _CELERP_TAXES = {_json.dumps(_taxes_list)};
 const _CELERP_DEFAULT_TAX = {repr(_default_tax_value)};
 /* Currency precision: amounts use _CELERP_CDP decimals, unit prices may use up to _CELERP_RDP. */
@@ -7182,6 +7277,7 @@ const _L = {_json.dumps({
     "net_subtotal": t("documents.net_subtotal"),
     "double_click_rename": t("documents.double_click_rename"),
     "save_failed": t("documents.save_failed"),
+    "save_reload_action": t("documents.save_reload_action"),
     "reprice_failed": t("documents.reprice_failed"),
     "import_failed": t("documents.import_failed"),
     "allow_split_warn": t("documents.allow_split_warn"),
@@ -8090,7 +8186,10 @@ async function _celerpPersist() {{
     const lines = _celerpCollectLines();
     // Persist even when empty if the doc had lines - deleting the last line must stick.
     // Skip only a blank doc that never had any lines (avoids a spurious empty save).
-    if (!lines.length && !_celerpHadLines) return;
+    // Return value: true when nothing needed saving or the save succeeded, false when a
+    // save was attempted and failed, so callers that gate on a clean save (page navigation)
+    // can hold position instead of discarding unsaved rows.
+    if (!lines.length && !_celerpHadLines) return true;
     const subtotal = lines.reduce((s, l) => s + l.line_total, 0);
     const grossTax = lines.reduce((s, l) => s + l.line_total * (l.tax_rate / 100), 0);
     // Apply the header discount to the taxable base; tax scales by the same ratio (see
@@ -8099,9 +8198,13 @@ async function _celerpPersist() {{
     const tax = grossTax * hd.ratio;
     const total = hd.taxable + tax;
     const statusEl = document.getElementById('save-status');
+    // Send only the current page's rows plus the stored offset they occupy. The server
+    // overwrites positions [offset, offset+len) and recomputes totals from the full
+    // merged array, so off-page rows are never touched by a page save.
     const resp = await fetch(_CELERP_BASE + _CELERP_EID + '/lines', {{
         method: 'POST', headers: {{'Content-Type': 'application/json'}},
-        body: JSON.stringify({{line_items: lines, subtotal, tax, total,
+        body: JSON.stringify({{line_items: lines, offset: _CELERP_LINE_OFFSET,
+            subtotal, tax, total,
             discount: hd.value, discount_type: hd.type, discount_amount: hd.amount,
             expected_version: _celerpListVersion}})
     }});
@@ -8115,24 +8218,61 @@ async function _celerpPersist() {{
         statusEl.textContent = '✓';
         statusEl.style.color = '';
         setTimeout(() => {{ statusEl.textContent = ''; }}, 1500);
+        return true;
     }} else {{
         // A stale-version 409 carries {{code: 'stale_version', error: <reload prompt>}}; every
         // other failure carries {{error}}. Both surface the server's message (no client-side
         // English matching), so the same display path handles them.
         let msg = _L.save_failed;
         let conflicts = null;
+        let stale = false;
         try {{
             const e = await resp.json();
             if (e && e.error) msg = e.error;
             if (e && e.reserved_conflicts) conflicts = e.reserved_conflicts;
+            if (e && e.code === 'stale_version') stale = true;
         }} catch (_e) {{}}
         if (conflicts && conflicts.length) {{
             statusEl.textContent = '';
             _celerpShowReservedConflicts(conflicts);
+        }} else if (stale) {{
+            // Another save landed first, so this tab's rows are stale. Offer the only safe
+            // way back to a consistent state - reload the latest before editing again - rather
+            // than a dead-end error. Nothing was written.
+            statusEl.textContent = '';
+            statusEl.style.color = 'red';
+            const label = document.createElement('span');
+            label.textContent = '\\u2717 ' + msg + ' ';
+            const reload = document.createElement('button');
+            reload.type = 'button';
+            reload.className = 'btn btn--ghost btn--xs';
+            reload.textContent = _L.save_reload_action;
+            reload.onclick = function() {{ window.location.reload(); }};
+            statusEl.append(label, reload);
         }} else {{
             statusEl.textContent = '✗ ' + msg;
             statusEl.style.color = 'red';
         }}
+        return false;
+    }}
+}}
+/* Save the current page, then swap to another page of the same list. Paging a draft must
+   never silently drop unsaved edits, so a failed save (including a stale-version conflict)
+   holds the current page in place with its message showing. A clean page saves nothing and
+   swaps straight through. */
+async function celerpPageNav(offset, limit) {{
+    const ok = await _celerpPersist();
+    if (!ok) return;
+    const url = _CELERP_BASE + _CELERP_EID + '?offset=' + offset + '&limit=' + limit;
+    const safeId = _CELERP_EID.replace(/[:/]/g, '-');
+    const sel = '#list-line-section-' + safeId;
+    const target = document.getElementById('list-line-section-' + safeId);
+    if (target) {{
+        // The list route returns the whole page, so extract just the lines section from it
+        // (hx select) before swapping it in place.
+        htmx.ajax('GET', url, {{target: target, select: sel, swap: 'outerHTML'}});
+    }} else {{
+        window.location.assign(url);
     }}
 }}
 /* Foreign-reserved save rejection: resolution dialog instead of the inline error.
@@ -8371,6 +8511,11 @@ async function celerpCsvImport(input, entityId) {{
 """),
             cls="lines-section",
         )
+        if is_list:
+            # Wrap the editable list lines in the pager's swap target so a page control can
+            # replace the whole section (rows + pager) in place after saving the current page.
+            _draft_safe_id = entity_id.replace(":", "-").replace("/", "-")
+            lines_section = Div(lines_section, id=f"list-line-section-{_draft_safe_id}")
     else:
         # Show checkboxes + bulk toolbar on finalized docs when celerp-labels is installed
         # or when doc type supports per-line fulfill/revert
@@ -8562,11 +8707,14 @@ async function celerpCsvImport(input, entityId) {{
             _thead_base.append(Th(t("documents.th_comment"), cls="col-comment"))
         _colspan = len(_thead_base)
         _fin_bulk_id = "fin-lines-body"
+        _fin_total = line_total if line_total is not None else len(line_items)
+        _fin_safe_id = entity_id.replace(":", "-").replace("/", "-")
+        _fin_pager = _list_line_pager(entity_id, line_offset, line_limit, _fin_total) if is_list else None
         lines_section = Div(
             _li_bulk_toolbar(entity_id, is_list, labels_only=True, show_fulfill=_fin_show_fulfill, show_reserve=_fin_show_reserve, is_inbound=_is_vendor_doc, inbound_line_items=line_items if _is_vendor_doc else None, locations=locations) if _fin_show_bulk else None,
             Table(
                 Thead(Tr(*_thead_base)),
-                Tbody(*([_li_row(li, i) for i, li in enumerate(line_items)] if line_items else [
+                Tbody(*([_li_row(li, line_offset + i) for i, li in enumerate(line_items)] if line_items else [
                     Tr(Td(t("doc.no_line_items"), colspan=str(_colspan), cls="empty-state-msg"))
                 ]), id=_fin_bulk_id),
                 cls="data-table doc-lines" + (" doc-lines--fin-invoice" if doc_type in _INVOICE_LAYOUT_DOC_TYPES else "")
@@ -8738,7 +8886,10 @@ async function celerpCsvImport(input, entityId) {{
   }};
 }})();
 """) if _fin_show_bulk else None,
+            _fin_pager,
         )
+        if is_list:
+            lines_section = Div(lines_section, id=f"list-line-section-{_fin_safe_id}")
 
     # --- Totals ---
     # Compute gross (pre-discount) and net (post-discount) subtotals. Every per-line amount is

--- a/ui/routes/settings.py
+++ b/ui/routes/settings.py
@@ -2384,7 +2384,7 @@ def setup_routes(app):
             status = await _api.get_backup_status(token)
             return JSONResponse({"active": bool(status.get("active"))})
         except Exception:
-            return JSONResponse({"state": "error"})
+            return JSONResponse({"state": "error"}, status_code=503)
 
     @app.get("/backup/list")
     async def backup_list(request: Request):

--- a/ui/routes/settings.py
+++ b/ui/routes/settings.py
@@ -2370,7 +2370,11 @@ def setup_routes(app):
     async def backup_active(request: Request):
         """Lightweight poll for the global 'backup in progress' banner (#161).
 
-        Returns {"active": bool} — true while a snapshot is building (writes paused)."""
+        On success returns {"active": bool} - true while a snapshot is building
+        (writes paused). When the upstream backup-status call cannot be reached,
+        returns a distinct {"state": "error"} instead of a bare {"active": false}:
+        a failed poll must never read as a healthy idle backend, so the banner can
+        hold its last known state rather than flip to "not active"."""
         from starlette.responses import JSONResponse
         import ui.api_client as _api
         token = _token(request)
@@ -2380,7 +2384,7 @@ def setup_routes(app):
             status = await _api.get_backup_status(token)
             return JSONResponse({"active": bool(status.get("active"))})
         except Exception:
-            return JSONResponse({"active": False})
+            return JSONResponse({"state": "error"})
 
     @app.get("/backup/list")
     async def backup_list(request: Request):


### PR DESCRIPTION
Open a large list now loads one page of lines at a time instead of the whole list, so lists with hundreds or thousands of lines open quickly and stay smooth to scroll, page through, and edit.

Editing and saving a line on a large list now saves just that page under a version check. The save is fast and never disturbs lines on other pages, and if someone else changed the list first you are told and can reload before saving so no one silently overwrites another person's edit.

The lists overview, its totals, search, sorting, and CSV export are computed in the database and streamed in batches, so they stay fast as the number of lists grows.

Background status checks no longer stack up repeated requests: each check waits for the previous one to finish and eases off when the service cannot be reached. The backup indicator now shows a clear unknown state when it cannot reach the backend, instead of a misleading "not active".

Requests to the relay are pooled through a bounded connection and can be cancelled or time boxed, so a slow or stuck request no longer ties up resources or blocks other work.
