### PR TITLE
Apply cost visibility to the inventory CSV export

### DIFF
--- a/default_modules/celerp-inventory/celerp_inventory/routes.py
+++ b/default_modules/celerp-inventory/celerp_inventory/routes.py
@@ -3945,14 +3945,41 @@ async def undo_import_batch(
 async def export_items_csv(
     company_id=Depends(get_current_company_id),
     session: AsyncSession = Depends(get_session),
+    role: str = Depends(get_current_role),
+    settings: dict = Depends(get_current_company_settings),
     q: str | None = None,
     category: str | None = None,
     status: str | None = None,
 ) -> StreamingResponse:
+    from celerp.services.field_schema import get_effective_field_schema
+
     stmt = select(Projection).where(Projection.company_id == company_id, Projection.entity_type == "item")
     rows = (await session.execute(stmt)).scalars().all()
     price_config = await get_price_config(session, company_id)
     items = [flatten_item(r.state, r.entity_id, created_at=r.created_at, updated_at=r.updated_at, price_config=price_config) for r in rows]
+
+    # Strip fields the requesting role may not see, per the item's category schema, exactly
+    # as the list and detail endpoints do. Without this the export is a cost-visibility
+    # bypass: cost_price/cost_total and any visible_to_roles-restricted column leak verbatim
+    # to a role denied them in every other surface.
+    can_see_costs = role_has_permission(settings, role, "view_inventory_costs")
+    can_author_drafts = role_has_permission(settings, role, "edit_inventory")
+    _schema_cache: dict[str | None, list[dict]] = {}
+
+    async def _category_schema(cat: str | None) -> list[dict]:
+        if cat not in _schema_cache:
+            _schema_cache[cat] = await get_effective_field_schema(session, company_id, category=cat)
+        return _schema_cache[cat]
+
+    _stripped: list[dict] = []
+    for it in items:
+        fs = await _category_schema(it.get("category"))
+        _stripped.append(apply_field_visibility(
+            [it], role, fs, can_see_costs,
+            can_author_drafts=can_author_drafts,
+            derived_field_deps=DERIVED_FIELD_DEPS,
+        )[0])
+    items = _stripped
     if q:
         ql = q.lower()
         def _csv_matches(it: dict) -> bool:
@@ -3976,8 +4003,16 @@ async def export_items_csv(
     if status:
         items = [it for it in items if it.get("status") == status]
 
-    # Build price columns dynamically from the price config fetched above
-    price_cols = [price_key(pl["name"]) for pl in price_config[0] if pl.get("name")]
+    # Build price columns dynamically from the price config fetched above. Cost-list
+    # columns (cost, landed, ...) are dropped entirely for a role without view_inventory_costs:
+    # apply_field_visibility strips cost_price/cost_total from the row dicts, but a landed
+    # cost list serialises under landed_price, which is not a stripped key, so the column
+    # itself must be excluded here or landed cost leaks through the header.
+    price_cols = [
+        price_key(pl["name"])
+        for pl in price_config[0]
+        if pl.get("name") and (can_see_costs or not is_cost_list_name(pl["name"]))
+    ]
 
     _COLS = ["id", "sku", "name", "category", "quantity", "status"] + price_cols + ["weight", "weight_unit", "pieces", "sell_by", "barcode", "hs_code", "purchase_sku", "purchase_name", "purchase_unit", "purchase_conversion_factor", "created_at", "updated_at"]
 

--- a/default_modules/first_party.lock.json
+++ b/default_modules/first_party.lock.json
@@ -7,7 +7,7 @@
   "celerp-contacts": "899cf9febb388356290f6eb8c8ab6d67f1f92a9c9fa8377ebb6d46bf04cedbc3",
   "celerp-dashboard": "1b813cb8756ac600f06f0c061b7e7c507ad8ede0e49901e98df6231fdb28ec46",
   "celerp-docs": "d69d14fe2c87800f3fc767bd03d8b55e6fabe53ce4b97e957192f87727a20ee1",
-  "celerp-inventory": "553026656fe83dbc0dc7bf13bdf01a2e055a728783c384d74fa9101293c1ff35",
+  "celerp-inventory": "5df0a338066cb78774f5656474ceb9bdf2db959285a64e8f7f725ad4da67a1f6",
   "celerp-labels": "ec12cae73b1e37fbeb18dd25671cc8903be55a7aab9d448de8aef1f6f9f8882a",
   "celerp-manufacturing": "f1d90823286b6815e2c4ca88d4e86e9de7feb568c6540c84d1d342bc051283ee",
   "celerp-reports": "f100f83b3fc3e4565685d3a0c8e62dcc724bb35d32238f051b05c5f97ae10d13",

--- a/tests/test_routers/test_items_gaps.py
+++ b/tests/test_routers/test_items_gaps.py
@@ -203,6 +203,94 @@ async def test_items_export_csv_derives_sell_by_measure(client):
 # Phase 1: Search scope tests
 # ---------------------------------------------------------------------------
 
+# ---------------------------------------------------------------------------
+# Export CSV — cost-visibility parity with the list/detail endpoints
+# ---------------------------------------------------------------------------
+
+async def _user_with_role(client, session, admin_token: str, role: str) -> str:
+    addr = f"{role}-{uuid.uuid4().hex[:8]}@gaps.test"
+    r = await client.post(
+        "/companies/me/users",
+        json={"name": role.title(), "email": addr, "password": "testpass123", "role": role},
+        headers=_h(admin_token),
+    )
+    assert r.status_code == 200, r.text
+    from celerp.services.session_tracker import clear as _clear_tracker
+    await _clear_tracker(session)
+    r2 = await client.post("/auth/login", json={"email": addr, "password": "testpass123"})
+    assert r2.status_code == 200, r2.text
+    return r2.json()["access_token"]
+
+
+def _csv_reader(text):
+    import csv, io
+    return csv.DictReader(io.StringIO(text))
+
+
+@pytest.mark.asyncio
+async def test_export_csv_strips_cost_price_for_role_without_permission(client, session):
+    """A role lacking view_inventory_costs must not see cost via the CSV export, exactly
+    as the list and detail endpoints strip it. The default 'Cost' price list serialises
+    the goods cost under cost_price (plus cost_total), so both must be absent for a viewer
+    while present for the admin who set them."""
+    admin = await _reg(client)
+    viewer = await _user_with_role(client, session, admin, "viewer")
+    await _item(client, admin, name="CostWidget", sku="CW-1",
+                cost_price=50.0, wholesale_price=75.0, quantity=4)
+
+    r_admin = await client.get("/items/export/csv", headers=_h(admin))
+    assert r_admin.status_code == 200
+    admin_reader = _csv_reader(r_admin.text)
+    assert "cost_price" in admin_reader.fieldnames
+    admin_rows = {row["sku"]: row for row in admin_reader}
+    assert float(admin_rows["CW-1"]["cost_price"]) == 50.0
+
+    r_viewer = await client.get("/items/export/csv", headers=_h(viewer))
+    assert r_viewer.status_code == 200
+    viewer_fields = _csv_reader(r_viewer.text).fieldnames or []
+    assert "cost_price" not in viewer_fields
+    assert "cost_total" not in viewer_fields
+    # The value itself must not leak through any other column either.
+    assert "50.0" not in r_viewer.text
+
+
+@pytest.mark.asyncio
+async def test_export_csv_strips_landed_cost_column_for_role_without_permission(client, session):
+    """A cost-named price list other than 'Cost' (here 'Landed') serialises under
+    landed_price, which apply_field_visibility does not strip (it is not cost_price /
+    cost_total). The export must drop the whole cost-list column for a role without
+    view_inventory_costs, or landed goods cost leaks through the header."""
+    from sqlalchemy import select as _select
+    from celerp.models.company import Company
+
+    admin = await _reg(client)
+    # Configure a 'Landed' cost price list on the company (stored, non-derived: its value
+    # comes from the item, not a multiplier).
+    co = (await session.execute(_select(Company))).scalars().first()
+    s = dict(co.settings or {})
+    s["price_lists"] = [{"name": "Retail"}, {"name": "Wholesale"}, {"name": "Cost"}, {"name": "Landed"}]
+    co.settings = s
+    await session.commit()
+
+    viewer = await _user_with_role(client, session, admin, "viewer")
+    await _item(client, admin, name="LandedWidget", sku="LW-1",
+                cost_price=50.0, landed_price=62.0, quantity=4)
+
+    r_admin = await client.get("/items/export/csv", headers=_h(admin))
+    assert r_admin.status_code == 200
+    admin_reader = _csv_reader(r_admin.text)
+    assert "landed_price" in admin_reader.fieldnames
+    admin_rows = {row["sku"]: row for row in admin_reader}
+    assert float(admin_rows["LW-1"]["landed_price"]) == 62.0
+
+    r_viewer = await client.get("/items/export/csv", headers=_h(viewer))
+    assert r_viewer.status_code == 200
+    viewer_fields = _csv_reader(r_viewer.text).fieldnames or []
+    assert "landed_price" not in viewer_fields
+    assert "cost_price" not in viewer_fields
+    assert "62.0" not in r_viewer.text
+
+
 @pytest.mark.asyncio
 async def test_list_items_search_by_name(client):
     """Search by name (q param) returns matching item."""


### PR DESCRIPTION
The inventory CSV export previously included cost columns for anyone who could open it, regardless of whether their role is allowed to view costs. The export now applies the same cost visibility as the inventory list and item detail views.

A role without permission to view costs gets an export with no cost price, cost total, or landed cost columns. A permitted role sees those columns unchanged. Field-level visibility rules configured per company are honored on the export too, matching the list view.

Adds regression tests covering both a role with and without cost permission, including a landed cost price list.